### PR TITLE
Issue #40: validation queue state machine and transition guards

### DIFF
--- a/docs/contracts/queue_states.md
+++ b/docs/contracts/queue_states.md
@@ -1,0 +1,61 @@
+# Queue State Machine Contract
+
+Issue: #40  
+Parent workstream: #14
+
+This document defines the validation queue state semantics, transition matrix, and
+permission checks for deterministic queue behavior.
+
+## States
+
+- `new`: Newly created queue item, not yet assigned.
+- `assigned`: Item has an assignee and is waiting for active review.
+- `in_review`: Assignee is actively validating and resolving the item.
+- `blocked`: Item cannot progress without an external dependency or ops decision.
+- `resolved`: Terminal state; item processing is complete.
+
+## Allowed Transitions
+
+| From | To |
+| --- | --- |
+| `new` | `assigned` |
+| `assigned` | `in_review`, `blocked` |
+| `in_review` | `resolved`, `blocked`, `assigned` |
+| `blocked` | `assigned`, `in_review` |
+| `resolved` | _none_ |
+
+Any transition outside this matrix is rejected with:
+
+- `QueueTransitionError("invalid transition: <from> -> <to>")`
+
+## Permission Rules
+
+### Assignment
+
+- `new -> assigned` via `assign_item`:
+  - Allowed actor roles: `analyst`, `ops`
+  - Rejected for `system` with:
+    - `QueuePermissionError("only analyst or ops can assign new items")`
+- Reassignment from `assigned`/`in_review`/`blocked` via `assign_item`:
+  - Allowed actor role: `ops` only
+  - Rejected otherwise with:
+    - `QueuePermissionError("only ops can reassign active items")`
+- Assignment from `resolved` rejected with:
+  - `QueueTransitionError("cannot assign item from terminal state: resolved")`
+
+### State Transitions
+
+- Transition to `assigned` is allowed only for `ops`:
+  - Rejected otherwise with:
+    - `QueuePermissionError("only ops can transition item to assigned")`
+- Transition to `in_review`, `blocked`, or `resolved`:
+  - Allowed for assignee
+  - Allowed for `ops`
+  - Rejected for non-assignee analyst/system actors with:
+    - `QueuePermissionError("only assignee or ops can transition this item")`
+
+## Deterministic Behavior
+
+- `transition_item(..., to_state=<current_state>)` is a no-op and returns the input item.
+- `actor_id` and assignment IDs must be non-empty.
+- All item timestamps are persisted in UTC ISO-8601 format with second precision.

--- a/src/inv_man_intake/queue/__init__.py
+++ b/src/inv_man_intake/queue/__init__.py
@@ -1,0 +1,21 @@
+"""Validation queue state machine primitives."""
+
+from inv_man_intake.queue.state_machine import (
+    QueueItem,
+    QueuePermissionError,
+    QueueState,
+    QueueTransitionError,
+    assign_item,
+    create_queue_item,
+    transition_item,
+)
+
+__all__ = [
+    "QueueItem",
+    "QueuePermissionError",
+    "QueueState",
+    "QueueTransitionError",
+    "assign_item",
+    "create_queue_item",
+    "transition_item",
+]

--- a/src/inv_man_intake/queue/state_machine.py
+++ b/src/inv_man_intake/queue/state_machine.py
@@ -1,0 +1,126 @@
+"""Validation queue state machine and transition guard rails."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from datetime import UTC, datetime
+from typing import Literal
+
+QueueState = Literal["new", "assigned", "in_review", "resolved", "blocked"]
+ActorRole = Literal["analyst", "ops", "system"]
+
+_ALLOWED_TRANSITIONS: dict[QueueState, set[QueueState]] = {
+    "new": {"assigned"},
+    "assigned": {"in_review", "blocked"},
+    "in_review": {"resolved", "blocked", "assigned"},
+    "blocked": {"assigned", "in_review"},
+    "resolved": set(),
+}
+
+
+class QueueTransitionError(ValueError):
+    """Raised when a requested queue transition is not allowed."""
+
+
+class QueuePermissionError(ValueError):
+    """Raised when actor permissions do not permit the action."""
+
+
+@dataclass(frozen=True)
+class QueueItem:
+    """Queue item tracked through state and assignee changes."""
+
+    item_id: str
+    state: QueueState
+    assignee_id: str | None
+    created_at: str
+    updated_at: str
+
+
+def create_queue_item(*, item_id: str) -> QueueItem:
+    """Create a queue item in the initial `new` state."""
+
+    if not item_id:
+        raise QueueTransitionError("item_id must be non-empty")
+    timestamp = _utc_now()
+    return QueueItem(
+        item_id=item_id,
+        state="new",
+        assignee_id=None,
+        created_at=timestamp,
+        updated_at=timestamp,
+    )
+
+
+def assign_item(
+    item: QueueItem,
+    *,
+    actor_id: str,
+    actor_role: ActorRole,
+    assignee_id: str,
+) -> QueueItem:
+    """Assign or reassign ownership and move item into `assigned` state."""
+
+    if not actor_id:
+        raise QueuePermissionError("actor_id must be non-empty")
+    if not assignee_id:
+        raise QueuePermissionError("assignee_id must be non-empty")
+
+    if item.state == "new":
+        if actor_role not in {"analyst", "ops"}:
+            raise QueuePermissionError("only analyst or ops can assign new items")
+    elif item.state in {"assigned", "in_review", "blocked"}:
+        if actor_role != "ops":
+            raise QueuePermissionError("only ops can reassign active items")
+    else:
+        raise QueueTransitionError(f"cannot assign item from terminal state: {item.state}")
+
+    timestamp = _utc_now()
+    return replace(item, state="assigned", assignee_id=assignee_id, updated_at=timestamp)
+
+
+def transition_item(
+    item: QueueItem,
+    *,
+    actor_id: str,
+    actor_role: ActorRole,
+    to_state: QueueState,
+) -> QueueItem:
+    """Transition to a new state when matrix and permission rules allow it."""
+
+    if not actor_id:
+        raise QueuePermissionError("actor_id must be non-empty")
+    if to_state == item.state:
+        return item
+
+    allowed = _ALLOWED_TRANSITIONS[item.state]
+    if to_state not in allowed:
+        raise QueueTransitionError(f"invalid transition: {item.state} -> {to_state}")
+
+    _check_transition_permission(item=item, actor_id=actor_id, actor_role=actor_role, to_state=to_state)
+    timestamp = _utc_now()
+    return replace(item, state=to_state, updated_at=timestamp)
+
+
+def _check_transition_permission(
+    *,
+    item: QueueItem,
+    actor_id: str,
+    actor_role: ActorRole,
+    to_state: QueueState,
+) -> None:
+    if to_state == "assigned":
+        if actor_role != "ops":
+            raise QueuePermissionError("only ops can transition item to assigned")
+        return
+
+    if item.assignee_id is None:
+        raise QueuePermissionError("assignee_id must be set before workflow transitions")
+
+    is_assignee = actor_id == item.assignee_id
+    if actor_role not in {"ops", "system"} and not is_assignee:
+        raise QueuePermissionError("only assignee or ops can transition this item")
+
+
+def _utc_now() -> str:
+    return datetime.now(UTC).isoformat(timespec="seconds")

--- a/tests/queue/test_state_machine.py
+++ b/tests/queue/test_state_machine.py
@@ -1,0 +1,123 @@
+"""Tests for queue state machine transitions and permission guards."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+import pytest
+
+from inv_man_intake.queue.state_machine import (
+    QueuePermissionError,
+    QueueTransitionError,
+    assign_item,
+    create_queue_item,
+    transition_item,
+)
+
+
+def test_create_queue_item_defaults_to_new_and_unassigned() -> None:
+    item = create_queue_item(item_id="queue-1")
+
+    assert item.state == "new"
+    assert item.assignee_id is None
+    assert item.created_at == item.updated_at
+
+
+@pytest.mark.parametrize(
+    ("role", "assignee"),
+    [
+        ("analyst", "analyst-1"),
+        ("ops", "analyst-2"),
+    ],
+)
+def test_assign_new_item_allows_analyst_or_ops(
+    role: Literal["analyst", "ops"], assignee: str
+) -> None:
+    item = create_queue_item(item_id="queue-2")
+
+    assigned = assign_item(item, actor_id="actor-1", actor_role=role, assignee_id=assignee)
+
+    assert assigned.state == "assigned"
+    assert assigned.assignee_id == assignee
+
+
+def test_assign_new_item_rejects_system_actor() -> None:
+    item = create_queue_item(item_id="queue-3")
+
+    with pytest.raises(QueuePermissionError, match="only analyst or ops can assign new items"):
+        assign_item(item, actor_id="svc-1", actor_role="system", assignee_id="analyst-1")
+
+
+def test_transition_matrix_accepts_valid_paths() -> None:
+    item = create_queue_item(item_id="queue-4")
+    item = assign_item(item, actor_id="ops-1", actor_role="ops", assignee_id="analyst-1")
+    item = transition_item(item, actor_id="analyst-1", actor_role="analyst", to_state="in_review")
+    item = transition_item(item, actor_id="analyst-1", actor_role="analyst", to_state="blocked")
+    item = transition_item(item, actor_id="ops-1", actor_role="ops", to_state="assigned")
+    item = transition_item(item, actor_id="analyst-1", actor_role="analyst", to_state="in_review")
+    item = transition_item(item, actor_id="analyst-1", actor_role="analyst", to_state="resolved")
+
+    assert item.state == "resolved"
+
+
+@pytest.mark.parametrize(
+    ("from_state", "to_state"),
+    [
+        ("new", "in_review"),
+        ("new", "blocked"),
+        ("assigned", "resolved"),
+        ("blocked", "resolved"),
+        ("resolved", "assigned"),
+        ("resolved", "in_review"),
+    ],
+)
+def test_transition_matrix_rejects_invalid_transitions(from_state: str, to_state: str) -> None:
+    item = create_queue_item(item_id=f"queue-{from_state}-{to_state}")
+    if from_state != "new":
+        item = assign_item(item, actor_id="ops-1", actor_role="ops", assignee_id="analyst-1")
+    if from_state == "in_review":
+        item = transition_item(item, actor_id="analyst-1", actor_role="analyst", to_state="in_review")
+    if from_state == "blocked":
+        item = transition_item(item, actor_id="analyst-1", actor_role="analyst", to_state="in_review")
+        item = transition_item(item, actor_id="analyst-1", actor_role="analyst", to_state="blocked")
+    if from_state == "resolved":
+        item = transition_item(item, actor_id="analyst-1", actor_role="analyst", to_state="in_review")
+        item = transition_item(item, actor_id="analyst-1", actor_role="analyst", to_state="resolved")
+
+    with pytest.raises(QueueTransitionError, match=f"invalid transition: {from_state} -> {to_state}"):
+        transition_item(item, actor_id="analyst-1", actor_role="analyst", to_state=to_state)  # type: ignore[arg-type]
+
+
+def test_transition_rejects_non_assignee_non_ops_actor() -> None:
+    item = create_queue_item(item_id="queue-5")
+    item = assign_item(item, actor_id="ops-1", actor_role="ops", assignee_id="analyst-1")
+
+    with pytest.raises(QueuePermissionError, match="only assignee or ops can transition this item"):
+        transition_item(item, actor_id="analyst-2", actor_role="analyst", to_state="in_review")
+
+
+def test_transition_to_assigned_requires_ops_role() -> None:
+    item = create_queue_item(item_id="queue-6")
+    item = assign_item(item, actor_id="ops-1", actor_role="ops", assignee_id="analyst-1")
+    item = transition_item(item, actor_id="analyst-1", actor_role="analyst", to_state="in_review")
+
+    with pytest.raises(QueuePermissionError, match="only ops can transition item to assigned"):
+        transition_item(item, actor_id="analyst-1", actor_role="analyst", to_state="assigned")
+
+
+def test_assign_reassignment_requires_ops_for_active_items() -> None:
+    item = create_queue_item(item_id="queue-7")
+    item = assign_item(item, actor_id="ops-1", actor_role="ops", assignee_id="analyst-1")
+
+    with pytest.raises(QueuePermissionError, match="only ops can reassign active items"):
+        assign_item(item, actor_id="analyst-1", actor_role="analyst", assignee_id="analyst-2")
+
+
+def test_resolved_state_rejects_reassignment() -> None:
+    item = create_queue_item(item_id="queue-8")
+    item = assign_item(item, actor_id="ops-1", actor_role="ops", assignee_id="analyst-1")
+    item = transition_item(item, actor_id="analyst-1", actor_role="analyst", to_state="in_review")
+    item = transition_item(item, actor_id="analyst-1", actor_role="analyst", to_state="resolved")
+
+    with pytest.raises(QueueTransitionError, match="cannot assign item from terminal state: resolved"):
+        assign_item(item, actor_id="ops-1", actor_role="ops", assignee_id="analyst-2")


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #40

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Queue state transitions must be enforceable to keep human intervention workflow reliable and auditable.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#14](https://github.com/stranske/Inv-Man-Intake/issues/14)
- [#7](https://github.com/stranske/Inv-Man-Intake/issues/7)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] Define queue state machine (`new`, `assigned`, `in_review`, `resolved`, `blocked`)
- [ ] Implement allowed transition matrix and rejection behavior
- [ ] Implement permission checks for transition actions
- [ ] Add unit tests for all valid and invalid transitions
- [ ] Document state semantics and transition rules

#### Acceptance criteria
- [ ] Queue transitions follow documented matrix only
- [ ] Invalid transitions are rejected with deterministic errors
- [ ] Permission checks are enforced and tested
- [ ] State machine documentation is complete and accurate

**Head SHA:** 0070a5b1c7a000ffaa6526350e85c446735b3f75
**Latest Runs:** ⏭️ skipped — Agents PR Meta
**Required:** gate: ⏸️ not started

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents PR Event Hub | ❔ in progress | [View run](https://github.com/stranske/Inv-Man-Intake/actions/runs/22835917993) |
| Agents PR Meta | ⏭️ skipped | [View run](https://github.com/stranske/Inv-Man-Intake/actions/runs/22835917968) |
<!-- auto-status-summary:end -->