### PR TITLE
Issue #38: scoring explainability payload contract

### DIFF
--- a/docs/contracts/scoring_explainability.md
+++ b/docs/contracts/scoring_explainability.md
@@ -1,0 +1,34 @@
+# Scoring Explainability Contract
+
+Issue: #38  
+Parent workstream: #13
+
+This contract defines deterministic explainability payloads for scoring outputs.
+
+## Payload Schema
+
+Top-level fields:
+
+- `overall_score` (`float`): final score value.
+- `total_contribution` (`float`): sum of component contributions.
+- `components` (`array`): sorted component-level explanation rows.
+
+Each component object includes:
+
+- `component` (`string`): stable component identifier.
+- `weight` (`float`): component weight used in scoring.
+- `contribution` (`float`): `weight * score` rounded to 6 decimals.
+- `rationale` (`string`): concise explanation for the component effect.
+
+## Determinism Rules
+
+- Components are sorted by `component` identifier before output.
+- Numeric values are rounded to 6 decimals.
+- Formatting is stable for repeated calls with identical payload input.
+
+## Reconciliation Rules
+
+- `total_contribution` is the exact sum of formatted component contributions.
+- If `overall_score` is supplied by caller, it must reconcile to component total
+  within tolerance (`1e-6`), otherwise reject with deterministic error.
+- If `overall_score` is omitted, it defaults to `total_contribution`.

--- a/src/inv_man_intake/scoring/__init__.py
+++ b/src/inv_man_intake/scoring/__init__.py
@@ -11,6 +11,13 @@ from inv_man_intake.scoring.engine import (
     compute_score,
     default_weights_by_asset_class,
 )
+from inv_man_intake.scoring.explainability import (
+    ExplainabilityPayload,
+    ScoreComponentInput,
+    ScoreComponentOutput,
+    build_explainability_payload,
+    format_explainability_payload,
+)
 from inv_man_intake.scoring.regression import (
     CalibrationStats,
     DriftAlert,
@@ -25,15 +32,20 @@ __all__ = [
     "CalibrationStats",
     "DriftAlert",
     "DriftReport",
+    "ExplainabilityPayload",
     "RedFlagDecision",
     "RedFlagHook",
     "ScoreComponent",
+    "ScoreComponentInput",
+    "ScoreComponentOutput",
     "ScoreEntry",
     "ScoreResult",
     "ScoreSubmission",
+    "build_explainability_payload",
     "build_calibration_stats",
     "compute_score",
     "default_weights_by_asset_class",
     "detect_score_drift",
+    "format_explainability_payload",
     "rank_by_asset_class",
 ]

--- a/src/inv_man_intake/scoring/explainability.py
+++ b/src/inv_man_intake/scoring/explainability.py
@@ -1,0 +1,105 @@
+"""Explainability payload contract and deterministic formatter for scoring output."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+_ROUND_PRECISION = 6
+_RECONCILIATION_TOLERANCE = 1e-6
+
+
+@dataclass(frozen=True)
+class ScoreComponentInput:
+    """Input component used to compute contribution values."""
+
+    component: str
+    weight: float
+    score: float
+    rationale: str
+
+
+@dataclass(frozen=True)
+class ScoreComponentOutput:
+    """Deterministic explainability output for one score component."""
+
+    component: str
+    weight: float
+    contribution: float
+    rationale: str
+
+
+@dataclass(frozen=True)
+class ExplainabilityPayload:
+    """Top-level explainability contract attached to score outputs."""
+
+    overall_score: float
+    total_contribution: float
+    components: tuple[ScoreComponentOutput, ...]
+
+
+def build_explainability_payload(
+    *,
+    components: tuple[ScoreComponentInput, ...],
+    overall_score: float | None = None,
+) -> ExplainabilityPayload:
+    """Build a deterministic explainability payload with reconciled totals."""
+
+    if not components:
+        raise ValueError("components must contain at least one component")
+
+    normalized = tuple(_normalize_component(component) for component in components)
+    ordered = tuple(sorted(normalized, key=lambda component: component.component))
+
+    computed_total = _round(sum(component.contribution for component in ordered))
+    resolved_overall = computed_total if overall_score is None else _round(overall_score)
+    if abs(resolved_overall - computed_total) > _RECONCILIATION_TOLERANCE:
+        raise ValueError(
+            "overall_score does not reconcile with summed component contributions: "
+            f"{resolved_overall} vs {computed_total}"
+        )
+
+    return ExplainabilityPayload(
+        overall_score=resolved_overall,
+        total_contribution=computed_total,
+        components=ordered,
+    )
+
+
+def format_explainability_payload(payload: ExplainabilityPayload) -> dict[str, object]:
+    """Format payload as a stable dictionary for API output and audit logs."""
+
+    return {
+        "overall_score": payload.overall_score,
+        "total_contribution": payload.total_contribution,
+        "components": [
+            {
+                "component": component.component,
+                "weight": component.weight,
+                "contribution": component.contribution,
+                "rationale": component.rationale,
+            }
+            for component in payload.components
+        ],
+    }
+
+
+def _normalize_component(component: ScoreComponentInput) -> ScoreComponentOutput:
+    if not component.component:
+        raise ValueError("component must be non-empty")
+    if not component.rationale:
+        raise ValueError(f"{component.component}.rationale must be non-empty")
+    if component.weight < 0:
+        raise ValueError(f"{component.component}.weight must be >= 0")
+    if component.score < 0 or component.score > 1:
+        raise ValueError(f"{component.component}.score must be between 0 and 1")
+
+    return ScoreComponentOutput(
+        component=component.component,
+        weight=_round(component.weight),
+        contribution=_round(component.weight * component.score),
+        rationale=component.rationale,
+    )
+
+
+def _round(value: float) -> float:
+    return round(value, _ROUND_PRECISION)

--- a/tests/scoring/test_explainability.py
+++ b/tests/scoring/test_explainability.py
@@ -1,0 +1,103 @@
+"""Tests for scoring explainability payload contract and deterministic formatting."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import pytest
+
+from inv_man_intake.scoring.explainability import (
+    ScoreComponentInput,
+    build_explainability_payload,
+    format_explainability_payload,
+)
+
+
+def test_build_payload_computes_component_contributions_and_reconciles_total() -> None:
+    payload = build_explainability_payload(
+        components=(
+            ScoreComponentInput(
+                component="alpha_quality",
+                weight=0.4,
+                score=0.75,
+                rationale="Consistent alpha generation in lookback window.",
+            ),
+            ScoreComponentInput(
+                component="risk_stability",
+                weight=0.6,
+                score=0.5,
+                rationale="Drawdown profile within policy threshold.",
+            ),
+        )
+    )
+
+    assert payload.total_contribution == pytest.approx(0.6)
+    assert payload.overall_score == pytest.approx(0.6)
+    assert tuple(component.component for component in payload.components) == (
+        "alpha_quality",
+        "risk_stability",
+    )
+
+
+def test_build_payload_rejects_non_reconciling_overall_score() -> None:
+    with pytest.raises(ValueError, match="overall_score does not reconcile"):
+        build_explainability_payload(
+            components=(
+                ScoreComponentInput(
+                    component="alpha_quality",
+                    weight=0.4,
+                    score=0.75,
+                    rationale="Consistent alpha generation in lookback window.",
+                ),
+                ScoreComponentInput(
+                    component="risk_stability",
+                    weight=0.6,
+                    score=0.5,
+                    rationale="Drawdown profile within policy threshold.",
+                ),
+            ),
+            overall_score=0.65,
+        )
+
+
+def test_formatter_is_stable_for_unordered_input_components() -> None:
+    payload = build_explainability_payload(
+        components=(
+            ScoreComponentInput(
+                component="z_tail_risk",
+                weight=0.3,
+                score=0.8,
+                rationale="Tail-risk controls improved this period.",
+            ),
+            ScoreComponentInput(
+                component="a_liquidity",
+                weight=0.7,
+                score=0.4,
+                rationale="Liquidity coverage remains moderate.",
+            ),
+        )
+    )
+
+    formatted_once = format_explainability_payload(payload)
+    formatted_twice = format_explainability_payload(payload)
+
+    assert formatted_once == formatted_twice
+    components = cast(list[dict[str, Any]], formatted_once["components"])
+    assert [entry["component"] for entry in components] == [
+        "a_liquidity",
+        "z_tail_risk",
+    ]
+
+
+def test_component_validations_enforced() -> None:
+    with pytest.raises(ValueError, match="between 0 and 1"):
+        build_explainability_payload(
+            components=(
+                ScoreComponentInput(
+                    component="risk_stability",
+                    weight=0.5,
+                    score=1.1,
+                    rationale="Invalid score",
+                ),
+            )
+        )


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #38

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Stakeholder direction requires explainable scoring to build analyst trust and adoption.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#13](https://github.com/stranske/Inv-Man-Intake/issues/13)
- [#7](https://github.com/stranske/Inv-Man-Intake/issues/7)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] Define explainability output schema (component, weight, contribution, rationale)
- [ ] Implement formatter that attaches explanations to score output
- [ ] Ensure formatting is stable and deterministic for audit use
- [ ] Add tests for contribution math and payload consistency
- [ ] Document explainability contract for consumers

#### Acceptance criteria
- [ ] Scoring output includes complete component-level explanation payload
- [ ] Contribution totals reconcile with overall score calculation
- [ ] Deterministic formatting is validated by tests
- [ ] Contract docs are available for downstream consumers

**Head SHA:** a5a492783142d6dac7cddc60e66869f73f9a2ab2
**Latest Runs:** ⏭️ skipped — Agents PR Meta
**Required:** gate: ⏸️ not started

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents PR Event Hub | ❔ in progress | [View run](https://github.com/stranske/Inv-Man-Intake/actions/runs/22835874669) |
| Agents PR Meta | ⏭️ skipped | [View run](https://github.com/stranske/Inv-Man-Intake/actions/runs/22835874666) |
<!-- auto-status-summary:end -->