### PR TITLE
Standardize Python runtime on 3.12

### DIFF
--- a/.github/workflows/agents-auto-label.yml
+++ b/.github/workflows/agents-auto-label.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/agents-auto-pilot.yml
+++ b/.github/workflows/agents-auto-pilot.yml
@@ -225,7 +225,7 @@ jobs:
         if: steps.check_enabled.outputs.enabled == 'true'
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
       - name: Cache pip (LLM requirements)
         if: steps.check_enabled.outputs.enabled == 'true'

--- a/.github/workflows/agents-capability-check.yml
+++ b/.github/workflows/agents-capability-check.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/agents-decompose.yml
+++ b/.github/workflows/agents-decompose.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/agents-dedup.yml
+++ b/.github/workflows/agents-dedup.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/agents-issue-optimizer.yml
+++ b/.github/workflows/agents-issue-optimizer.yml
@@ -141,7 +141,7 @@ jobs:
         if: steps.check.outputs.should_run == 'true'
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
       - name: Install dependencies
         if: steps.check.outputs.should_run == 'true'

--- a/.github/workflows/agents-keepalive-loop.yml
+++ b/.github/workflows/agents-keepalive-loop.yml
@@ -629,7 +629,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
       - name: Install dependencies
         run: pip install pydantic langchain-openai langchain-anthropic

--- a/.github/workflows/agents-weekly-metrics.yml
+++ b/.github/workflows/agents-weekly-metrics.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Download metrics artifacts
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@
 # - Lint (Ruff)
 # - Format check (Black)
 # - Type checking (mypy)
-# - Tests (pytest) on Python 3.11 and 3.12
+# - Tests (pytest) on Python 3.12 and 3.13
 #
 # NOTE: Do NOT add a top-level 'permissions:' block here. It causes
 # startup_failure when calling reusable workflows. The reusable workflow
@@ -27,7 +27,7 @@ jobs:
     name: Python CI
     uses: stranske/Workflows/.github/workflows/reusable-10-ci-python.yml@main
     with:
-      python-versions: '["3.11", "3.12"]'
+      python-versions: '["3.12", "3.13"]'
       typecheck: true
       coverage: true
       coverage-min: '80'

--- a/.github/workflows/maint-coverage-guard.yml
+++ b/.github/workflows/maint-coverage-guard.yml
@@ -227,7 +227,8 @@ jobs:
 
           # Check for coverage json
           for candidate in \
-            "coverage_artifacts/payload/artifacts/coverage/runtimes/3.11/coverage.json" \
+            "coverage_artifacts/payload/artifacts/coverage/runtimes/3.12/coverage.json" \
+            "coverage_artifacts/payload/artifacts/coverage/runtimes/3.13/coverage.json" \
             "coverage_artifacts/payload/coverage.json" \
             "coverage_artifacts/coverage.json"; do
             if [ -f "$candidate" ]; then

--- a/.github/workflows/maint-dependabot-auto-lock.yml
+++ b/.github/workflows/maint-dependabot-auto-lock.yml
@@ -26,9 +26,9 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
       
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
-          python-version: '3.11'
+          python-version: '3.12'
       
       - name: Install uv
         run: pip install uv

--- a/.github/workflows/pr-00-gate.yml
+++ b/.github/workflows/pr-00-gate.yml
@@ -42,7 +42,7 @@ jobs:
     name: Python CI
     uses: stranske/Workflows/.github/workflows/reusable-10-ci-python.yml@main
     with:
-      python-versions: '["3.11", "3.12"]'
+      python-versions: '["3.12", "3.13"]'
       coverage-min: "80"
       format_check: false  # Using ruff for formatting
       working-directory: "."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "my-project"
 version = "0.1.0"
 description = "Template Python project with stranske/Workflows CI integration"
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 license = {text = "MIT"}
 authors = [
     {name = "Your Name", email = "your.email@example.com"},
@@ -17,7 +17,6 @@ classifiers = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
 ]
@@ -65,7 +64,7 @@ omit = [
 fail_under = 80
 
 [tool.ruff]
-target-version = "py311"
+target-version = "py312"
 line-length = 100
 src = ["src", "tests"]
 
@@ -89,7 +88,7 @@ ignore = [
 known-first-party = ["inv_man_intake", "my_project", "tools"]
 
 [tool.mypy]
-python_version = "3.11"
+python_version = "3.12"
 files = ["src/my_project", "tests/test_main.py"]
 exclude = ["^scripts/", "^tools/"]
 strict = true
@@ -105,4 +104,4 @@ show_error_codes = true
 
 [tool.black]
 line-length = 100
-target-version = ["py311"]
+target-version = ["py312"]

--- a/scripts/check_test_dependencies.sh
+++ b/scripts/check_test_dependencies.sh
@@ -22,10 +22,10 @@ python_version=$(python --version 2>&1 | awk '{print $2}')
 python_major=$(echo "$python_version" | cut -d. -f1)
 python_minor=$(echo "$python_version" | cut -d. -f2)
 
-if [[ "$python_major" -ge 3 ]] && [[ "$python_minor" -ge 11 ]]; then
-    echo -e "${GREEN}✓${NC} Python $python_version (>=3.11 required)"
+if [[ "$python_major" -gt 3 ]] || { [[ "$python_major" -eq 3 ]] && [[ "$python_minor" -ge 12 ]]; }; then
+    echo -e "${GREEN}✓${NC} Python $python_version (>=3.12 required)"
 else
-    echo -e "${RED}✗${NC} Python $python_version (>=3.11 required)"
+    echo -e "${RED}✗${NC} Python $python_version (>=3.12 required)"
     all_ok=false
 fi
 echo ""

--- a/scripts/generate_pr_thread_review.py
+++ b/scripts/generate_pr_thread_review.py
@@ -95,7 +95,7 @@ def render_review_markdown(
                 f"- Reviewer: `{comment.reviewer}`",
                 f"- File context: `{comment.path or 'unknown'}`"
                 + (f":{comment.line}" if comment.line else ""),
-                f"- Quote: \"{quote or 'TODO: add quote from original review comment'}\"",
+                f'- Quote: "{quote or "TODO: add quote from original review comment"}"',
                 "- Reviewer concern: TODO: summarize reviewer concern from thread discussion.",
                 "- Disposition options:",
                 "  - Fix: implement bounded code/test change and link follow-up PR.",

--- a/scripts/langchain/capability_check.py
+++ b/scripts/langchain/capability_check.py
@@ -139,9 +139,7 @@ def _build_llm_config(
     issue_or_pr = (
         str(issue_number)
         if issue_number is not None
-        else env_issue
-        if env_issue.isdigit()
-        else "unknown"
+        else env_issue if env_issue.isdigit() else "unknown"
     )
     metadata = {
         "repo": repo,

--- a/scripts/langchain/capability_check.py
+++ b/scripts/langchain/capability_check.py
@@ -139,7 +139,9 @@ def _build_llm_config(
     issue_or_pr = (
         str(issue_number)
         if issue_number is not None
-        else env_issue if env_issue.isdigit() else "unknown"
+        else env_issue
+        if env_issue.isdigit()
+        else "unknown"
     )
     metadata = {
         "repo": repo,

--- a/scripts/langchain/followup_issue_generator.py
+++ b/scripts/langchain/followup_issue_generator.py
@@ -493,6 +493,8 @@ class VerificationData:
 
     provider_verdicts: dict[str, dict[str, Any]] = field(default_factory=dict)
     concerns: list[str] = field(default_factory=list)
+    non_pass_output: list[str] = field(default_factory=list)
+    non_pass_findings: list[str] = field(default_factory=list)
     low_scores: dict[str, int] = field(default_factory=dict)
     iteration_count: int = 0
     tasks_attempted: int = 0
@@ -527,6 +529,8 @@ class FollowupIssue:
 def extract_verification_data(comment_body: str) -> VerificationData:
     """Extract structured data from verification comment(s)."""
     data = VerificationData()
+    non_pass_output: list[str] = []
+    non_pass_findings: list[str] = []
 
     # Extract provider verdicts (from comparison reports)
     lines = comment_body.splitlines()
@@ -558,16 +562,26 @@ def extract_verification_data(comment_body: str) -> VerificationData:
         confidence_text = cols[3]
         confidence = _parse_confidence_value(confidence_text)
         summary_text = cols[4].strip() if len(cols) >= 5 else ""
+        verdict_clean = verdict.strip()
         entry = {
             "model": model,
-            "verdict": verdict.strip(),
+            "verdict": verdict_clean,
             "confidence": confidence,
         }
         if summary_text:
             entry["summary"] = summary_text
-            if verdict.strip().upper() != "PASS":
+            if verdict_clean.upper() != "PASS":
                 provider_summary_concerns.append(summary_text)
         data.provider_verdicts[provider] = entry
+        if verdict_clean.lower() != "pass":
+            non_pass_output.append(
+                f"Provider={provider}; Model={model}; Verdict={verdict_clean}; "
+                f"Confidence={confidence}%"
+            )
+            if summary_text:
+                non_pass_findings.append(
+                    f"Provider={provider}; Verdict={verdict_clean}; Difference={summary_text}"
+                )
 
     # Extract verdicts from provider detail sections as a fallback.
     current_provider = None
@@ -690,6 +704,16 @@ def extract_verification_data(comment_body: str) -> VerificationData:
         if c_lower not in seen:
             seen.add(c_lower)
             data.concerns.append(c)
+
+    # Keep deterministic non-PASS findings in concerns for task derivation.
+    for finding in non_pass_findings:
+        finding_key = finding.strip().lower()
+        if finding_key and finding_key not in seen:
+            seen.add(finding_key)
+            data.concerns.append(finding)
+
+    data.non_pass_output = list(dict.fromkeys(non_pass_output))
+    data.non_pass_findings = list(dict.fromkeys(non_pass_findings))
 
     if not data.concerns and _should_add_missing_concerns_note(
         comment_body, data.provider_verdicts
@@ -1131,6 +1155,105 @@ def _append_advisory_notes(body: str, advisory_concerns: list[str]) -> str:
     return body.rstrip() + "\n" + "\n".join(notes_lines) + "\n"
 
 
+def _assess_code_change_requirement(verification_data: VerificationData) -> tuple[str, str]:
+    """Return ('yes'|'no', rationale) for whether verify:compare implies code changes."""
+    normalized_verdicts = {
+        provider: (payload.get("verdict") or "").strip().lower()
+        for provider, payload in verification_data.provider_verdicts.items()
+    }
+    if any(verdict == "fail" for verdict in normalized_verdicts.values()):
+        return (
+            "yes",
+            "Difference describes a functional defect or regression signal that should be "
+            "resolved in code.",
+        )
+
+    # High-confidence PASS can override low-confidence CONCERNS when no provider reports FAIL.
+    pass_confidences = [
+        int(payload.get("confidence") or 0)
+        for payload in verification_data.provider_verdicts.values()
+        if (payload.get("verdict") or "").strip().lower() == "pass"
+    ]
+    concerns_confidences = [
+        int(payload.get("confidence") or 0)
+        for payload in verification_data.provider_verdicts.values()
+        if (payload.get("verdict") or "").strip().lower() == "concerns"
+    ]
+    if (
+        pass_confidences
+        and concerns_confidences
+        and max(pass_confidences) >= 85
+        and max(concerns_confidences) < 70
+    ):
+        return (
+            "no",
+            "Difference is low-confidence and contradicted by high-confidence PASS " "provider(s).",
+        )
+
+    findings = verification_data.non_pass_findings or verification_data.concerns
+    actionable_findings = [finding for finding in findings if not _is_advisory_concern(finding)]
+    if actionable_findings:
+        return (
+            "yes",
+            "Difference describes a functional defect or regression signal that should be "
+            "resolved in code.",
+        )
+
+    return (
+        "no",
+        "Difference is advisory-only (style/wording/preference) and does not require a code "
+        "change.",
+    )
+
+
+def generate_disposition_comment(
+    verification_data: VerificationData,
+    *,
+    pr_number: int,
+    source_url: str | None = None,
+) -> str:
+    """Generate a markdown disposition comment from verify:compare output."""
+    requires_code_changes, rationale = _assess_code_change_requirement(verification_data)
+    lines = [
+        "## verify:compare Disposition",
+        "",
+        f"Source: verify:compare non-PASS output from PR #{pr_number}",
+    ]
+    if source_url:
+        lines.append(f"Source link: {source_url}")
+
+    lines.extend(["", "## verify:compare Evidence"])
+    for item in verification_data.non_pass_output:
+        lines.append(f"- `{item}`")
+    if not verification_data.non_pass_output:
+        lines.append("- No non-PASS provider rows were detected in the supplied output.")
+
+    lines.extend(
+        [
+            "",
+            "## verify:compare Analysis",
+            "",
+            f"- non-PASS output requires code changes: **{requires_code_changes}**",
+            (
+                "- requires code changes: "
+                f"**{requires_code_changes}**; technical rationale: {rationale}"
+            ),
+        ]
+    )
+
+    if verification_data.non_pass_findings:
+        lines.append("")
+        for finding in verification_data.non_pass_findings:
+            lines.append(f"- {finding}")
+
+    return "\n".join(lines)
+
+
+def generate_issue_disposition_link_comment(*, disposition_url: str) -> str:
+    """Generate issue comment body that links to a verify:compare disposition note."""
+    return "Disposition documentation for verify:compare is recorded here: " f"{disposition_url}"
+
+
 def generate_followup_issue(
     verification_data: VerificationData,
     original_issue: OriginalIssueData,
@@ -1413,6 +1536,7 @@ def _generate_without_llm(
         verdict=verdict,
         needs_human_reason=needs_human_reason,
     )
+    requires_code_changes, rationale = _assess_code_change_requirement(verification_data)
 
     # Convert concerns to tasks
     tasks = []
@@ -1438,18 +1562,42 @@ def _generate_without_llm(
         "",
         why_section,
         "",
-        "## Source",
+        "## verify:compare Analysis",
         "",
-        f"- Original PR: #{pr_number}",
-        f"- Parent issue: #{original_issue.number}",
-        "",
-        "## Scope",
-        "",
-        f"Address verification concerns from PR #{pr_number} related to {original_issue.title}.",
-        "",
-        "## Tasks",
-        "",
+        f"- non-PASS output requires code changes: **{requires_code_changes}**",
+        f"- requires code changes: **{requires_code_changes}**; technical rationale: {rationale}",
     ]
+    for finding in verification_data.non_pass_findings:
+        body_parts.append(f"- {finding}")
+
+    body_parts.extend(
+        [
+            "",
+            "## verify:compare Evidence",
+            "",
+        ]
+    )
+    for evidence in verification_data.non_pass_output:
+        body_parts.append(f"- {evidence}")
+    if not verification_data.non_pass_output:
+        body_parts.append("- No non-PASS provider rows were detected in the supplied output.")
+
+    body_parts.extend(
+        [
+            "",
+            "## Source",
+            "",
+            f"- Original PR: #{pr_number}",
+            f"- Parent issue: #{original_issue.number}",
+            "",
+            "## Scope",
+            "",
+            f"Address verification concerns from PR #{pr_number} related to {original_issue.title}.",
+            "",
+            "## Tasks",
+            "",
+        ]
+    )
 
     if needs_human:
         body_parts.append(

--- a/scripts/langchain/injection_guard.py
+++ b/scripts/langchain/injection_guard.py
@@ -41,9 +41,9 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
-from typing import Final, Literal, TypeAlias, TypedDict, cast
+from typing import Final, Literal, TypedDict, cast
 
-ReasonCode: TypeAlias = Literal[
+type ReasonCode = Literal[
     "INSTRUCTION_OVERRIDE",
     "SYSTEM_PROMPT_EXFILTRATION",
     "ROLE_CONFUSION",
@@ -51,7 +51,7 @@ ReasonCode: TypeAlias = Literal[
     "TOOL_INJECTION",
 ]
 
-GuardResult: TypeAlias = tuple[bool, str]
+type GuardResult = tuple[bool, str]
 
 
 class GuardCheckResultAllowed(TypedDict):
@@ -70,7 +70,7 @@ class GuardCheckResultBlocked(TypedDict):
     code: ReasonCode | Literal["GUARD_ERROR"] | None
 
 
-GuardCheckResult: TypeAlias = GuardCheckResultAllowed | GuardCheckResultBlocked
+type GuardCheckResult = GuardCheckResultAllowed | GuardCheckResultBlocked
 
 
 @dataclass(frozen=True)

--- a/scripts/langchain/issue_optimizer.py
+++ b/scripts/langchain/issue_optimizer.py
@@ -319,9 +319,7 @@ def _build_llm_config(
     issue_or_pr = (
         str(issue_number)
         if issue_number is not None
-        else env_issue
-        if env_issue.isdigit()
-        else "unknown"
+        else env_issue if env_issue.isdigit() else "unknown"
     )
     metadata = {
         "repo": repo,

--- a/scripts/langchain/issue_optimizer.py
+++ b/scripts/langchain/issue_optimizer.py
@@ -319,7 +319,9 @@ def _build_llm_config(
     issue_or_pr = (
         str(issue_number)
         if issue_number is not None
-        else env_issue if env_issue.isdigit() else "unknown"
+        else env_issue
+        if env_issue.isdigit()
+        else "unknown"
     )
     metadata = {
         "repo": repo,

--- a/scripts/langchain/structured_output.py
+++ b/scripts/langchain/structured_output.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any, Generic, TypeVar
+from typing import Any, TypeVar
 
 from pydantic import BaseModel, ValidationError
 
@@ -31,7 +31,7 @@ MAX_REPAIR_ATTEMPTS = 1
 
 
 @dataclass(frozen=True)
-class StructuredOutputResult(Generic[T]):
+class StructuredOutputResult[T: BaseModel]:
     payload: T | None
     raw_content: str | None
     error_stage: str | None
@@ -95,7 +95,7 @@ def clamp_repair_attempts(max_repair_attempts: int) -> int:
     )
 
 
-def _invoke_repair_loop(
+def _invoke_repair_loop[T: BaseModel](
     *,
     repair: Callable[[str, str, str], str | None] | None,
     attempts: int,
@@ -154,7 +154,7 @@ def _invoke_repair_loop(
     )
 
 
-def invoke_repair_loop(
+def invoke_repair_loop[T: BaseModel](
     *,
     repair: Callable[[str, str, str], str | None] | None,
     attempts: int,
@@ -171,7 +171,7 @@ def invoke_repair_loop(
     )
 
 
-def parse_structured_output(
+def parse_structured_output[T: BaseModel](
     content: str,
     model: type[T],
     *,

--- a/tools/coverage_guard.py
+++ b/tools/coverage_guard.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""Coverage guard script for maintaining baseline breach issues.
+
+This script compares current coverage against a baseline and creates/updates
+a tracking issue when coverage falls below the threshold.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    """Load JSON from a file, returning empty dict on error."""
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError):
+        return {}
+
+
+def _get_hotspots(coverage_data: dict[str, Any], limit: int = 15) -> list[dict[str, Any]]:
+    """Extract files with lowest coverage from coverage.json."""
+    files = coverage_data.get("files", {})
+    hotspots = []
+
+    for filepath, data in files.items():
+        summary = data.get("summary", {})
+        percent = summary.get("percent_covered", 0.0)
+        missing = summary.get("missing_lines", 0)
+        hotspots.append(
+            {
+                "file": filepath,
+                "coverage": percent,
+                "missing_lines": missing,
+            }
+        )
+
+    # Sort by coverage ascending (lowest first)
+    hotspots.sort(key=lambda x: x["coverage"])
+    return hotspots[:limit]
+
+
+def _format_issue_body(
+    current: float,
+    baseline: float,
+    delta: float,
+    hotspots: list[dict[str, Any]],
+    run_url: str,
+) -> str:
+    """Format the issue body with coverage summary and hotspots."""
+    status_emoji = "✅" if current >= baseline else "❌"
+
+    body = f"""## Coverage Baseline Breach Report
+
+{status_emoji} **Current Coverage: {current:.2f}%** (baseline: {baseline:.2f}%, delta: {delta:+.2f}%)
+
+### Summary
+
+| Metric | Value |
+|--------|-------|
+| Current | {current:.2f}% |
+| Baseline | {baseline:.2f}% |
+| Delta | {delta:+.2f}% |
+| Status | {"Pass ✅" if current >= baseline else "Below baseline ❌"} |
+
+### Low Coverage Hotspots
+
+These files have the lowest coverage and are candidates for additional tests:
+
+| File | Coverage | Missing Lines |
+|------|----------|---------------|
+"""
+
+    for spot in hotspots:
+        body += f"| `{spot['file']}` | {spot['coverage']:.1f}% | {spot['missing_lines']} |\n"
+
+    if not hotspots:
+        body += "| _(no files with low coverage)_ | - | - |\n"
+
+    body += f"""
+
+### Actions
+
+- [ ] Review hotspot files and add tests for uncovered code
+- [ ] Update baseline once coverage improves
+
+### Source
+
+[Gate Workflow Run]({run_url})
+
+---
+_This issue is automatically updated by the coverage guard workflow._
+"""
+    return body
+
+
+def _find_or_create_issue(repo: str, title: str, body: str, labels: list[str]) -> None:
+    """Find existing issue or create a new one using gh CLI."""
+    import subprocess
+
+    # Search for existing issue
+    search_result = subprocess.run(
+        [
+            "gh",
+            "issue",
+            "list",
+            "--repo",
+            repo,
+            "--search",
+            f'"{title}" in:title',
+            "--json",
+            "number,title",
+            "--limit",
+            "1",
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    existing_issues = json.loads(search_result.stdout) if search_result.stdout.strip() else []
+
+    if existing_issues:
+        # Update existing issue
+        issue_number = existing_issues[0]["number"]
+        subprocess.run(
+            ["gh", "issue", "edit", str(issue_number), "--repo", repo, "--body", body],
+            check=True,
+        )
+        print(f"Updated issue #{issue_number}")
+    else:
+        # Create new issue
+        label_args = []
+        for label in labels:
+            label_args.extend(["--label", label])
+
+        subprocess.run(
+            [
+                "gh",
+                "issue",
+                "create",
+                "--repo",
+                repo,
+                "--title",
+                title,
+                "--body",
+                body,
+                *label_args,
+            ],
+            check=True,
+        )
+        print(f"Created new issue: {title}")
+
+
+def main(args: list[str] | None = None) -> int:
+    """Main entry point for coverage guard."""
+    parser = argparse.ArgumentParser(description="Coverage guard - maintain baseline breach issues")
+    parser.add_argument("--repo", required=True, help="Repository (owner/repo)")
+    parser.add_argument("--trend-path", type=Path, help="Path to coverage-trend.json")
+    parser.add_argument("--coverage-path", type=Path, help="Path to coverage.json")
+    parser.add_argument("--baseline-path", type=Path, help="Path to coverage-baseline.json")
+    parser.add_argument("--run-url", default="", help="URL to the workflow run")
+    parser.add_argument("--issue-title", default="[coverage] baseline breach", help="Issue title")
+    parser.add_argument("--dry-run", action="store_true", help="Print issue body without creating")
+    parsed = parser.parse_args(args)
+
+    # Load trend data
+    trend_data = {}
+    if parsed.trend_path and parsed.trend_path.exists():
+        trend_data = _load_json(parsed.trend_path)
+
+    # Load coverage data for hotspots
+    coverage_data = {}
+    if parsed.coverage_path and parsed.coverage_path.exists():
+        coverage_data = _load_json(parsed.coverage_path)
+
+    # Load baseline
+    baseline_data = {}
+    if parsed.baseline_path and parsed.baseline_path.exists():
+        baseline_data = _load_json(parsed.baseline_path)
+
+    # Extract values
+    current = trend_data.get("current", 0.0)
+    baseline = baseline_data.get("coverage", trend_data.get("baseline", 70.0))
+    delta = current - baseline
+
+    # Get hotspots
+    hotspots = _get_hotspots(coverage_data)
+
+    # Format issue body
+    body = _format_issue_body(current, baseline, delta, hotspots, parsed.run_url)
+
+    if parsed.dry_run:
+        print("=" * 60)
+        print(f"Issue Title: {parsed.issue_title}")
+        print("=" * 60)
+        print(body)
+        return 0
+
+    # Create or update issue
+    if current < baseline:
+        _find_or_create_issue(
+            repo=parsed.repo,
+            title=parsed.issue_title,
+            body=body,
+            labels=["coverage", "automated"],
+        )
+    else:
+        print(f"Coverage {current:.2f}% meets baseline {baseline:.2f}% - no issue needed")
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    sys.exit(main())

--- a/tools/resolve_mypy_pin.py
+++ b/tools/resolve_mypy_pin.py
@@ -74,7 +74,7 @@ def main() -> int:
         output_version = mypy_version
     else:
         # Default to the primary Python version (first in typical matrices)
-        output_version = matrix_version or "3.11"
+        output_version = matrix_version or "3.12"
 
     # Write to GITHUB_OUTPUT
     github_output = os.environ.get("GITHUB_OUTPUT")


### PR DESCRIPTION
## Summary
- standardize repo workflow/runtime references on Python 3.12
- move CI matrices from 3.11/3.12 to 3.12/3.13 where applicable
- update project/runtime metadata and dependency lock markers that encode the old 3.11 floor

## Verification
- YAML parsed successfully across audited workflow/action files for all patched repos
- pyproject metadata parsed successfully and now declares a 3.12 floor where present
- runtime audit has no remaining Python 3.11/py311 policy hits; residual 3.10/3.11 strings are package versions or wheel tags, not runtime targets

This pairs with stranske/Workflows#1777, which updated the Workflows source-of-truth and templates.