### PR TITLE
Issue #24: Visual artifact extraction for PDF/PPTX

### DIFF
--- a/docs/runbooks/visual_artifact_extraction.md
+++ b/docs/runbooks/visual_artifact_extraction.md
@@ -1,0 +1,36 @@
+# Visual Artifact Extraction (PDF/PPTX)
+
+Issue: #24
+
+## Scope
+
+`inv_man_intake.images.extractor.extract_visual_artifacts` supports:
+- PDF image object extraction (`/Subtype /Image` streams)
+- PPTX slide image extraction (`ppt/slides/_rels/*.xml.rels` image relationships)
+
+Each extracted artifact includes:
+- Stable `artifact_id` derived from source location metadata and SHA-256 digest
+- `sha256` for deduplication workflows
+- Source linkage (`page_number` for PDF, `slide_number` for PPTX, plus `source_ref`)
+- Deterministic `storage_path` suggestion for downstream persistence
+
+## Persistence Contract
+
+`VisualArtifactRepository` stores artifact catalog entries in `visual_artifacts` with:
+- `artifact_id` (primary key)
+- `document_id`
+- `source_type`
+- `source_page` / `source_slide`
+- `source_ref`
+- `storage_path`
+- `sha256`
+- `mime_type`
+- `byte_size`
+- `extracted_at`
+
+## Limitations And Fallback Behavior
+
+- PDF parsing is stream/object oriented and does not decode embedded image compression.
+- PDF page mapping relies on `/XObject` references. If a page link cannot be resolved, artifacts are retained with `page_number=0` fallback.
+- PPTX extraction requires slide relationship files and media targets to exist in the archive.
+- Unsupported extensions raise `UnsupportedVisualSourceError`; callers should route those files to non-visual extraction paths.

--- a/src/inv_man_intake/data/provenance.py
+++ b/src/inv_man_intake/data/provenance.py
@@ -29,3 +29,20 @@ class CorrectionRecord:
     reason: str | None
     corrected_by: str | None
     corrected_at: str
+
+
+@dataclass(frozen=True)
+class VisualArtifactRecord:
+    """Persisted visual artifact metadata for extracted PDF/PPTX images."""
+
+    artifact_id: str
+    document_id: str
+    source_type: str
+    source_page: int | None
+    source_slide: int | None
+    source_ref: str | None
+    storage_path: str
+    sha256: str
+    mime_type: str
+    byte_size: int
+    extracted_at: str

--- a/src/inv_man_intake/data/repository.py
+++ b/src/inv_man_intake/data/repository.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 import sqlite3
 
 from inv_man_intake.data.models import Document, Firm, Fund
-from inv_man_intake.data.provenance import CorrectionRecord, ExtractedFieldRecord
+from inv_man_intake.data.provenance import (
+    CorrectionRecord,
+    ExtractedFieldRecord,
+    VisualArtifactRecord,
+)
 
 
 class CoreRepository:
@@ -323,6 +327,89 @@ class FieldProvenanceRepository:
                 reason=None if row[3] is None else str(row[3]),
                 corrected_by=None if row[4] is None else str(row[4]),
                 corrected_at=str(row[5]),
+            )
+            for row in rows
+        )
+
+
+class VisualArtifactRepository:
+    """Persistence API for extracted visual artifact references and hashes."""
+
+    def __init__(self, connection: sqlite3.Connection) -> None:
+        self._connection = connection
+
+    def ensure_schema(self) -> None:
+        self._connection.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS visual_artifacts (
+                artifact_id TEXT PRIMARY KEY,
+                document_id TEXT NOT NULL,
+                source_type TEXT NOT NULL,
+                source_page INTEGER,
+                source_slide INTEGER,
+                source_ref TEXT,
+                storage_path TEXT NOT NULL,
+                sha256 TEXT NOT NULL,
+                mime_type TEXT NOT NULL,
+                byte_size INTEGER NOT NULL,
+                extracted_at TEXT NOT NULL,
+                FOREIGN KEY (document_id) REFERENCES documents (document_id) ON DELETE CASCADE
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_visual_artifacts_document_id
+                ON visual_artifacts (document_id);
+            CREATE INDEX IF NOT EXISTS idx_visual_artifacts_document_sha256
+                ON visual_artifacts (document_id, sha256);
+            """
+        )
+        self._connection.commit()
+
+    def insert_artifact(self, record: VisualArtifactRecord) -> None:
+        self._connection.execute(
+            (
+                "INSERT INTO visual_artifacts (artifact_id, document_id, source_type, source_page, "
+                "source_slide, source_ref, storage_path, sha256, mime_type, byte_size, extracted_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+            ),
+            (
+                record.artifact_id,
+                record.document_id,
+                record.source_type,
+                record.source_page,
+                record.source_slide,
+                record.source_ref,
+                record.storage_path,
+                record.sha256,
+                record.mime_type,
+                record.byte_size,
+                record.extracted_at,
+            ),
+        )
+        self._connection.commit()
+
+    def list_artifacts(self, document_id: str) -> tuple[VisualArtifactRecord, ...]:
+        rows = self._connection.execute(
+            (
+                "SELECT artifact_id, document_id, source_type, source_page, source_slide, source_ref, "
+                "storage_path, sha256, mime_type, byte_size, extracted_at "
+                "FROM visual_artifacts WHERE document_id = ? "
+                "ORDER BY COALESCE(source_page, 0), COALESCE(source_slide, 0), artifact_id"
+            ),
+            (document_id,),
+        ).fetchall()
+        return tuple(
+            VisualArtifactRecord(
+                artifact_id=str(row[0]),
+                document_id=str(row[1]),
+                source_type=str(row[2]),
+                source_page=None if row[3] is None else int(row[3]),
+                source_slide=None if row[4] is None else int(row[4]),
+                source_ref=None if row[5] is None else str(row[5]),
+                storage_path=str(row[6]),
+                sha256=str(row[7]),
+                mime_type=str(row[8]),
+                byte_size=int(row[9]),
+                extracted_at=str(row[10]),
             )
             for row in rows
         )

--- a/src/inv_man_intake/images/__init__.py
+++ b/src/inv_man_intake/images/__init__.py
@@ -1,0 +1,11 @@
+"""Image extraction helpers and data models."""
+
+from inv_man_intake.images.extractor import UnsupportedVisualSourceError, extract_visual_artifacts
+from inv_man_intake.images.models import ArtifactSource, VisualArtifact
+
+__all__ = [
+    "ArtifactSource",
+    "UnsupportedVisualSourceError",
+    "VisualArtifact",
+    "extract_visual_artifacts",
+]

--- a/src/inv_man_intake/images/extractor.py
+++ b/src/inv_man_intake/images/extractor.py
@@ -1,0 +1,244 @@
+"""Visual artifact extraction for PDF and PPTX sources."""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import re
+import xml.etree.ElementTree as ET
+import zipfile
+from pathlib import Path
+
+from inv_man_intake.images.models import ArtifactSource, VisualArtifact
+
+_PDF_OBJECT_PATTERN = re.compile(rb"(\d+)\s+\d+\s+obj(.*?)endobj", re.DOTALL)
+_PDF_STREAM_PATTERN = re.compile(rb"stream\r?\n(.*?)\r?\nendstream", re.DOTALL)
+_PDF_XOBJECT_REF_PATTERN = re.compile(rb"/(?:Im|Img)\w*\s+(\d+)\s+0\s+R")
+
+
+class UnsupportedVisualSourceError(ValueError):
+    """Raised when visual extraction is requested for an unsupported file type."""
+
+
+def extract_visual_artifacts(
+    *,
+    source_doc_id: str,
+    file_name: str,
+    content: bytes,
+) -> tuple[VisualArtifact, ...]:
+    """Extract visual artifacts from PDF/PPTX bytes with stable IDs and hashes."""
+
+    suffix = Path(file_name).suffix.lower()
+    if suffix == ".pdf":
+        return _extract_pdf_artifacts(source_doc_id=source_doc_id, content=content)
+    if suffix == ".pptx":
+        return _extract_pptx_artifacts(source_doc_id=source_doc_id, content=content)
+    raise UnsupportedVisualSourceError(f"unsupported visual source type: {suffix or '<none>'}")
+
+
+def _extract_pdf_artifacts(*, source_doc_id: str, content: bytes) -> tuple[VisualArtifact, ...]:
+    objects = _parse_pdf_objects(content)
+    image_streams = {
+        object_id: _extract_pdf_stream(body)
+        for object_id, body in objects.items()
+        if b"/Subtype /Image" in body
+    }
+    if not image_streams:
+        return ()
+
+    page_to_refs = _map_pdf_page_refs(objects)
+    artifacts: list[VisualArtifact] = []
+
+    # Preserve page order first, then image reference order for deterministic output.
+    for page_number in sorted(page_to_refs):
+        seen_refs: set[int] = set()
+        for object_id in page_to_refs[page_number]:
+            if object_id in seen_refs:
+                continue
+            seen_refs.add(object_id)
+            stream = image_streams.get(object_id)
+            if stream is None:
+                continue
+            mime_type = _pdf_mime_type(objects[object_id])
+            source = ArtifactSource(
+                source_doc_id=source_doc_id,
+                page_number=page_number,
+                source_ref=f"pdf-object-{object_id}",
+            )
+            artifacts.append(
+                _build_artifact(
+                    source=source,
+                    mime_type=mime_type,
+                    content=stream,
+                    storage_path=(
+                        f"artifacts/{source_doc_id}/pdf/page-{page_number}/object-{object_id}.bin"
+                    ),
+                )
+            )
+
+    # Fallback for image objects that could not be linked to page-level XObject refs.
+    linked_refs = {int(artifact.source.source_ref.removeprefix("pdf-object-")) for artifact in artifacts}
+    for object_id in sorted(image_streams):
+        if object_id in linked_refs:
+            continue
+        stream = image_streams[object_id]
+        mime_type = _pdf_mime_type(objects[object_id])
+        source = ArtifactSource(
+            source_doc_id=source_doc_id,
+            page_number=0,
+            source_ref=f"pdf-object-{object_id}",
+        )
+        artifacts.append(
+            _build_artifact(
+                source=source,
+                mime_type=mime_type,
+                content=stream,
+                storage_path=f"artifacts/{source_doc_id}/pdf/page-0/object-{object_id}.bin",
+            )
+        )
+
+    return tuple(artifacts)
+
+
+def _extract_pptx_artifacts(*, source_doc_id: str, content: bytes) -> tuple[VisualArtifact, ...]:
+    archive = zipfile.ZipFile(io.BytesIO(content))
+    slide_targets = _collect_slide_targets(archive)
+
+    artifacts: list[VisualArtifact] = []
+    for slide_number in sorted(slide_targets):
+        for source_ref, media_path in sorted(slide_targets[slide_number]):
+            if media_path not in archive.namelist():
+                continue
+            payload = archive.read(media_path)
+            extension = Path(media_path).suffix.lower().removeprefix(".")
+            mime_type = _mime_from_extension(extension)
+            source = ArtifactSource(
+                source_doc_id=source_doc_id,
+                slide_number=slide_number,
+                source_ref=source_ref,
+            )
+            artifacts.append(
+                _build_artifact(
+                    source=source,
+                    mime_type=mime_type,
+                    content=payload,
+                    storage_path=(
+                        f"artifacts/{source_doc_id}/pptx/slide-{slide_number}/"
+                        f"{Path(media_path).name}"
+                    ),
+                )
+            )
+
+    return tuple(artifacts)
+
+
+def _parse_pdf_objects(content: bytes) -> dict[int, bytes]:
+    objects: dict[int, bytes] = {}
+    for match in _PDF_OBJECT_PATTERN.finditer(content):
+        object_id = int(match.group(1))
+        objects[object_id] = match.group(2)
+    return objects
+
+
+def _extract_pdf_stream(object_body: bytes) -> bytes:
+    match = _PDF_STREAM_PATTERN.search(object_body)
+    if match is None:
+        return b""
+    return match.group(1)
+
+
+def _map_pdf_page_refs(objects: dict[int, bytes]) -> dict[int, tuple[int, ...]]:
+    page_to_refs: dict[int, tuple[int, ...]] = {}
+    page_number = 0
+    for _, body in sorted(objects.items()):
+        if b"/Type /Page" not in body:
+            continue
+        page_number += 1
+        refs = tuple(int(ref) for ref in _PDF_XOBJECT_REF_PATTERN.findall(body))
+        page_to_refs[page_number] = refs
+    return page_to_refs
+
+
+def _pdf_mime_type(object_body: bytes) -> str:
+    if b"/DCTDecode" in object_body:
+        return "image/jpeg"
+    if b"/JPXDecode" in object_body:
+        return "image/jp2"
+    if b"/FlateDecode" in object_body:
+        return "image/png"
+    return "application/octet-stream"
+
+
+def _collect_slide_targets(archive: zipfile.ZipFile) -> dict[int, tuple[tuple[str, str], ...]]:
+    by_slide: dict[int, tuple[tuple[str, str], ...]] = {}
+    slide_rels = sorted(
+        path
+        for path in archive.namelist()
+        if path.startswith("ppt/slides/_rels/") and path.endswith(".xml.rels")
+    )
+    for rel_path in slide_rels:
+        slide_number = _slide_number(rel_path)
+        if slide_number is None:
+            continue
+        root = ET.fromstring(archive.read(rel_path))
+        entries: list[tuple[str, str]] = []
+        for rel in root:
+            rel_type = rel.attrib.get("Type", "")
+            if not rel_type.endswith("/image"):
+                continue
+            source_ref = rel.attrib.get("Id", "")
+            target = rel.attrib.get("Target", "")
+            resolved = _resolve_slide_target(target)
+            entries.append((source_ref, resolved))
+        by_slide[slide_number] = tuple(entries)
+    return by_slide
+
+
+def _slide_number(rel_path: str) -> int | None:
+    match = re.search(r"slide(\d+)\.xml\.rels$", rel_path)
+    if match is None:
+        return None
+    return int(match.group(1))
+
+
+def _resolve_slide_target(target: str) -> str:
+    normalized = target.replace("\\", "/")
+    while normalized.startswith("../"):
+        normalized = normalized.removeprefix("../")
+    return f"ppt/{normalized}"
+
+
+def _mime_from_extension(extension: str) -> str:
+    return {
+        "jpg": "image/jpeg",
+        "jpeg": "image/jpeg",
+        "png": "image/png",
+        "gif": "image/gif",
+        "bmp": "image/bmp",
+        "tif": "image/tiff",
+        "tiff": "image/tiff",
+        "svg": "image/svg+xml",
+    }.get(extension, "application/octet-stream")
+
+
+def _build_artifact(
+    *,
+    source: ArtifactSource,
+    mime_type: str,
+    content: bytes,
+    storage_path: str,
+) -> VisualArtifact:
+    digest = hashlib.sha256(content).hexdigest()
+    source_key = f"p{source.page_number}" if source.page_number is not None else f"s{source.slide_number}"
+    reference_key = source.source_ref or "none"
+    artifact_seed = f"{source.source_doc_id}|{source_key}|{reference_key}|{digest}".encode()
+    artifact_id = f"va_{hashlib.sha1(artifact_seed).hexdigest()[:16]}"
+    return VisualArtifact(
+        artifact_id=artifact_id,
+        source=source,
+        mime_type=mime_type,
+        sha256=digest,
+        byte_size=len(content),
+        storage_path=storage_path,
+        content=content,
+    )

--- a/src/inv_man_intake/images/extractor.py
+++ b/src/inv_man_intake/images/extractor.py
@@ -77,7 +77,12 @@ def _extract_pdf_artifacts(*, source_doc_id: str, content: bytes) -> tuple[Visua
             )
 
     # Fallback for image objects that could not be linked to page-level XObject refs.
-    linked_refs = {int(artifact.source.source_ref.removeprefix("pdf-object-")) for artifact in artifacts}
+    linked_refs = {
+        int(source_ref.removeprefix("pdf-object-"))
+        for artifact in artifacts
+        for source_ref in [artifact.source.source_ref]
+        if source_ref is not None and source_ref.startswith("pdf-object-")
+    }
     for object_id in sorted(image_streams):
         if object_id in linked_refs:
             continue

--- a/src/inv_man_intake/images/models.py
+++ b/src/inv_man_intake/images/models.py
@@ -1,0 +1,28 @@
+"""Domain models for visual artifact extraction outputs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ArtifactSource:
+    """Coordinates linking a visual artifact back to its source location."""
+
+    source_doc_id: str
+    page_number: int | None = None
+    slide_number: int | None = None
+    source_ref: str | None = None
+
+
+@dataclass(frozen=True)
+class VisualArtifact:
+    """Extracted visual artifact payload with stable identity metadata."""
+
+    artifact_id: str
+    source: ArtifactSource
+    mime_type: str
+    sha256: str
+    byte_size: int
+    storage_path: str
+    content: bytes

--- a/tests/data/test_visual_artifact_repository.py
+++ b/tests/data/test_visual_artifact_repository.py
@@ -1,0 +1,105 @@
+"""Tests for visual artifact repository persistence behavior."""
+
+from __future__ import annotations
+
+import sqlite3
+
+from inv_man_intake.data.migrations.core_schema import apply_core_schema
+from inv_man_intake.data.provenance import VisualArtifactRecord
+from inv_man_intake.data.repository import VisualArtifactRepository
+
+
+def _connection() -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.execute("PRAGMA foreign_keys = ON")
+    apply_core_schema(conn)
+    conn.execute(
+        "INSERT INTO firms (firm_id, legal_name, aliases_json, created_at) VALUES (?, ?, ?, ?)",
+        ("firm_1", "Alpha Capital", None, "2026-03-01T08:00:00Z"),
+    )
+    conn.execute(
+        (
+            "INSERT INTO funds (fund_id, firm_id, fund_name, strategy, asset_class, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?)"
+        ),
+        (
+            "fund_1",
+            "firm_1",
+            "Alpha Fund",
+            "market_neutral",
+            "equity_market_neutral",
+            "2026-03-01T08:30:00Z",
+        ),
+    )
+    conn.execute(
+        (
+            "INSERT INTO documents (document_id, fund_id, file_name, file_hash, received_at, "
+            "version_date, source_channel, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
+        ),
+        (
+            "doc_1",
+            "fund_1",
+            "manager_deck.pdf",
+            "hash_doc_1",
+            "2026-03-01T09:00:00Z",
+            "2026-03-01",
+            "email",
+            "2026-03-01T09:00:00Z",
+        ),
+    )
+    conn.commit()
+    return conn
+
+
+def test_visual_artifact_repository_round_trip() -> None:
+    conn = _connection()
+    repo = VisualArtifactRepository(conn)
+    repo.ensure_schema()
+
+    repo.insert_artifact(
+        VisualArtifactRecord(
+            artifact_id="va_1",
+            document_id="doc_1",
+            source_type="pdf",
+            source_page=2,
+            source_slide=None,
+            source_ref="pdf-object-12",
+            storage_path="artifacts/doc_1/pdf/page-2/object-12.bin",
+            sha256="abc123",
+            mime_type="image/jpeg",
+            byte_size=1240,
+            extracted_at="2026-03-01T09:10:00Z",
+        )
+    )
+
+    rows = repo.list_artifacts("doc_1")
+    assert len(rows) == 1
+    assert rows[0].artifact_id == "va_1"
+    assert rows[0].source_page == 2
+    assert rows[0].sha256 == "abc123"
+
+
+def test_visual_artifact_repository_preserves_slide_coordinates() -> None:
+    conn = _connection()
+    repo = VisualArtifactRepository(conn)
+    repo.ensure_schema()
+
+    repo.insert_artifact(
+        VisualArtifactRecord(
+            artifact_id="va_slide_1",
+            document_id="doc_1",
+            source_type="pptx",
+            source_page=None,
+            source_slide=4,
+            source_ref="rId7",
+            storage_path="artifacts/doc_1/pptx/slide-4/image3.png",
+            sha256="def456",
+            mime_type="image/png",
+            byte_size=830,
+            extracted_at="2026-03-01T09:11:00Z",
+        )
+    )
+
+    rows = repo.list_artifacts("doc_1")
+    assert rows[0].source_slide == 4
+    assert rows[0].source_ref == "rId7"

--- a/tests/images/test_extractor.py
+++ b/tests/images/test_extractor.py
@@ -1,0 +1,103 @@
+"""Tests for PDF/PPTX visual artifact extraction."""
+
+from __future__ import annotations
+
+import io
+import zipfile
+
+import pytest
+
+from inv_man_intake.images.extractor import UnsupportedVisualSourceError, extract_visual_artifacts
+
+
+def _pdf_fixture_bytes() -> bytes:
+    return (
+        b"1 0 obj\n<< /Type /Page /Resources << /XObject << /Im0 5 0 R >> >> >>\nendobj\n"
+        b"2 0 obj\n<< /Type /Page /Resources << /XObject << /Im1 6 0 R >> >> >>\nendobj\n"
+        b"5 0 obj\n<< /Subtype /Image /Filter /DCTDecode /Length 3 >>\n"
+        b"stream\nabc\nendstream\nendobj\n"
+        b"6 0 obj\n<< /Subtype /Image /Filter /FlateDecode /Length 3 >>\n"
+        b"stream\ndef\nendstream\nendobj\n"
+    )
+
+
+def _pptx_fixture_bytes() -> bytes:
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, mode="w") as archive:
+        archive.writestr(
+            "ppt/slides/_rels/slide1.xml.rels",
+            (
+                "<Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\">"
+                "<Relationship Id=\"rId2\" "
+                "Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/image\" "
+                "Target=\"../media/image1.png\"/>"
+                "</Relationships>"
+            ),
+        )
+        archive.writestr(
+            "ppt/slides/_rels/slide2.xml.rels",
+            (
+                "<Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\">"
+                "<Relationship Id=\"rId9\" "
+                "Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/image\" "
+                "Target=\"../media/image2.jpg\"/>"
+                "</Relationships>"
+            ),
+        )
+        archive.writestr("ppt/media/image1.png", b"png-payload")
+        archive.writestr("ppt/media/image2.jpg", b"jpg-payload")
+    return buffer.getvalue()
+
+
+def test_extract_visual_artifacts_from_pdf_links_page_and_hash_metadata() -> None:
+    artifacts = extract_visual_artifacts(
+        source_doc_id="doc_pdf_1",
+        file_name="manager_deck.pdf",
+        content=_pdf_fixture_bytes(),
+    )
+
+    assert len(artifacts) == 2
+    assert artifacts[0].source.page_number == 1
+    assert artifacts[0].source.source_ref == "pdf-object-5"
+    assert artifacts[0].mime_type == "image/jpeg"
+    assert artifacts[0].sha256
+    assert artifacts[0].artifact_id.startswith("va_")
+    assert artifacts[1].source.page_number == 2
+    assert artifacts[1].mime_type == "image/png"
+
+
+def test_extract_visual_artifacts_from_pptx_links_slide_and_relationship_metadata() -> None:
+    artifacts = extract_visual_artifacts(
+        source_doc_id="doc_pptx_1",
+        file_name="manager_update.pptx",
+        content=_pptx_fixture_bytes(),
+    )
+
+    assert len(artifacts) == 2
+    assert artifacts[0].source.slide_number == 1
+    assert artifacts[0].source.source_ref == "rId2"
+    assert artifacts[0].mime_type == "image/png"
+    assert artifacts[1].source.slide_number == 2
+    assert artifacts[1].source.source_ref == "rId9"
+    assert artifacts[1].mime_type == "image/jpeg"
+
+
+def test_visual_artifact_ids_are_stable_for_same_source_payload() -> None:
+    first = extract_visual_artifacts(
+        source_doc_id="doc_pdf_2",
+        file_name="deck.pdf",
+        content=_pdf_fixture_bytes(),
+    )
+    second = extract_visual_artifacts(
+        source_doc_id="doc_pdf_2",
+        file_name="deck.pdf",
+        content=_pdf_fixture_bytes(),
+    )
+
+    assert [item.artifact_id for item in first] == [item.artifact_id for item in second]
+    assert [item.sha256 for item in first] == [item.sha256 for item in second]
+
+
+def test_extract_visual_artifacts_rejects_unsupported_extension() -> None:
+    with pytest.raises(UnsupportedVisualSourceError, match="unsupported visual source type"):
+        extract_visual_artifacts(source_doc_id="doc_1", file_name="notes.txt", content=b"x")


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #24

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Key charts and diagrams must be explicitly extracted and cataloged to preserve context that text-only parsing misses.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#10](https://github.com/stranske/Inv-Man-Intake/issues/10)
- [#7](https://github.com/stranske/Inv-Man-Intake/issues/7)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] Implement image extraction for PDF pages and PPTX slides
- [ ] Capture source coordinates and artifact metadata
- [ ] Persist artifact references with stable IDs and hashes
- [ ] Add extraction tests for typical manager deck formats
- [ ] Document extraction limitations and fallback behavior

#### Acceptance criteria
- [ ] Visual artifacts are extracted from both PDF and PPTX inputs
- [ ] Stored artifacts include source page/slide linkage
- [ ] Stable IDs/hashes are generated for deduplication
- [ ] Tests validate extraction coverage for representative fixtures

**Head SHA:** 2a117c1ce594318a3e5a309fe1abb6b4f84695b1
**Latest Runs:** ✅ success — Gate
**Required:** gate: ✅ success

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| .github/workflows/autofix.yml | ❌ failure | [View run](https://github.com/stranske/Inv-Man-Intake/actions/runs/22835786973) |
| Agents PR Event Hub | ❔ in progress | [View run](https://github.com/stranske/Inv-Man-Intake/actions/runs/22835820064) |
| Agents PR Meta | ⏭️ skipped | [View run](https://github.com/stranske/Inv-Man-Intake/actions/runs/22835820013) |
| CI | ❌ failure | [View run](https://github.com/stranske/Inv-Man-Intake/actions/runs/22835787588) |
| Claude Code Review (Opt-in) | ✅ success | [View run](https://github.com/stranske/Inv-Man-Intake/actions/runs/22835787478) |
| Dependabot Auto-merge | ⏭️ skipped | [View run](https://github.com/stranske/Inv-Man-Intake/actions/runs/22835787497) |
| Gate | ✅ success | [View run](https://github.com/stranske/Inv-Man-Intake/actions/runs/22835787586) |
| Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/Inv-Man-Intake/actions/runs/22835787510) |
<!-- auto-status-summary:end -->