### PR TITLE
Issue #22: confidence thresholds config and enforcement

### DIFF
--- a/config/extraction_thresholds.yaml
+++ b/config/extraction_thresholds.yaml
@@ -1,0 +1,9 @@
+# v1 extraction threshold policy
+field_auto_accept_min: 0.85
+key_field_confidence_min: 0.75
+document_key_field_coverage_min: 0.80
+mandatory_field_min: 0.60
+mandatory_fields:
+  - terms.management_fee
+  - performance.net_return_1y
+  - operations.aum

--- a/docs/contracts/extraction_thresholds.md
+++ b/docs/contracts/extraction_thresholds.md
@@ -1,0 +1,36 @@
+# Extraction Thresholds (v1)
+
+Issue: #22
+
+## Config Source
+
+Thresholds are loaded from [`config/extraction_thresholds.yaml`](../../config/extraction_thresholds.yaml) using `load_threshold_config` in `src/inv_man_intake/extraction/confidence.py`.
+
+## Threshold Semantics
+
+- `field_auto_accept_min` (0.85)
+  - A field is marked auto-acceptable when `field.confidence >= field_auto_accept_min`.
+- `key_field_confidence_min` (0.75)
+  - A key field counts toward document coverage when `field.confidence >= key_field_confidence_min`.
+- `document_key_field_coverage_min` (0.80)
+  - Document auto-pass requires key-field coverage ratio `>= document_key_field_coverage_min`.
+- `mandatory_field_min` (0.60)
+  - Any configured mandatory field below this value forces escalation.
+- `mandatory_fields`
+  - Required keys that must exist and meet `mandatory_field_min`.
+
+## Escalation Rules
+
+Escalation is deterministic and reason-coded:
+- `missing_mandatory_field:<field_key>` when a mandatory field is absent.
+- `confidence_below_threshold:<field_key>` when a mandatory field falls below floor.
+- `low_key_field_coverage` when mandatory checks pass but document coverage fails.
+
+## Orchestration Attachment
+
+`attach_threshold_summary` appends document-level confidence policy fields:
+- `confidence.document.key_field_coverage_ratio`
+- `confidence.document.auto_pass`
+- `confidence.document.escalation_reason`
+
+These fields allow downstream orchestration/queue routing to read threshold outcomes without re-computing policy logic.

--- a/docs/contracts/extraction_thresholds.md
+++ b/docs/contracts/extraction_thresholds.md
@@ -5,6 +5,11 @@ Issue: #22
 ## Config Source
 
 Thresholds are loaded from [`config/extraction_thresholds.yaml`](../../config/extraction_thresholds.yaml) using `load_threshold_config` in `src/inv_man_intake/extraction/confidence.py`.
+The loader intentionally supports a strict subset:
+- scalar numeric keys must be plain `key: value` entries
+- `mandatory_fields` must use block-list syntax (`mandatory_fields:` followed by `- field.key` lines)
+- inline list forms like `mandatory_fields: [a, b]` are rejected
+- unknown keys are rejected
 
 ## Threshold Semantics
 

--- a/src/inv_man_intake/extraction/__init__.py
+++ b/src/inv_man_intake/extraction/__init__.py
@@ -1,1 +1,17 @@
 """Extraction contracts and provider implementations."""
+
+from inv_man_intake.extraction.confidence import (
+    ThresholdConfig,
+    ThresholdDecision,
+    attach_threshold_summary,
+    evaluate_thresholds,
+    load_threshold_config,
+)
+
+__all__ = [
+    "ThresholdConfig",
+    "ThresholdDecision",
+    "attach_threshold_summary",
+    "evaluate_thresholds",
+    "load_threshold_config",
+]

--- a/src/inv_man_intake/extraction/confidence.py
+++ b/src/inv_man_intake/extraction/confidence.py
@@ -91,9 +91,7 @@ def evaluate_thresholds(
         for key in key_fields
         if key in field_by_key and field_by_key[key].confidence >= config.key_field_confidence_min
     ]
-    key_field_coverage_ratio = (
-        len(eligible_key_fields) / len(key_fields) if key_fields else 1.0
-    )
+    key_field_coverage_ratio = len(eligible_key_fields) / len(key_fields) if key_fields else 1.0
     auto_pass_document = key_field_coverage_ratio >= config.document_key_field_coverage_min
 
     for mandatory_field in config.mandatory_fields:

--- a/src/inv_man_intake/extraction/confidence.py
+++ b/src/inv_man_intake/extraction/confidence.py
@@ -45,13 +45,25 @@ def load_threshold_config(path: str | Path) -> ThresholdConfig:
         if line == "mandatory_fields:":
             in_mandatory_list = True
             continue
+        if line.startswith("mandatory_fields:"):
+            raise ValueError(
+                "unsupported mandatory_fields format: use block list form with one '- <field>' per line"
+            )
         if in_mandatory_list and line.startswith("-"):
             mandatory_fields.append(line.removeprefix("-").strip().strip('"'))
             continue
         if ":" in line:
             in_mandatory_list = False
             key, value = line.split(":", 1)
-            values[key.strip()] = value.strip().strip('"')
+            normalized_key = key.strip()
+            if normalized_key not in {
+                "field_auto_accept_min",
+                "key_field_confidence_min",
+                "document_key_field_coverage_min",
+                "mandatory_field_min",
+            }:
+                raise ValueError(f"unknown threshold config key: {normalized_key}")
+            values[normalized_key] = value.strip().strip('"')
 
     required = {
         "field_auto_accept_min",
@@ -91,7 +103,7 @@ def evaluate_thresholds(
         for key in key_fields
         if key in field_by_key and field_by_key[key].confidence >= config.key_field_confidence_min
     ]
-    key_field_coverage_ratio = len(eligible_key_fields) / len(key_fields) if key_fields else 1.0
+    key_field_coverage_ratio = len(eligible_key_fields) / len(key_fields) if key_fields else 0.0
     auto_pass_document = key_field_coverage_ratio >= config.document_key_field_coverage_min
 
     for mandatory_field in config.mandatory_fields:

--- a/src/inv_man_intake/extraction/confidence.py
+++ b/src/inv_man_intake/extraction/confidence.py
@@ -1,0 +1,165 @@
+"""Confidence threshold loading and enforcement helpers for extraction decisions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from inv_man_intake.extraction.providers.base import ExtractedDocumentResult, ExtractedField
+
+
+@dataclass(frozen=True)
+class ThresholdConfig:
+    """Confidence policy values used for extraction gating decisions."""
+
+    field_auto_accept_min: float
+    key_field_confidence_min: float
+    document_key_field_coverage_min: float
+    mandatory_field_min: float
+    mandatory_fields: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ThresholdDecision:
+    """Outcome of applying threshold policy to an extraction result."""
+
+    auto_accept_fields: tuple[str, ...]
+    key_field_coverage_ratio: float
+    auto_pass_document: bool
+    escalate: bool
+    escalation_reason: str | None
+
+
+def load_threshold_config(path: str | Path) -> ThresholdConfig:
+    """Load threshold policy values from a simple YAML config file."""
+
+    lines = Path(path).read_text(encoding="utf-8").splitlines()
+    values: dict[str, str] = {}
+    mandatory_fields: list[str] = []
+    in_mandatory_list = False
+
+    for raw_line in lines:
+        line = raw_line.split("#", 1)[0].strip()
+        if not line:
+            continue
+        if line == "mandatory_fields:":
+            in_mandatory_list = True
+            continue
+        if in_mandatory_list and line.startswith("-"):
+            mandatory_fields.append(line.removeprefix("-").strip().strip('"'))
+            continue
+        if ":" in line:
+            in_mandatory_list = False
+            key, value = line.split(":", 1)
+            values[key.strip()] = value.strip().strip('"')
+
+    required = {
+        "field_auto_accept_min",
+        "key_field_confidence_min",
+        "document_key_field_coverage_min",
+        "mandatory_field_min",
+    }
+    missing = sorted(required.difference(values))
+    if missing:
+        raise ValueError(f"missing threshold config keys: {', '.join(missing)}")
+
+    return ThresholdConfig(
+        field_auto_accept_min=float(values["field_auto_accept_min"]),
+        key_field_confidence_min=float(values["key_field_confidence_min"]),
+        document_key_field_coverage_min=float(values["document_key_field_coverage_min"]),
+        mandatory_field_min=float(values["mandatory_field_min"]),
+        mandatory_fields=tuple(mandatory_fields),
+    )
+
+
+def evaluate_thresholds(
+    *,
+    result: ExtractedDocumentResult,
+    key_fields: tuple[str, ...],
+    config: ThresholdConfig,
+) -> ThresholdDecision:
+    """Apply threshold policy to field/document extraction confidence."""
+
+    field_by_key = {field.key: field for field in result.fields}
+
+    auto_accept_fields = tuple(
+        field.key for field in result.fields if field.confidence >= config.field_auto_accept_min
+    )
+
+    eligible_key_fields = [
+        key
+        for key in key_fields
+        if key in field_by_key and field_by_key[key].confidence >= config.key_field_confidence_min
+    ]
+    key_field_coverage_ratio = (
+        len(eligible_key_fields) / len(key_fields) if key_fields else 1.0
+    )
+    auto_pass_document = key_field_coverage_ratio >= config.document_key_field_coverage_min
+
+    for mandatory_field in config.mandatory_fields:
+        candidate = field_by_key.get(mandatory_field)
+        if candidate is None:
+            return ThresholdDecision(
+                auto_accept_fields=auto_accept_fields,
+                key_field_coverage_ratio=key_field_coverage_ratio,
+                auto_pass_document=False,
+                escalate=True,
+                escalation_reason=f"missing_mandatory_field:{mandatory_field}",
+            )
+        if candidate.confidence < config.mandatory_field_min:
+            return ThresholdDecision(
+                auto_accept_fields=auto_accept_fields,
+                key_field_coverage_ratio=key_field_coverage_ratio,
+                auto_pass_document=False,
+                escalate=True,
+                escalation_reason=f"confidence_below_threshold:{mandatory_field}",
+            )
+
+    escalate = not auto_pass_document
+    reason = None if auto_pass_document else "low_key_field_coverage"
+
+    return ThresholdDecision(
+        auto_accept_fields=auto_accept_fields,
+        key_field_coverage_ratio=key_field_coverage_ratio,
+        auto_pass_document=auto_pass_document,
+        escalate=escalate,
+        escalation_reason=reason,
+    )
+
+
+def attach_threshold_summary(
+    *,
+    result: ExtractedDocumentResult,
+    decision: ThresholdDecision,
+) -> ExtractedDocumentResult:
+    """Attach deterministic threshold summary fields onto extraction output."""
+
+    summary_fields = (
+        ExtractedField(
+            key="confidence.document.key_field_coverage_ratio",
+            value=f"{decision.key_field_coverage_ratio:.4f}",
+            confidence=1.0,
+            source_doc_id=result.source_doc_id,
+            source_page=0,
+        ),
+        ExtractedField(
+            key="confidence.document.auto_pass",
+            value="true" if decision.auto_pass_document else "false",
+            confidence=1.0,
+            source_doc_id=result.source_doc_id,
+            source_page=0,
+        ),
+        ExtractedField(
+            key="confidence.document.escalation_reason",
+            value=decision.escalation_reason or "none",
+            confidence=1.0,
+            source_doc_id=result.source_doc_id,
+            source_page=0,
+        ),
+    )
+
+    return ExtractedDocumentResult(
+        source_doc_id=result.source_doc_id,
+        provider_name=result.provider_name,
+        fields=tuple(result.fields) + summary_fields,
+    )

--- a/tests/extraction/test_thresholds.py
+++ b/tests/extraction/test_thresholds.py
@@ -1,0 +1,133 @@
+"""Tests for extraction confidence threshold loading and enforcement."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from inv_man_intake.extraction.confidence import (
+    attach_threshold_summary,
+    evaluate_thresholds,
+    load_threshold_config,
+)
+from inv_man_intake.extraction.providers.base import ExtractedDocumentResult, ExtractedField
+
+
+def _result(*fields: tuple[str, float]) -> ExtractedDocumentResult:
+    return ExtractedDocumentResult(
+        source_doc_id="doc_1",
+        provider_name="primary",
+        fields=tuple(
+            ExtractedField(
+                key=key,
+                value="value",
+                confidence=confidence,
+                source_doc_id="doc_1",
+                source_page=1,
+            )
+            for key, confidence in fields
+        ),
+    )
+
+
+def test_load_threshold_config_reads_policy_values() -> None:
+    config = load_threshold_config(Path("config/extraction_thresholds.yaml"))
+
+    assert config.field_auto_accept_min == 0.85
+    assert config.key_field_confidence_min == 0.75
+    assert config.document_key_field_coverage_min == 0.80
+    assert config.mandatory_field_min == 0.60
+    assert "terms.management_fee" in config.mandatory_fields
+
+
+def test_evaluate_thresholds_boundary_values_are_deterministic() -> None:
+    config = load_threshold_config(Path("config/extraction_thresholds.yaml"))
+    result = _result(
+        ("terms.management_fee", 0.85),
+        ("performance.net_return_1y", 0.75),
+        ("operations.aum", 0.60),
+        ("other.field", 0.40),
+    )
+
+    decision = evaluate_thresholds(
+        result=result,
+        key_fields=(
+            "terms.management_fee",
+            "performance.net_return_1y",
+            "operations.aum",
+            "other.field",
+        ),
+        config=config,
+    )
+
+    assert set(decision.auto_accept_fields) == {"terms.management_fee"}
+    assert decision.key_field_coverage_ratio == 0.5
+    assert decision.auto_pass_document is False
+    assert decision.escalate is True
+    assert decision.escalation_reason == "low_key_field_coverage"
+
+
+def test_evaluate_thresholds_escalates_when_mandatory_field_below_floor() -> None:
+    config = load_threshold_config(Path("config/extraction_thresholds.yaml"))
+    result = _result(
+        ("terms.management_fee", 0.95),
+        ("performance.net_return_1y", 0.90),
+        ("operations.aum", 0.59),
+    )
+
+    decision = evaluate_thresholds(
+        result=result,
+        key_fields=(
+            "terms.management_fee",
+            "performance.net_return_1y",
+            "operations.aum",
+        ),
+        config=config,
+    )
+
+    assert decision.auto_pass_document is False
+    assert decision.escalate is True
+    assert decision.escalation_reason == "confidence_below_threshold:operations.aum"
+
+
+def test_evaluate_thresholds_escalates_when_mandatory_field_is_missing() -> None:
+    config = load_threshold_config(Path("config/extraction_thresholds.yaml"))
+    result = _result(
+        ("terms.management_fee", 0.95),
+        ("performance.net_return_1y", 0.91),
+    )
+
+    decision = evaluate_thresholds(
+        result=result,
+        key_fields=(
+            "terms.management_fee",
+            "performance.net_return_1y",
+        ),
+        config=config,
+    )
+
+    assert decision.escalate is True
+    assert decision.escalation_reason == "missing_mandatory_field:operations.aum"
+
+
+def test_attach_threshold_summary_adds_document_policy_fields() -> None:
+    config = load_threshold_config(Path("config/extraction_thresholds.yaml"))
+    result = _result(
+        ("terms.management_fee", 0.95),
+        ("performance.net_return_1y", 0.91),
+        ("operations.aum", 0.90),
+    )
+    decision = evaluate_thresholds(
+        result=result,
+        key_fields=(
+            "terms.management_fee",
+            "performance.net_return_1y",
+            "operations.aum",
+        ),
+        config=config,
+    )
+
+    updated = attach_threshold_summary(result=result, decision=decision)
+    by_key = {field.key: field for field in updated.fields}
+
+    assert by_key["confidence.document.auto_pass"].value == "true"
+    assert by_key["confidence.document.escalation_reason"].value == "none"

--- a/tests/extraction/test_thresholds.py
+++ b/tests/extraction/test_thresholds.py
@@ -11,6 +11,8 @@ from inv_man_intake.extraction.confidence import (
 )
 from inv_man_intake.extraction.providers.base import ExtractedDocumentResult, ExtractedField
 
+_CONFIG_PATH = Path(__file__).resolve().parents[2] / "config" / "extraction_thresholds.yaml"
+
 
 def _result(*fields: tuple[str, float]) -> ExtractedDocumentResult:
     return ExtractedDocumentResult(
@@ -30,7 +32,7 @@ def _result(*fields: tuple[str, float]) -> ExtractedDocumentResult:
 
 
 def test_load_threshold_config_reads_policy_values() -> None:
-    config = load_threshold_config(Path("config/extraction_thresholds.yaml"))
+    config = load_threshold_config(_CONFIG_PATH)
 
     assert config.field_auto_accept_min == 0.85
     assert config.key_field_confidence_min == 0.75
@@ -40,7 +42,7 @@ def test_load_threshold_config_reads_policy_values() -> None:
 
 
 def test_evaluate_thresholds_boundary_values_are_deterministic() -> None:
-    config = load_threshold_config(Path("config/extraction_thresholds.yaml"))
+    config = load_threshold_config(_CONFIG_PATH)
     result = _result(
         ("terms.management_fee", 0.85),
         ("performance.net_return_1y", 0.75),
@@ -67,7 +69,7 @@ def test_evaluate_thresholds_boundary_values_are_deterministic() -> None:
 
 
 def test_evaluate_thresholds_escalates_when_mandatory_field_below_floor() -> None:
-    config = load_threshold_config(Path("config/extraction_thresholds.yaml"))
+    config = load_threshold_config(_CONFIG_PATH)
     result = _result(
         ("terms.management_fee", 0.95),
         ("performance.net_return_1y", 0.90),
@@ -90,7 +92,7 @@ def test_evaluate_thresholds_escalates_when_mandatory_field_below_floor() -> Non
 
 
 def test_evaluate_thresholds_escalates_when_mandatory_field_is_missing() -> None:
-    config = load_threshold_config(Path("config/extraction_thresholds.yaml"))
+    config = load_threshold_config(_CONFIG_PATH)
     result = _result(
         ("terms.management_fee", 0.95),
         ("performance.net_return_1y", 0.91),
@@ -110,7 +112,7 @@ def test_evaluate_thresholds_escalates_when_mandatory_field_is_missing() -> None
 
 
 def test_attach_threshold_summary_adds_document_policy_fields() -> None:
-    config = load_threshold_config(Path("config/extraction_thresholds.yaml"))
+    config = load_threshold_config(_CONFIG_PATH)
     result = _result(
         ("terms.management_fee", 0.95),
         ("performance.net_return_1y", 0.91),
@@ -131,3 +133,19 @@ def test_attach_threshold_summary_adds_document_policy_fields() -> None:
 
     assert by_key["confidence.document.auto_pass"].value == "true"
     assert by_key["confidence.document.escalation_reason"].value == "none"
+
+
+def test_evaluate_thresholds_empty_key_fields_forces_escalation() -> None:
+    config = load_threshold_config(_CONFIG_PATH)
+    result = _result(
+        ("terms.management_fee", 0.95),
+        ("performance.net_return_1y", 0.91),
+        ("operations.aum", 0.90),
+    )
+
+    decision = evaluate_thresholds(result=result, key_fields=(), config=config)
+
+    assert decision.key_field_coverage_ratio == 0.0
+    assert decision.auto_pass_document is False
+    assert decision.escalate is True
+    assert decision.escalation_reason == "low_key_field_coverage"


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #22

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Confidence policy determines what can flow straight through and what must be reviewed; this must be explicit and configurable from day one.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#9](https://github.com/stranske/Inv-Man-Intake/issues/9)
- [#7](https://github.com/stranske/Inv-Man-Intake/issues/7)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] Implement confidence scoring utility and schema attachment
- [ ] Implement config loader for threshold values
- [ ] Enforce approved v1 thresholds in orchestration decisions
- [ ] Add tests for threshold boundary behavior
- [ ] Document threshold semantics for operator tuning

#### Acceptance criteria
- [ ] Field-level and document-level thresholds are read from config
- [ ] Boundary values are handled deterministically in tests
- [ ] Escalation trigger activates for mandatory fields below threshold
- [ ] Documentation describes each threshold effect clearly

**Head SHA:** 8c172eff007a9b1f276be7a0874459c07a1e1e61
**Latest Runs:** ⏭️ skipped — Agents PR Meta
**Required:** gate: ⏸️ not started

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents PR Event Hub | ❔ in progress | [View run](https://github.com/stranske/Inv-Man-Intake/actions/runs/22835732663) |
| Agents PR Meta | ⏭️ skipped | [View run](https://github.com/stranske/Inv-Man-Intake/actions/runs/22835732633) |
<!-- auto-status-summary:end -->