### PR TITLE
deps: sync dev tool versions

### DIFF
--- a/.github/workflows/autofix-versions.env
+++ b/.github/workflows/autofix-versions.env
@@ -5,10 +5,10 @@
 # Runtime dependencies (PyYAML, Pydantic, Hypothesis) should be managed via Dependabot
 # in each consumer repo's pyproject.toml directly, NOT synced from this file.
 BLACK_VERSION=26.3.1
-RUFF_VERSION=0.15.11
+RUFF_VERSION=0.15.12
 ISORT_VERSION=8.0.1
 DOCFORMATTER_VERSION=1.7.7
-MYPY_VERSION=1.20.1
+MYPY_VERSION=1.20.2
 PYTEST_VERSION=9.0.3
 PYTEST_COV_VERSION=7.1.0
 PYTEST_XDIST_VERSION=3.8.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,8 +26,8 @@ dependencies = []
 dev = [
     "pytest==9.0.3",
     "pytest-cov==7.1.0",
-    "ruff==0.15.10",
-    "mypy==1.20.1",
+    "ruff>=0.15.12",
+    "mypy>=1.20.2",
     "black==26.3.1",
 ]
 

--- a/requirements.lock
+++ b/requirements.lock
@@ -14,7 +14,7 @@ iniconfig==2.3.0
     # via pytest
 librt==0.9.0 ; platform_python_implementation != 'PyPy'
     # via mypy
-mypy==1.20.1
+mypy==1.20.2
     # via my-project (/tmp/inv-pr197/pyproject.toml)
 mypy-extensions==1.1.0
     # via
@@ -44,7 +44,7 @@ pytest-cov==7.1.0
     # via my-project (/tmp/inv-pr197/pyproject.toml)
 pytokens==0.4.1
     # via black
-ruff==0.15.10
+ruff==0.15.12
     # via my-project (/tmp/inv-pr197/pyproject.toml)
 typing-extensions==4.15.0
     # via mypy


### PR DESCRIPTION
## Dev Tool Version Sync

This PR updates dev tool versions in `pyproject.toml` to match the central
version pins from [stranske/Workflows](https://github.com/stranske/Workflows).

### Changes
```
Found 4 version updates:
  - ruff: ==0.15.10 -> >=0.15.12
  - mypy: ==1.20.1 -> >=1.20.2
  - requirements.lock:mypy: 1.20.1 -> ==1.20.2
  - requirements.lock:ruff: 0.15.10 -> ==0.15.12

Run with --apply to update dependency files
```

### Why
Consistent dev tool versions across repos ensures:
- CI behaviors match between repos
- No surprises from version drift
- Easier debugging when tools behave the same everywhere

---
**Source:** `.github/workflows/autofix-versions.env`