### PR TITLE
Issue #401: Wire LangSmith trace export

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The v1 design target is documented in
 - Performance normalization, metric calculation, and source-conflict escalation.
 - Analyst-first validation queue states, ownership, SLA, audit, and API contracts.
 - Configurable scoring weights, score explainability, red-flag hooks, and regression fixtures.
-- Observability helpers for tracing, logging, metrics, and setup validation.
+- Observability helpers for tracing, LangSmith export, logging, metrics, and setup validation.
 
 ## Quick Start
 

--- a/docs/runbooks/langsmith_tracing.md
+++ b/docs/runbooks/langsmith_tracing.md
@@ -9,6 +9,7 @@ Provide reusable tracing wrappers that can be enabled or disabled without changi
 - `TraceContext`: trace ID + parent span + tags
 - `Tracer`: starts spans when enabled
 - `InMemoryTraceSink`: local sink for tests/dev
+- `LangSmithTraceSink`: runtime sink that exports spans through `langsmith.Client`
 - `NoopSpan`: safe no-op when tracing is disabled
 
 ## Usage Pattern
@@ -21,8 +22,7 @@ Provide reusable tracing wrappers that can be enabled or disabled without changi
 ## Example
 
 ```python
-sink = InMemoryTraceSink()
-tracer = Tracer(enabled=True, sink=sink)
+tracer = Tracer.from_env()
 ctx = new_trace_context(tags={"stage": "intake"})
 
 with tracer.start_span(name="ingest", context=ctx, metadata={"package_id": "pkg_1"}):
@@ -77,11 +77,13 @@ export LANGSMITH_TRACING_ENABLED="true"
    - `env | rg 'LANGSMITH_API_KEY|LANGSMITH_PROJECT|LANGCHAIN_TRACING_V2|INV_MAN_TRACING_ENABLED'`
 2. Run setup validator (fails fast if required values are missing/disabled):
    - `python -m inv_man_intake.observability.setup_validation --require-project`
-3. Run tracing tests:
-   - `pytest tests/observability/test_tracing_toggle.py -m "not slow"`
-4. Validate disabled mode behavior still works by setting:
+3. Run the probe validator to emit one span through the configured LangSmith client:
+   - `python -m inv_man_intake.observability.setup_validation --require-project --probe`
+4. Run tracing export tests:
+   - `pytest tests/observability/test_langsmith_export.py tests/observability/test_tracing_toggle.py -m "not slow"`
+5. Validate disabled mode behavior still works by setting:
    - `INV_MAN_TRACING_ENABLED=false`
-5. Validate enabled mode by setting:
+6. Validate enabled mode by setting:
    - `INV_MAN_TRACING_ENABLED=true`
    - `LANGCHAIN_TRACING_V2=true`
 
@@ -89,11 +91,11 @@ export LANGSMITH_TRACING_ENABLED="true"
 
 1. Validate shell env before startup:
    - `env | rg 'LANGSMITH_API_KEY|LANGSMITH_PROJECT|LANGCHAIN_TRACING_V2|INV_MAN_TRACING_ENABLED'`
-2. Re-run setup validation:
-   - `python -m inv_man_intake.observability.setup_validation --require-project`
-3. Confirm toggles resolve as enabled in tests:
-   - `pytest -q tests/observability/test_setup_validation.py tests/observability/test_tracing_toggle.py --no-cov`
-4. Verify application code uses `Tracer.from_env(...)` or `Tracer(enabled=True, ...)` with a sink.
+2. Re-run setup validation with the probe enabled:
+   - `python -m inv_man_intake.observability.setup_validation --require-project --probe`
+3. Confirm toggles and mocked client export resolve as enabled in tests:
+   - `pytest -q tests/observability/test_setup_validation.py tests/observability/test_langsmith_export.py tests/observability/test_tracing_toggle.py --no-cov`
+4. Verify application code uses `Tracer.from_env(...)`; local/offline smoke code may still pass an explicit `InMemoryTraceSink`.
 
 ## Missing Metrics Troubleshooting
 
@@ -101,5 +103,5 @@ export LANGSMITH_TRACING_ENABLED="true"
 2. Run fallback/escalation regression coverage:
    - `pytest -q tests/test_extraction_orchestrator.py --no-cov`
 3. Validate observability smoke target locally:
-   - `pytest -q tests/observability/test_setup_validation.py tests/observability/test_tracing_toggle.py --no-cov`
+   - `pytest -q tests/observability/test_setup_validation.py tests/observability/test_langsmith_export.py tests/observability/test_tracing_toggle.py --no-cov`
 4. If CI passes but runtime metrics are absent, verify runtime logging/metrics sink wiring and deployment env toggles.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,9 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
 ]
-dependencies = []
+dependencies = [
+    "langsmith>=0.4.59",
+]
 
 [project.optional-dependencies]
 dev = [

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -14,6 +14,8 @@ coverage==7.13.5
     # via pytest-cov
 iniconfig==2.3.0
     # via pytest
+langsmith==0.4.59
+    # via inv-man-intake (pyproject.toml)
 librt==0.9.0 ; platform_python_implementation != 'PyPy'
     # via mypy
 mypy==1.20.2

--- a/requirements.lock
+++ b/requirements.lock
@@ -14,6 +14,8 @@ coverage==7.13.5
     # via pytest-cov
 iniconfig==2.3.0
     # via pytest
+langsmith==0.4.59
+    # via inv-man-intake (pyproject.toml)
 librt==0.9.0 ; platform_python_implementation != 'PyPy'
     # via mypy
 mypy==1.20.2

--- a/src/inv_man_intake/extraction/orchestrator.py
+++ b/src/inv_man_intake/extraction/orchestrator.py
@@ -72,7 +72,7 @@ class ExtractionOrchestrator:
         self._fallback = _Provider(name=fallback_name, extractor=fallback_extractor)
         self._policy = policy or RetryPolicy()
         self._metrics_hook = metrics_hook
-        self._tracer = tracer or Tracer(enabled=False)
+        self._tracer = tracer or Tracer.from_env()
 
     def run(
         self, payload: dict[str, Any], trace_context: TraceContext | None = None

--- a/src/inv_man_intake/observability/__init__.py
+++ b/src/inv_man_intake/observability/__init__.py
@@ -1,5 +1,6 @@
 """Observability utilities for trace and metric instrumentation."""
 
+from .langsmith_sink import LangSmithTraceSink
 from .logging import (
     CORRELATION_ID_KEY,
     LogContext,
@@ -19,6 +20,8 @@ from .metrics import (
 )
 from .tracing import (
     LANGCHAIN_TRACE_ENABLED_ENV_KEY,
+    LANGSMITH_API_KEY_ENV_KEY,
+    LANGSMITH_PROJECT_ENV_KEY,
     LANGSMITH_TRACE_ENABLED_ENV_KEY,
     TRACE_ENABLED_ENV_KEY,
     InMemoryTraceSink,
@@ -42,6 +45,9 @@ __all__ = [
     "FALLBACK_COUNT",
     "InMemoryMetrics",
     "InMemoryTraceSink",
+    "LANGSMITH_API_KEY_ENV_KEY",
+    "LANGSMITH_PROJECT_ENV_KEY",
+    "LangSmithTraceSink",
     "LANGCHAIN_TRACE_ENABLED_ENV_KEY",
     "LANGSMITH_TRACE_ENABLED_ENV_KEY",
     "LATENCY_MS",

--- a/src/inv_man_intake/observability/langsmith_sink.py
+++ b/src/inv_man_intake/observability/langsmith_sink.py
@@ -1,0 +1,115 @@
+"""LangSmith trace sink for repository trace events."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Callable, Mapping
+from typing import Any, Literal, Protocol
+from uuid import NAMESPACE_URL, UUID, uuid5
+
+from .tracing import LANGSMITH_PROJECT_ENV_KEY, TraceEvent
+
+
+class LangSmithClient(Protocol):
+    """Minimal LangSmith client surface used by the trace sink."""
+
+    def create_run(
+        self,
+        name: str,
+        inputs: dict[str, Any],
+        run_type: Literal["tool", "chain", "llm", "retriever", "embedding", "prompt", "parser"],
+        **kwargs: Any,
+    ) -> Any:
+        """Create a LangSmith run."""
+
+    def update_run(self, run_id: UUID, **kwargs: Any) -> Any:
+        """Update a LangSmith run."""
+
+
+ClientFactory = Callable[[], LangSmithClient]
+
+
+class LangSmithTraceSink:
+    """Emit trace events to LangSmith through ``langsmith.Client``."""
+
+    def __init__(
+        self,
+        client: LangSmithClient | None = None,
+        client_factory: ClientFactory | None = None,
+        project_name: str | None = None,
+    ) -> None:
+        self._client = client
+        self._client_factory = client_factory or _default_client_factory
+        self._project_name = project_name
+
+    @classmethod
+    def from_env(cls, env: Mapping[str, str] | None = None) -> LangSmithTraceSink:
+        """Create a sink using the LangSmith project configured in env."""
+        source = env if env is not None else os.environ
+        project_name = source.get(LANGSMITH_PROJECT_ENV_KEY, "").strip() or None
+        return cls(project_name=project_name)
+
+    def on_span_start(self, event: TraceEvent) -> None:
+        run_id = _event_run_uuid(event)
+        payload: dict[str, Any] = {
+            "id": run_id,
+            "name": event.name,
+            "run_type": "chain" if event.kind == "run" else "tool",
+            "inputs": {
+                "trace_id": event.trace_id,
+                "span_id": event.span_id,
+                "run_id": event.run_id,
+            },
+            "start_time": event.started_at,
+            "extra": {
+                "metadata": event.metadata,
+                "trace": {
+                    "kind": event.kind,
+                    "trace_id": event.trace_id,
+                    "span_id": event.span_id,
+                    "run_id": event.run_id,
+                    "parent_run_id": event.parent_run_id,
+                    "parent_span_id": event.parent_span_id,
+                },
+            },
+        }
+        if self._project_name:
+            payload["project_name"] = self._project_name
+        parent_id = _parent_run_uuid(event)
+        if parent_id is not None:
+            payload["parent_run_id"] = parent_id
+
+        self._get_client().create_run(**payload)
+
+    def on_span_end(self, event: TraceEvent) -> None:
+        payload: dict[str, Any] = {
+            "end_time": event.ended_at,
+            "outputs": {
+                "trace_id": event.trace_id,
+                "span_id": event.span_id,
+                "metadata": event.metadata,
+            },
+        }
+        self._get_client().update_run(_event_run_uuid(event), **payload)
+
+    def _get_client(self) -> LangSmithClient:
+        if self._client is None:
+            self._client = self._client_factory()
+        return self._client
+
+
+def _default_client_factory() -> LangSmithClient:
+    from langsmith import Client
+
+    return Client()
+
+
+def _event_run_uuid(event: TraceEvent) -> UUID:
+    return uuid5(NAMESPACE_URL, f"{event.trace_id}:{event.span_id}")
+
+
+def _parent_run_uuid(event: TraceEvent) -> UUID | None:
+    parent_id = event.parent_run_id or event.parent_span_id
+    if parent_id is None:
+        return None
+    return uuid5(NAMESPACE_URL, f"{event.trace_id}:{parent_id}")

--- a/src/inv_man_intake/observability/setup_validation.py
+++ b/src/inv_man_intake/observability/setup_validation.py
@@ -31,6 +31,7 @@ __all__ = [
     "main",
 ]
 
+
 @dataclass(frozen=True)
 class SetupValidationResult:
     """Validation result for LangSmith tracing setup."""

--- a/src/inv_man_intake/observability/setup_validation.py
+++ b/src/inv_man_intake/observability/setup_validation.py
@@ -6,11 +6,18 @@ import argparse
 import os
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
+from typing import Any, Literal
+from uuid import UUID
 
+from .langsmith_sink import ClientFactory, LangSmithClient, LangSmithTraceSink
 from .tracing import (
     LANGCHAIN_TRACE_ENABLED_ENV_KEY,
+    LANGSMITH_API_KEY_ENV_KEY,
+    LANGSMITH_PROJECT_ENV_KEY,
     LANGSMITH_TRACE_ENABLED_ENV_KEY,
     TRACE_ENABLED_ENV_KEY,
+    Tracer,
+    new_trace_context,
     tracing_enabled_from_env,
 )
 
@@ -24,10 +31,6 @@ __all__ = [
     "main",
 ]
 
-LANGSMITH_API_KEY_ENV_KEY = "LANGSMITH_API_KEY"
-LANGSMITH_PROJECT_ENV_KEY = "LANGSMITH_PROJECT"
-
-
 @dataclass(frozen=True)
 class SetupValidationResult:
     """Validation result for LangSmith tracing setup."""
@@ -40,6 +43,8 @@ class SetupValidationResult:
 def validate_langsmith_setup(
     env: Mapping[str, str] | None = None,
     require_project: bool = False,
+    probe_emit: bool = False,
+    client_factory: ClientFactory | None = None,
 ) -> SetupValidationResult:
     """Validate required environment for LangSmith tracing setup."""
     source = env if env is not None else os.environ
@@ -84,6 +89,26 @@ def validate_langsmith_setup(
         else:
             warnings.append(message)
 
+    if probe_emit and len(errors) == 0:
+        try:
+            probe_client = _ProbeClient((client_factory or _default_probe_client_factory)())
+            sink = LangSmithTraceSink(
+                client=probe_client,
+                project_name=project_name or None,
+            )
+            tracer = Tracer(enabled=True, sink=sink)
+            context = new_trace_context(tags={"validation": "langsmith_probe"})
+            with tracer.start_span(
+                name="langsmith_setup_probe",
+                context=context,
+                metadata={"probe": True},
+            ):
+                pass
+            if probe_client.observed_run_count == 0:
+                errors.append("LangSmith probe emitted no run; verify client wiring.")
+        except Exception as exc:  # pragma: no cover - exact client failures vary.
+            errors.append(f"LangSmith probe failed to emit a trace span: {exc}")
+
     return SetupValidationResult(
         is_valid=len(errors) == 0,
         errors=tuple(errors),
@@ -91,7 +116,11 @@ def validate_langsmith_setup(
     )
 
 
-def main(argv: Sequence[str] | None = None, env: Mapping[str, str] | None = None) -> int:
+def main(
+    argv: Sequence[str] | None = None,
+    env: Mapping[str, str] | None = None,
+    client_factory: ClientFactory | None = None,
+) -> int:
     """CLI entrypoint for setup validation."""
     parser = argparse.ArgumentParser(
         prog="python -m inv_man_intake.observability.setup_validation",
@@ -102,9 +131,19 @@ def main(argv: Sequence[str] | None = None, env: Mapping[str, str] | None = None
         action="store_true",
         help=f"Require {LANGSMITH_PROJECT_ENV_KEY} to be set.",
     )
+    parser.add_argument(
+        "--probe",
+        action="store_true",
+        help="Emit one probe span through the configured LangSmith client.",
+    )
     args = parser.parse_args(list(argv) if argv is not None else None)
 
-    result = validate_langsmith_setup(env=env, require_project=args.require_project)
+    result = validate_langsmith_setup(
+        env=env,
+        require_project=args.require_project,
+        probe_emit=args.probe,
+        client_factory=client_factory,
+    )
 
     for warning in result.warnings:
         print(f"WARNING: {warning}")
@@ -126,6 +165,38 @@ def _parse_bool(value: str) -> bool | None:
     if normalized in {"0", "false", "f", "no", "n", "off"}:
         return False
     return None
+
+
+class _ProbeClient:
+    def __init__(self, client: LangSmithClient) -> None:
+        self._client = client
+        self.create_run_count = 0
+
+    def create_run(
+        self,
+        name: str,
+        inputs: dict[str, Any],
+        run_type: Literal["tool", "chain", "llm", "retriever", "embedding", "prompt", "parser"],
+        **kwargs: Any,
+    ) -> Any:
+        self.create_run_count += 1
+        return self._client.create_run(name=name, inputs=inputs, run_type=run_type, **kwargs)
+
+    def update_run(self, run_id: UUID, **kwargs: Any) -> Any:
+        return self._client.update_run(run_id, **kwargs)
+
+    @property
+    def observed_run_count(self) -> int:
+        create_calls = getattr(self._client, "create_calls", None)
+        if isinstance(create_calls, list):
+            return len(create_calls)
+        return self.create_run_count
+
+
+def _default_probe_client_factory() -> LangSmithClient:
+    from langsmith import Client
+
+    return Client()
 
 
 if __name__ == "__main__":

--- a/src/inv_man_intake/observability/tracing.py
+++ b/src/inv_man_intake/observability/tracing.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import warnings
 from collections.abc import Callable, Mapping, MutableMapping
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
@@ -20,6 +21,8 @@ TAGS_KEY = f"{TRACE_CONTEXT_PREFIX}tags"
 TRACE_ENABLED_ENV_KEY = "INV_MAN_TRACING_ENABLED"
 LANGSMITH_TRACE_ENABLED_ENV_KEY = "LANGSMITH_TRACING_ENABLED"
 LANGCHAIN_TRACE_ENABLED_ENV_KEY = "LANGCHAIN_TRACING_V2"
+LANGSMITH_API_KEY_ENV_KEY = "LANGSMITH_API_KEY"
+LANGSMITH_PROJECT_ENV_KEY = "LANGSMITH_PROJECT"
 P = ParamSpec("P")
 R = TypeVar("R")
 
@@ -153,7 +156,20 @@ class Tracer:
         default_enabled: bool = False,
     ) -> Tracer:
         """Construct tracer using environment-based enable toggles."""
+        source = env if env is not None else os.environ
         enabled = tracing_enabled_from_env(env=env, default_enabled=default_enabled)
+        if sink is None and enabled:
+            if source.get(LANGSMITH_API_KEY_ENV_KEY, "").strip():
+                from .langsmith_sink import LangSmithTraceSink
+
+                sink = LangSmithTraceSink.from_env(env=source)
+            else:
+                warnings.warn(
+                    f"{LANGSMITH_API_KEY_ENV_KEY} is empty; using InMemoryTraceSink.",
+                    RuntimeWarning,
+                    stacklevel=2,
+                )
+                sink = InMemoryTraceSink()
         return cls(enabled=enabled, sink=sink)
 
     def start_span(

--- a/src/inv_man_intake/observability/tracing.py
+++ b/src/inv_man_intake/observability/tracing.py
@@ -159,10 +159,13 @@ class Tracer:
         source = env if env is not None else os.environ
         enabled = tracing_enabled_from_env(env=env, default_enabled=default_enabled)
         if sink is None and enabled:
-            if source.get(LANGSMITH_API_KEY_ENV_KEY, "").strip():
+            api_key = source.get(LANGSMITH_API_KEY_ENV_KEY, "").strip()
+            if api_key and langsmith_export_enabled_from_env(env=source):
                 from .langsmith_sink import LangSmithTraceSink
 
                 sink = LangSmithTraceSink.from_env(env=source)
+            elif api_key:
+                sink = InMemoryTraceSink()
             else:
                 warnings.warn(
                     f"{LANGSMITH_API_KEY_ENV_KEY} is empty; using InMemoryTraceSink.",
@@ -374,6 +377,19 @@ def tracing_enabled_from_env(
         if parsed is not None:
             return parsed
     return default_enabled
+
+
+def langsmith_export_enabled_from_env(env: Mapping[str, str] | None = None) -> bool:
+    """Return whether repo-specific toggles permit LangSmith export."""
+    source = env if env is not None else os.environ
+    for key in (TRACE_ENABLED_ENV_KEY, LANGSMITH_TRACE_ENABLED_ENV_KEY):
+        value = source.get(key)
+        if value is None:
+            continue
+        parsed = _parse_toggle(value)
+        if parsed is not None:
+            return parsed
+    return False
 
 
 def _parse_toggle(value: str) -> bool | None:

--- a/tests/observability/test_langsmith_export.py
+++ b/tests/observability/test_langsmith_export.py
@@ -14,6 +14,7 @@ from inv_man_intake.observability.tracing import (
     TRACE_ENABLED_ENV_KEY,
     InMemoryTraceSink,
     Tracer,
+    child_trace_context,
     new_trace_context,
 )
 
@@ -54,6 +55,22 @@ def test_langsmith_sink_emits_create_and_update_payloads() -> None:
     update_run_id, update_payload = client.update_calls[0]
     assert update_run_id == create_payload["id"]
     assert update_payload["end_time"] is not None
+
+
+def test_langsmith_sink_records_parent_linkage_for_child_run() -> None:
+    client = FakeLangSmithClient()
+    sink = LangSmithTraceSink(client=client, project_name="inv-man-intake-dev")
+    tracer = Tracer(enabled=True, sink=sink)
+    root_context = new_trace_context(tags={"stage": "root"})
+    child_context = child_trace_context(root_context, parent_span_id="run_parent_1")
+
+    with tracer.start_run(name="score_pipeline", context=child_context):
+        pass
+
+    create_payload = client.create_calls[0]
+    assert create_payload["run_type"] == "chain"
+    assert create_payload["parent_run_id"] is not None
+    assert create_payload["extra"]["trace"]["parent_span_id"] == "run_parent_1"
 
 
 def test_tracer_from_env_uses_langsmith_sink_when_enabled_with_api_key(

--- a/tests/observability/test_langsmith_export.py
+++ b/tests/observability/test_langsmith_export.py
@@ -123,6 +123,24 @@ def test_tracer_from_env_does_not_construct_client_when_disabled(monkeypatch) ->
         pass
 
 
+def test_tracer_from_env_requires_repo_toggle_for_langsmith_export(monkeypatch) -> None:
+    def _client_factory() -> FakeLangSmithClient:
+        raise AssertionError("LangSmith client should not be constructed")
+
+    monkeypatch.setattr(
+        "inv_man_intake.observability.langsmith_sink._default_client_factory",
+        _client_factory,
+    )
+    env = {
+        LANGSMITH_API_KEY_ENV_KEY: "lsv2_pt_x",
+        LANGSMITH_PROJECT_ENV_KEY: "inv-man-intake-dev",
+        LANGCHAIN_TRACE_ENABLED_ENV_KEY: "true",
+    }
+
+    tracer = Tracer.from_env(env=env)
+    assert isinstance(tracer._sink, InMemoryTraceSink)
+
+
 def test_tracer_from_env_falls_back_to_memory_sink_without_api_key() -> None:
     env = {
         LANGSMITH_API_KEY_ENV_KEY: "",

--- a/tests/observability/test_langsmith_export.py
+++ b/tests/observability/test_langsmith_export.py
@@ -1,0 +1,121 @@
+"""Tests for LangSmith trace export wiring."""
+
+from __future__ import annotations
+
+import warnings
+from typing import Any
+from uuid import UUID
+
+from inv_man_intake.observability.langsmith_sink import LangSmithTraceSink
+from inv_man_intake.observability.tracing import (
+    LANGCHAIN_TRACE_ENABLED_ENV_KEY,
+    LANGSMITH_API_KEY_ENV_KEY,
+    LANGSMITH_PROJECT_ENV_KEY,
+    TRACE_ENABLED_ENV_KEY,
+    InMemoryTraceSink,
+    Tracer,
+    new_trace_context,
+)
+
+
+class FakeLangSmithClient:
+    def __init__(self) -> None:
+        self.create_calls: list[dict[str, Any]] = []
+        self.update_calls: list[tuple[UUID, dict[str, Any]]] = []
+
+    def create_run(self, **kwargs: Any) -> None:
+        self.create_calls.append(kwargs)
+
+    def update_run(self, run_id: UUID, **kwargs: Any) -> None:
+        self.update_calls.append((run_id, kwargs))
+
+
+def test_langsmith_sink_emits_create_and_update_payloads() -> None:
+    client = FakeLangSmithClient()
+    sink = LangSmithTraceSink(client=client, project_name="inv-man-intake-dev")
+    tracer = Tracer(enabled=True, sink=sink)
+    context = new_trace_context(tags={"stage": "intake"})
+
+    with tracer.start_span(
+        name="extract_positions",
+        context=context,
+        metadata={"provider": "primary"},
+    ):
+        pass
+
+    assert len(client.create_calls) == 1
+    create_payload = client.create_calls[0]
+    assert create_payload["name"] == "extract_positions"
+    assert create_payload["project_name"] == "inv-man-intake-dev"
+    assert create_payload["run_type"] == "tool"
+    assert create_payload["inputs"]["trace_id"] == context.trace_id
+    assert create_payload["extra"]["metadata"] == {"provider": "primary"}
+    assert len(client.update_calls) == 1
+    update_run_id, update_payload = client.update_calls[0]
+    assert update_run_id == create_payload["id"]
+    assert update_payload["end_time"] is not None
+
+
+def test_tracer_from_env_uses_langsmith_sink_when_enabled_with_api_key(
+    monkeypatch,
+) -> None:
+    created_clients: list[FakeLangSmithClient] = []
+
+    def _client_factory() -> FakeLangSmithClient:
+        client = FakeLangSmithClient()
+        created_clients.append(client)
+        return client
+
+    monkeypatch.setattr(
+        "inv_man_intake.observability.langsmith_sink._default_client_factory",
+        _client_factory,
+    )
+    env = {
+        LANGSMITH_API_KEY_ENV_KEY: "lsv2_pt_x",
+        LANGSMITH_PROJECT_ENV_KEY: "inv-man-intake-dev",
+        LANGCHAIN_TRACE_ENABLED_ENV_KEY: "true",
+        TRACE_ENABLED_ENV_KEY: "true",
+    }
+
+    tracer = Tracer.from_env(env=env)
+    context = new_trace_context()
+    with tracer.start_span(name="probe", context=context):
+        pass
+
+    assert len(created_clients) == 1
+    assert len(created_clients[0].create_calls) == 1
+
+
+def test_tracer_from_env_does_not_construct_client_when_disabled(monkeypatch) -> None:
+    def _client_factory() -> FakeLangSmithClient:
+        raise AssertionError("LangSmith client should not be constructed")
+
+    monkeypatch.setattr(
+        "inv_man_intake.observability.langsmith_sink._default_client_factory",
+        _client_factory,
+    )
+    env = {
+        LANGSMITH_API_KEY_ENV_KEY: "lsv2_pt_x",
+        LANGSMITH_PROJECT_ENV_KEY: "inv-man-intake-dev",
+        LANGCHAIN_TRACE_ENABLED_ENV_KEY: "true",
+        TRACE_ENABLED_ENV_KEY: "false",
+    }
+
+    tracer = Tracer.from_env(env=env)
+    with tracer.start_span(name="disabled", context=new_trace_context()):
+        pass
+
+
+def test_tracer_from_env_falls_back_to_memory_sink_without_api_key() -> None:
+    env = {
+        LANGSMITH_API_KEY_ENV_KEY: "",
+        LANGCHAIN_TRACE_ENABLED_ENV_KEY: "true",
+        TRACE_ENABLED_ENV_KEY: "true",
+    }
+
+    with warnings.catch_warnings(record=True) as captured:
+        warnings.simplefilter("always")
+        tracer = Tracer.from_env(env=env)
+
+    assert isinstance(tracer._sink, InMemoryTraceSink)
+    assert any("LANGSMITH_API_KEY is empty" in str(item.message) for item in captured)

--- a/tests/observability/test_setup_validation.py
+++ b/tests/observability/test_setup_validation.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from typing import Any
+from uuid import UUID
+
 import pytest
 
 from inv_man_intake.observability.setup_validation import (
@@ -12,6 +15,20 @@ from inv_man_intake.observability.setup_validation import (
     main,
     validate_langsmith_setup,
 )
+
+
+class FakeLangSmithClient:
+    def __init__(self, record_create: bool = True) -> None:
+        self.record_create = record_create
+        self.create_calls: list[dict[str, Any]] = []
+        self.update_calls: list[tuple[UUID, dict[str, Any]]] = []
+
+    def create_run(self, **kwargs: Any) -> None:
+        if self.record_create:
+            self.create_calls.append(kwargs)
+
+    def update_run(self, run_id: UUID, **kwargs: Any) -> None:
+        self.update_calls.append((run_id, kwargs))
 
 
 def test_validate_langsmith_setup_accepts_valid_required_env() -> None:
@@ -27,6 +44,44 @@ def test_validate_langsmith_setup_accepts_valid_required_env() -> None:
     assert result.is_valid is True
     assert result.errors == ()
     assert result.warnings == ()
+
+
+def test_validate_langsmith_setup_probe_emits_mocked_span() -> None:
+    client = FakeLangSmithClient()
+    env = {
+        LANGSMITH_API_KEY_ENV_KEY: "lsv2_pt_123456",
+        LANGSMITH_PROJECT_ENV_KEY: "inv-man-intake-dev",
+        TRACE_ENABLED_ENV_KEY: "true",
+        LANGCHAIN_TRACE_ENABLED_ENV_KEY: "true",
+    }
+
+    result = validate_langsmith_setup(
+        env=env,
+        probe_emit=True,
+        client_factory=lambda: client,
+    )
+
+    assert result.is_valid is True
+    assert len(client.create_calls) == 1
+    assert client.create_calls[0]["name"] == "langsmith_setup_probe"
+
+
+def test_validate_langsmith_setup_probe_fails_when_client_records_no_run() -> None:
+    env = {
+        LANGSMITH_API_KEY_ENV_KEY: "lsv2_pt_123456",
+        LANGSMITH_PROJECT_ENV_KEY: "inv-man-intake-dev",
+        TRACE_ENABLED_ENV_KEY: "true",
+        LANGCHAIN_TRACE_ENABLED_ENV_KEY: "true",
+    }
+
+    result = validate_langsmith_setup(
+        env=env,
+        probe_emit=True,
+        client_factory=lambda: FakeLangSmithClient(record_create=False),
+    )
+
+    assert result.is_valid is False
+    assert any("probe emitted no run" in message for message in result.errors)
 
 
 def test_validate_langsmith_setup_requires_api_key() -> None:
@@ -95,6 +150,25 @@ def test_main_returns_success_for_valid_env(capsys: pytest.CaptureFixture[str]) 
     }
 
     exit_code = main(argv=[], env=env)
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert "LangSmith setup validation passed." in captured.out
+
+
+def test_main_probe_uses_mocked_client(capsys: pytest.CaptureFixture[str]) -> None:
+    env = {
+        LANGSMITH_API_KEY_ENV_KEY: "lsv2_pt_123456",
+        LANGSMITH_PROJECT_ENV_KEY: "inv-man-intake-dev",
+        TRACE_ENABLED_ENV_KEY: "true",
+        LANGCHAIN_TRACE_ENABLED_ENV_KEY: "true",
+    }
+
+    exit_code = main(
+        argv=["--probe"],
+        env=env,
+        client_factory=lambda: FakeLangSmithClient(),
+    )
     captured = capsys.readouterr()
 
     assert exit_code == 0

--- a/tests/observability/test_setup_validation.py
+++ b/tests/observability/test_setup_validation.py
@@ -173,3 +173,25 @@ def test_main_probe_uses_mocked_client(capsys: pytest.CaptureFixture[str]) -> No
 
     assert exit_code == 0
     assert "LangSmith setup validation passed." in captured.out
+
+
+def test_main_probe_returns_failure_when_no_run_recorded(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    env = {
+        LANGSMITH_API_KEY_ENV_KEY: "lsv2_pt_123456",
+        LANGSMITH_PROJECT_ENV_KEY: "inv-man-intake-dev",
+        TRACE_ENABLED_ENV_KEY: "true",
+        LANGCHAIN_TRACE_ENABLED_ENV_KEY: "true",
+    }
+
+    exit_code = main(
+        argv=["--probe"],
+        env=env,
+        client_factory=lambda: FakeLangSmithClient(record_create=False),
+    )
+    captured = capsys.readouterr()
+
+    assert exit_code == 1
+    assert "ERROR:" in captured.out
+    assert "probe emitted no run" in captured.out

--- a/tests/test_extraction_orchestrator.py
+++ b/tests/test_extraction_orchestrator.py
@@ -304,3 +304,27 @@ def test_orchestrator_emits_trace_events_for_fallback_attempt() -> None:
     ]
     assert sink.events[1].metadata["provider"] == "primary-provider"
     assert sink.events[3].metadata["provider"] == "fallback-provider"
+
+
+def test_orchestrator_defaults_to_tracer_from_env(monkeypatch) -> None:
+    tracer = Tracer(enabled=False)
+    calls = {"count": 0}
+
+    def _fake_from_env() -> Tracer:
+        calls["count"] += 1
+        return tracer
+
+    monkeypatch.setattr(
+        "inv_man_intake.extraction.orchestrator.Tracer.from_env",
+        staticmethod(_fake_from_env),
+    )
+
+    orchestrator = ExtractionOrchestrator(
+        primary_name="primary-provider",
+        primary_extractor=lambda payload: payload,
+        fallback_name="fallback-provider",
+        fallback_extractor=lambda payload: payload,
+    )
+
+    assert calls["count"] == 1
+    assert orchestrator._tracer is tracer

--- a/tests/test_v1_acceptance_smoke.py
+++ b/tests/test_v1_acceptance_smoke.py
@@ -14,6 +14,7 @@ from inv_man_intake.scoring.engine import compute_score
 from inv_man_intake.v1_smoke import (
     _assert_registered_package_state,
     _score_components,
+    run_v1_smoke_pipeline,
 )
 
 _FIXTURE_ROOT = Path("tests/fixtures/intake")
@@ -169,6 +170,20 @@ def test_v1_acceptance_smoke_fails_when_conflict_case_lacks_queue_or_audit_evide
             audit_entries=(),
             queue_item_id=None,
         )
+
+
+def test_v1_smoke_pipeline_uses_inmemory_sink_even_with_langsmith_env(monkeypatch) -> None:
+    monkeypatch.setenv("INV_MAN_TRACING_ENABLED", "true")
+    monkeypatch.setenv("LANGCHAIN_TRACING_V2", "true")
+    monkeypatch.setenv("LANGSMITH_API_KEY", "lsv2_pt_test")
+
+    artifacts = run_v1_smoke_pipeline(
+        fixture_root=_FIXTURE_ROOT,
+        package_id=_SMOKE_PACKAGE_ID,
+        expected_document_ids=_EXPECTED_DOCUMENT_IDS,
+    )
+
+    assert isinstance(artifacts.sink, InMemoryTraceSink)
 
 
 def _start_event(sink: InMemoryTraceSink, name: str):

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,5 +1,19 @@
 # Workloop State
 
+## 2026-05-09T15:43:30Z - opener lane PR #404 export toggle remediation
+
+- Source repo: `stranske/Inv-Man-Intake`.
+- Source issue: `#401`.
+- Source PR: `#404`, branch `codex/issue-401-langsmith-trace-export`.
+- Blockers addressed:
+  - Review thread on `Tracer.from_env(...)`: `LANGCHAIN_TRACING_V2=true` plus an API key no longer selects `LangSmithTraceSink` by itself; LangSmith export now also requires `INV_MAN_TRACING_ENABLED=true` or `LANGSMITH_TRACING_ENABLED=true`.
+  - CI lint-format remained covered by the exact Black command.
+- Validation passed:
+  - `uv run black --check --line-length 100 --exclude '(\.venv|\.workflows-lib|node_modules)' .`.
+  - `uv run pytest tests/observability/test_langsmith_export.py tests/observability/test_setup_validation.py tests/observability/test_tracing_toggle.py --no-cov` (33 passed).
+  - `uv run ruff check src/inv_man_intake/observability/tracing.py src/inv_man_intake/observability/setup_validation.py tests/observability/test_langsmith_export.py`.
+- Next action: push this branch update, then re-check PR `#404` for fresh CI and review-thread state.
+
 ## 2026-05-09T15:27:18Z - closer lane PR #404 lint-format remediation
 
 - Automation: `imi-merge-verify-closer` (codex closer lane).
@@ -22,7 +36,9 @@
   - `python -m pytest tests/observability/ tests/test_v1_acceptance_smoke.py --no-cov` (45 passed).
   - `python -m ruff check src/inv_man_intake/observability/setup_validation.py tests/observability/test_langsmith_export.py`.
 - Post-action state:
-  - Formatting remediation is ready to commit and push to PR `#404`.
+  - Pushed formatting remediation commit `402cf0e` to PR `#404`.
+  - Posted PR comment `https://github.com/stranske/Inv-Man-Intake/pull/404#issuecomment-4412869367` with the validation evidence.
+  - Immediate post-push check read showed fresh checks queued/pending, including `Observability Smoke`, `Python CI / Validate inputs`, `Resolve review target`, `classify changed paths`, and `guard`.
   - No terminal merge/verify event fired for PR `#404` in this round.
 - Next action: after push, re-check PR `#404`; if fresh checks are green and no unresolved review threads appear, merge it and apply `verify:compare`.
 

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,5 +1,29 @@
 # Workloop State
 
+## 2026-05-09T15:07:41Z - opener lane issue #401 PR materialization
+
+- Automation: `pd-workloop-resume` (codex opener lane).
+- Source repo: `stranske/Inv-Man-Intake`.
+- Source issue: `#401` (`Wire real LangSmith trace export so the documented runbook actually emits spans`, `priority:normal`, `repo-review-approved`).
+- Branch: `codex/issue-401-langsmith-trace-export`.
+- Selection:
+  - ACTION A succeeded from the neutral Code workspace and full fleet discovery ran across supported repos.
+  - Cap-health after infra repair reported `total_opener_owned=4`, `raw_cap_reached=false`, `normal_cap_reached=false`, and `non_drainable_cap_blocker=false`.
+  - Skipped `Workflows#2073` as an operational auth-expiry alert and `Inv-Man-Intake#381` because it was already served by merged PR `#400` and is now a verifier/closer lane.
+  - Selected `Inv-Man-Intake#401` as the next actionable issue; no existing open PR was found for this issue/title.
+- Implementation:
+  - Added `LangSmithTraceSink`, wired `Tracer.from_env(...)` to select it when tracing is enabled and `LANGSMITH_API_KEY` is present, and kept `InMemoryTraceSink` as the offline fallback with a warning.
+  - Added runtime `langsmith` dependency and re-exported LangSmith sink/constants from `inv_man_intake.observability`.
+  - Extended setup validation with `--probe` / `probe_emit=True` using an injectable mocked client for tests and a real `langsmith.Client` at runtime.
+  - Updated the LangSmith runbook and README to document real export plus the probe command.
+- Validation passed:
+  - `python -m pytest tests/observability/ tests/test_v1_acceptance_smoke.py --no-cov` (44 passed).
+  - `python -m ruff check src/inv_man_intake/observability tests/observability docs/runbooks/langsmith_tracing.md README.md pyproject.toml`.
+  - `python -m mypy src/inv_man_intake/observability`.
+  - `PYTHONPATH=src python -c 'import langsmith; import inv_man_intake.observability.langsmith_sink'`.
+  - `git diff --check`.
+- Next action: open a ready-for-review PR with `agent:codex`, `agents:keepalive`, and `autofix`; then keepalive's Codex runner takes over for CI fixups or review-comment work.
+
 ## 2026-05-09T09:28:09Z - closer lane PR #403 review-thread remediation
 
 - Automation: `imi-merge-verify-closer` (codex closer lane).

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -5,6 +5,7 @@
 - Automation: `pd-workloop-resume` (codex opener lane).
 - Source repo: `stranske/Inv-Man-Intake`.
 - Source issue: `#401` (`Wire real LangSmith trace export so the documented runbook actually emits spans`, `priority:normal`, `repo-review-approved`).
+- Source PR: `#404` (`https://github.com/stranske/Inv-Man-Intake/pull/404`), non-draft, labels `agent:codex` + `agents:keepalive` + `autofix`.
 - Branch: `codex/issue-401-langsmith-trace-export`.
 - Selection:
   - ACTION A succeeded from the neutral Code workspace and full fleet discovery ran across supported repos.
@@ -22,7 +23,8 @@
   - `python -m mypy src/inv_man_intake/observability`.
   - `PYTHONPATH=src python -c 'import langsmith; import inv_man_intake.observability.langsmith_sink'`.
   - `git diff --check`.
-- Next action: open a ready-for-review PR with `agent:codex`, `agents:keepalive`, and `autofix`; then keepalive's Codex runner takes over for CI fixups or review-comment work.
+- Relay event emitted: `pr_opened active.source_repo=stranske/Inv-Man-Intake active.source_issue=401 active.source_pr=404 active.next_action=wait_for_keepalive`.
+- Next action: keepalive's Codex runner takes over for CI fixups or review-comment work; opener is done with this lane.
 
 ## 2026-05-09T09:28:09Z - closer lane PR #403 review-thread remediation
 

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,5 +1,31 @@
 # Workloop State
 
+## 2026-05-09T15:27:18Z - closer lane PR #404 lint-format remediation
+
+- Automation: `imi-merge-verify-closer` (codex closer lane).
+- Source repo: `stranske/Inv-Man-Intake`.
+- Source issue: `#401` (`Wire real LangSmith trace export so the documented runbook actually emits spans`, `priority:normal`, `repo-review-approved`).
+- Source PR: `#404` (`https://github.com/stranske/Inv-Man-Intake/pull/404`), branch `codex/issue-401-langsmith-trace-export`.
+- Batch-safe sweep before selection:
+  - Closed `stranske/Trend_Model_Project#5238` after merged PR `#5263` had a durable Provider Comparison Report with OpenAI PASS and Anthropic PASS, and GraphQL review-thread audit showed 0 unresolved threads.
+  - Recorded `issue_closed`, recorded the batch sweep, then ran one deferred `reset-chain`.
+- Selection:
+  - Full fleet discovery ran across supported repos despite the single-slot sentinel active lane.
+  - PR `#404` was selected as the one complex lane because it was open, non-draft, issue-linked to `#401`, in-scope agent work, and CI had a concrete `Python CI / lint-format` failure.
+- Blocker found:
+  - CI job `Python CI / lint-format` on run `25604595641`, job `75164218682`, failed only because Black would reformat `src/inv_man_intake/observability/setup_validation.py`.
+- Action taken:
+  - Fast-forwarded the local PR worktree to `origin/codex/issue-401-langsmith-trace-export` at `75f4fd1`.
+  - Ran Black on `src/inv_man_intake/observability/setup_validation.py`; the only source change is the expected blank line before `SetupValidationResult`.
+- Validation passed:
+  - `python -m black --check --line-length 100 --exclude '(\.venv|\.workflows-lib|node_modules)' .` (184 files left unchanged).
+  - `python -m pytest tests/observability/ tests/test_v1_acceptance_smoke.py --no-cov` (45 passed).
+  - `python -m ruff check src/inv_man_intake/observability/setup_validation.py tests/observability/test_langsmith_export.py`.
+- Post-action state:
+  - Formatting remediation is ready to commit and push to PR `#404`.
+  - No terminal merge/verify event fired for PR `#404` in this round.
+- Next action: after push, re-check PR `#404`; if fresh checks are green and no unresolved review threads appear, merge it and apply `verify:compare`.
+
 ## 2026-05-09T15:07:41Z - opener lane issue #401 PR materialization
 
 - Automation: `pd-workloop-resume` (codex opener lane).


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:401 -->
> **Source:** Issue #401

Closes #401

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
`docs/INV_MAN_INTAKE_PLAN_V1.md:60,138` commit v1 to LangSmith tracing across ingestion/extraction/scoring, and `docs/runbooks/langsmith_tracing.md:50-66` tells operators to set `LANGSMITH_API_KEY` ("required for uploads"), `LANGSMITH_PROJECT`, and `LANGCHAIN_TRACING_V2=true` to start emitting traces. The code only validates those env vars as present strings: `src/inv_man_intake/observability/tracing.py:64-179` ships `InMemoryTraceSink` / `NoopSpan` / `Tracer` and never imports `langsmith`; `pyproject.toml:23` is `dependencies = []`; `src/inv_man_intake/v1_smoke.py:82-90` hard-codes `Tracer(enabled=True, sink=InMemoryTraceSink())`. An operator who follows the runbook today gets a green `setup_validation` exit code and zero spans in LangSmith — the runbook misrepresents what setting `LANGSMITH_API_KEY` does, and no production path ever constructs a `langsmith.Client`.

#### Tasks
- [x] Add `langsmith` to `pyproject.toml` `[project].dependencies` (currently `dependencies = []` at line 23).
- [x] Create `src/inv_man_intake/observability/langsmith_sink.py` implementing the `TraceSink` Protocol (`tracing.py:54-61`); translate `TraceEvent.kind` / `started_at` / `ended_at` / `parent_run_id` / `parent_span_id` / `metadata` into `langsmith.Client.create_run(...)` and `update_run(...)` calls.
- [x] Extend `Tracer.from_env(...)` (`tracing.py:148-157`) so that when toggles resolve enabled AND `LANGSMITH_API_KEY` is non-empty the default sink is `LangSmithTraceSink`; otherwise fall back to `InMemoryTraceSink`. Re-export the new sink from `observability/__init__.py:20-67`.
- [x] Extend `validate_langsmith_setup` (`setup_validation.py:40-91`) with a `probe_emit: bool = False` path and a `--probe` flag on `main()` (`setup_validation.py:94-119`) that opens one span and asserts the injected `Client` recorded a run.
- [x] Add `tests/observability/test_langsmith_export.py` covering: (a) toggles+API key set → mocked `Client.create_run` called with expected payload, (b) toggles disabled → `Client` never constructed, (c) toggles enabled but `LANGSMITH_API_KEY` empty → factory falls back to `InMemoryTraceSink` with a warning.
- [x] Update `docs/runbooks/langsmith_tracing.md:74-86` (Verification Checklist) to add the new `--probe` command, and update Missing Traces Troubleshooting at `:88-96` to point at the new emission test.
- [x] Update `README.md:20` Observability bullet to state LangSmith export is wired (currently "Observability helpers for tracing, logging, metrics, and setup validation" implies it is).
- [x] Re-run `python -m pytest tests/observability/ tests/test_v1_acceptance_smoke.py --no-cov` and confirm green.

#### Acceptance criteria
- [ ] `tests/observability/test_langsmith_export.py` exists, fails on `main` today, and passes after the change; with `LANGSMITH_API_KEY=lsv2_pt_x`, `LANGSMITH_PROJECT=inv-man-intake-dev`, `LANGCHAIN_TRACING_V2=true`, `INV_MAN_TRACING_ENABLED=true`, `Tracer.from_env(...)` produces a sink that calls a mocked `langsmith.Client` ≥1 time per span, and zero times when any toggle is disabled.
- [ ] `rg -n '^langsmith' pyproject.toml` matches inside `[project].dependencies`, and `python -c 'import langsmith; import inv_man_intake.observability.langsmith_sink'` exits 0 after `pip install -e ".[dev]"`.
- [ ] `python -m inv_man_intake.observability.setup_validation --require-project --probe` (with mocked client) exits 0 only when a probe span was observed, and exits 1 with a specific error referencing the probe when the client received no run.
- [ ] `python -m pytest tests/observability/ tests/test_v1_acceptance_smoke.py --no-cov` passes; `run_v1_smoke_pipeline` in `v1_smoke.py:76-225` continues to use `InMemoryTraceSink` as its offline default.
- [ ] `docs/runbooks/langsmith_tracing.md` checklist names the `--probe` command, and `README.md:20` no longer implies LangSmith export exists without qualification.

<!-- auto-status-summary:end -->