### PR TITLE
Issue #313: Add throughput readiness check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ codex-prompt.md
 codex-output.md
 verifier-context.md
 autofix_report_enriched.json
+
+# Local readiness reports
+reports/readiness/

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Inv-Man-Intake/
 ```bash
 pytest
 pytest tests/observability/test_pipeline_smoke.py --no-cov
+python -m inv_man_intake.readiness.throughput --output reports/readiness/throughput_readiness.json
 ruff check src/ tests/
 mypy
 ```

--- a/docs/INV_MAN_INTAKE_PLAN_V1.md
+++ b/docs/INV_MAN_INTAKE_PLAN_V1.md
@@ -190,3 +190,12 @@ Registry persistence is covered by:
 ```bash
 python -m pytest tests/intake/test_ingest_core_registry.py tests/intake/test_ingest_integration.py tests/data/test_repository_core.py --no-cov
 ```
+
+Same-business-day throughput readiness is covered by:
+
+```bash
+python -m inv_man_intake.readiness.throughput --output reports/readiness/throughput_readiness.json
+```
+
+The readiness report records package count, per-stage timing, score count, escalation count,
+and bottleneck warnings against the 10 to 15 packages/week and same-business-day targets.

--- a/docs/runbooks/throughput_readiness.md
+++ b/docs/runbooks/throughput_readiness.md
@@ -1,0 +1,20 @@
+# Throughput Readiness Check
+
+The same-business-day readiness check runs the deterministic v1 fixture package through the local intake-to-scoring smoke path and writes an ephemeral report:
+
+```bash
+python -m inv_man_intake.readiness.throughput --output reports/readiness/throughput_readiness.json
+```
+
+The command exits `0` only when every required stage produces measurable output and the projected same-day fixture capacity is consistent with the v1 target of 10 to 15 manager packages per week. It exits non-zero when a stage is unavailable, timing evidence is missing, scoring produces no verifiable score, or the fixture batch exceeds the same-business-day target.
+
+The report fields map to the v1 targets:
+
+- `package_count`: number of fixture manager packages processed in this readiness run.
+- `stage_timings`: elapsed milliseconds for intake, extraction plus threshold handling, performance normalization, queue/audit output, and scoring.
+- `score_count`: count of verifiable scoring outputs produced by the batch.
+- `escalation_count`: count of deterministic escalation paths exercised by the fixture batch.
+- `projected_packages_per_business_day`: same-day capacity estimate from the observed fixture runtime.
+- `bottleneck_warnings`: concrete reasons the check is not ready for live testing.
+
+The default output path is ignored by git. Treat it as an operator artifact, not source material.

--- a/src/inv_man_intake/readiness/__init__.py
+++ b/src/inv_man_intake/readiness/__init__.py
@@ -1,0 +1,1 @@
+"""Local readiness checks for v1 operational targets."""

--- a/src/inv_man_intake/readiness/throughput.py
+++ b/src/inv_man_intake/readiness/throughput.py
@@ -193,15 +193,16 @@ def _report_payload(report: ReadinessReport) -> dict[str, Any]:
 def _duration_for_events(trace_events: list[TraceEvent], names: tuple[str, ...]) -> float:
     durations = []
     for name in names:
-        duration = _first_completed_duration_ms(trace_events, name)
+        duration = _total_completed_duration_ms(trace_events, name)
         if duration <= 0:
             return 0.0
         durations.append(duration)
     return round(sum(durations), 3)
 
 
-def _first_completed_duration_ms(trace_events: list[TraceEvent], name: str) -> float:
+def _total_completed_duration_ms(trace_events: list[TraceEvent], name: str) -> float:
     starts_by_span_id: dict[str, list[TraceEvent]] = {}
+    total_duration = 0.0
     for event in trace_events:
         if event.name != name:
             continue
@@ -216,8 +217,8 @@ def _first_completed_duration_ms(trace_events: list[TraceEvent], name: str) -> f
         ended_at = datetime.fromisoformat(event.ended_at)
         duration = (ended_at - started_at).total_seconds() * 1000
         if duration > 0:
-            return duration
-    return 0.0
+            total_duration += duration
+    return round(total_duration, 3)
 
 
 def _escalation_count(

--- a/src/inv_man_intake/readiness/throughput.py
+++ b/src/inv_man_intake/readiness/throughput.py
@@ -13,12 +13,26 @@ from inv_man_intake.observability import TraceEvent
 from inv_man_intake.v1_smoke import run_v1_smoke_pipeline
 
 DEFAULT_FIXTURE_ROOT = Path("tests/fixtures/intake")
-DEFAULT_PACKAGE_ID = "pkg_pdf_mixed_001"
-DEFAULT_DOCUMENT_IDS = (
-    "pkg_pdf_mixed_001:doc:0",
-    "pkg_pdf_mixed_001:doc:1",
-    "pkg_pdf_mixed_001:doc:2",
-    "pkg_pdf_mixed_001:doc:3",
+DEFAULT_BATCH_PACKAGES = (
+    {
+        "intake_bundle_file": "pdf_primary_mixed_bundle.json",
+        "package_id": "pkg_pdf_mixed_001",
+        "expected_document_ids": (
+            "pkg_pdf_mixed_001:doc:0",
+            "pkg_pdf_mixed_001:doc:1",
+            "pkg_pdf_mixed_001:doc:2",
+            "pkg_pdf_mixed_001:doc:3",
+        ),
+    },
+    {
+        "intake_bundle_file": "pptx_primary_mixed_bundle.json",
+        "package_id": "pkg_pptx_mixed_001",
+        "expected_document_ids": (
+            "pkg_pptx_mixed_001:doc:0",
+            "pkg_pptx_mixed_001:doc:1",
+            "pkg_pptx_mixed_001:doc:2",
+        ),
+    },
 )
 DEFAULT_OUTPUT_PATH = Path("reports/readiness/throughput_readiness.json")
 MIN_PACKAGES_PER_WEEK = 10
@@ -70,26 +84,42 @@ class ReadinessReport:
 def run_readiness_check(output_path: Path = DEFAULT_OUTPUT_PATH) -> ReadinessReport:
     """Run the offline v1 fixture batch and write an ephemeral readiness report."""
 
-    artifacts = run_v1_smoke_pipeline(
-        fixture_root=DEFAULT_FIXTURE_ROOT,
-        package_id=DEFAULT_PACKAGE_ID,
-        expected_document_ids=DEFAULT_DOCUMENT_IDS,
-    )
-    record = cast(Any, artifacts.record)
-    score = cast(Any, artifacts.score)
-    threshold_decision = cast(Any, artifacts.threshold_decision)
-    conflict_result = cast(Any, artifacts.conflict_result)
-    secondary_extraction_result = cast(Any, artifacts.secondary_extraction_result)
-    report = build_readiness_report(
-        trace_events=artifacts.sink.events,
-        document_count=len(record.document_ids),
-        score_count=1 if score.final_score is not None else 0,
-        escalation_count=_escalation_count(
+    artifacts_batch = [
+        run_v1_smoke_pipeline(
+            fixture_root=DEFAULT_FIXTURE_ROOT,
+            intake_bundle_file=cast(str, package["intake_bundle_file"]),
+            package_id=cast(str, package["package_id"]),
+            expected_document_ids=cast(tuple[str, ...], package["expected_document_ids"]),
+        )
+        for package in DEFAULT_BATCH_PACKAGES
+    ]
+
+    trace_events: list[TraceEvent] = []
+    document_count = 0
+    score_count = 0
+    escalation_count = 0
+    for artifacts in artifacts_batch:
+        record = cast(Any, artifacts.record)
+        score = cast(Any, artifacts.score)
+        threshold_decision = cast(Any, artifacts.threshold_decision)
+        conflict_result = cast(Any, artifacts.conflict_result)
+        secondary_extraction_result = cast(Any, artifacts.secondary_extraction_result)
+        trace_events.extend(artifacts.sink.events)
+        document_count += len(record.document_ids)
+        score_count += 1 if score.final_score is not None else 0
+        escalation_count += _escalation_count(
             extraction_escalates=threshold_decision.escalate,
             conflict_escalates=conflict_result.escalate,
             secondary_escalates=not secondary_extraction_result.resolved,
-        ),
+        )
+
+    report = build_readiness_report(
+        trace_events=trace_events,
+        document_count=document_count,
+        score_count=score_count,
+        escalation_count=escalation_count,
         output_path=output_path,
+        package_count=len(DEFAULT_BATCH_PACKAGES),
     )
     output_path.parent.mkdir(parents=True, exist_ok=True)
     output_path.write_text(json.dumps(_report_payload(report), indent=2) + "\n", encoding="utf-8")
@@ -103,6 +133,7 @@ def build_readiness_report(
     score_count: int,
     escalation_count: int,
     output_path: Path,
+    package_count: int = 1,
 ) -> ReadinessReport:
     """Build a readiness report from v1 smoke trace events."""
 
@@ -125,7 +156,7 @@ def build_readiness_report(
     status = "pass" if not bottleneck_warnings else "fail"
     return ReadinessReport(
         status=status,
-        package_count=1,
+        package_count=package_count,
         document_count=document_count,
         score_count=score_count,
         escalation_count=escalation_count,

--- a/src/inv_man_intake/readiness/throughput.py
+++ b/src/inv_man_intake/readiness/throughput.py
@@ -1,0 +1,221 @@
+"""Same-business-day throughput readiness check for the v1 smoke pipeline."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import asdict, dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any, cast
+
+from inv_man_intake.observability import TraceEvent
+from inv_man_intake.v1_smoke import run_v1_smoke_pipeline
+
+DEFAULT_FIXTURE_ROOT = Path("tests/fixtures/intake")
+DEFAULT_PACKAGE_ID = "pkg_pdf_mixed_001"
+DEFAULT_DOCUMENT_IDS = (
+    "pkg_pdf_mixed_001:doc:0",
+    "pkg_pdf_mixed_001:doc:1",
+    "pkg_pdf_mixed_001:doc:2",
+    "pkg_pdf_mixed_001:doc:3",
+)
+DEFAULT_OUTPUT_PATH = Path("reports/readiness/throughput_readiness.json")
+MIN_PACKAGES_PER_WEEK = 10
+TARGET_PACKAGES_PER_WEEK = 15
+SAME_BUSINESS_DAY_SECONDS = 8 * 60 * 60
+STAGE_EVENT_NAMES = {
+    "intake": ("v1_acceptance.intake_register",),
+    "extraction_thresholds": (
+        "extraction_orchestrator.run",
+        "v1_acceptance.threshold_handling",
+    ),
+    "performance_normalization": ("v1_acceptance.performance_normalize",),
+    "queue_audit_output": ("v1_acceptance.queue_audit_output",),
+    "scoring": ("v1_acceptance.scoring_compute",),
+}
+
+
+@dataclass(frozen=True)
+class StageTiming:
+    """Elapsed wall time for one readiness stage."""
+
+    stage: str
+    duration_ms: float
+
+
+@dataclass(frozen=True)
+class ReadinessReport:
+    """Machine-readable throughput readiness result."""
+
+    status: str
+    package_count: int
+    document_count: int
+    score_count: int
+    escalation_count: int
+    target_packages_per_week: str
+    same_business_day_target_seconds: int
+    observed_total_seconds: float
+    projected_packages_per_business_day: float
+    stage_timings: list[StageTiming]
+    bottleneck_warnings: list[str]
+    report_path: str
+
+    @property
+    def passed(self) -> bool:
+        return self.status == "pass"
+
+
+def run_readiness_check(output_path: Path = DEFAULT_OUTPUT_PATH) -> ReadinessReport:
+    """Run the offline v1 fixture batch and write an ephemeral readiness report."""
+
+    artifacts = run_v1_smoke_pipeline(
+        fixture_root=DEFAULT_FIXTURE_ROOT,
+        package_id=DEFAULT_PACKAGE_ID,
+        expected_document_ids=DEFAULT_DOCUMENT_IDS,
+    )
+    record = cast(Any, artifacts.record)
+    score = cast(Any, artifacts.score)
+    threshold_decision = cast(Any, artifacts.threshold_decision)
+    conflict_result = cast(Any, artifacts.conflict_result)
+    secondary_extraction_result = cast(Any, artifacts.secondary_extraction_result)
+    report = build_readiness_report(
+        trace_events=artifacts.sink.events,
+        document_count=len(record.document_ids),
+        score_count=1 if score.final_score is not None else 0,
+        escalation_count=_escalation_count(
+            extraction_escalates=threshold_decision.escalate,
+            conflict_escalates=conflict_result.escalate,
+            secondary_escalates=not secondary_extraction_result.resolved,
+        ),
+        output_path=output_path,
+    )
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(_report_payload(report), indent=2) + "\n", encoding="utf-8")
+    return report
+
+
+def build_readiness_report(
+    *,
+    trace_events: list[TraceEvent],
+    document_count: int,
+    score_count: int,
+    escalation_count: int,
+    output_path: Path,
+) -> ReadinessReport:
+    """Build a readiness report from v1 smoke trace events."""
+
+    stage_timings = [
+        StageTiming(stage=stage, duration_ms=_duration_for_events(trace_events, names))
+        for stage, names in STAGE_EVENT_NAMES.items()
+    ]
+    missing_stages = [timing.stage for timing in stage_timings if timing.duration_ms <= 0]
+    observed_total_seconds = round(
+        sum(timing.duration_ms for timing in stage_timings) / 1000,
+        6,
+    )
+    projected_packages_per_business_day = _project_packages_per_business_day(observed_total_seconds)
+    bottleneck_warnings = _bottleneck_warnings(
+        missing_stages=missing_stages,
+        score_count=score_count,
+        observed_total_seconds=observed_total_seconds,
+        projected_packages_per_business_day=projected_packages_per_business_day,
+    )
+    status = "pass" if not bottleneck_warnings else "fail"
+    return ReadinessReport(
+        status=status,
+        package_count=1,
+        document_count=document_count,
+        score_count=score_count,
+        escalation_count=escalation_count,
+        target_packages_per_week=f"{MIN_PACKAGES_PER_WEEK}-{TARGET_PACKAGES_PER_WEEK}",
+        same_business_day_target_seconds=SAME_BUSINESS_DAY_SECONDS,
+        observed_total_seconds=observed_total_seconds,
+        projected_packages_per_business_day=projected_packages_per_business_day,
+        stage_timings=stage_timings,
+        bottleneck_warnings=bottleneck_warnings,
+        report_path=str(output_path),
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=DEFAULT_OUTPUT_PATH,
+        help=f"Ephemeral report path. Default: {DEFAULT_OUTPUT_PATH}",
+    )
+    args = parser.parse_args(argv)
+    report = run_readiness_check(output_path=args.output)
+    print(json.dumps(_report_payload(report), indent=2))
+    return 0 if report.passed else 1
+
+
+def _report_payload(report: ReadinessReport) -> dict[str, Any]:
+    payload = asdict(report)
+    payload["stage_timings"] = [asdict(timing) for timing in report.stage_timings]
+    return payload
+
+
+def _duration_for_events(trace_events: list[TraceEvent], names: tuple[str, ...]) -> float:
+    durations = []
+    for name in names:
+        start = next(
+            (event for event in trace_events if event.name == name and event.ended_at is None),
+            None,
+        )
+        end = next(
+            (event for event in trace_events if event.name == name and event.ended_at is not None),
+            None,
+        )
+        if start is None or end is None:
+            return 0.0
+        started_at = datetime.fromisoformat(start.started_at)
+        ended_at = datetime.fromisoformat(end.ended_at or "")
+        durations.append((ended_at - started_at).total_seconds() * 1000)
+    return round(sum(durations), 3)
+
+
+def _escalation_count(
+    *,
+    extraction_escalates: bool,
+    conflict_escalates: bool,
+    secondary_escalates: bool,
+) -> int:
+    return sum(
+        1
+        for escalates in (extraction_escalates, conflict_escalates, secondary_escalates)
+        if escalates
+    )
+
+
+def _project_packages_per_business_day(observed_total_seconds: float) -> float:
+    if observed_total_seconds <= 0:
+        return 0.0
+    return round(SAME_BUSINESS_DAY_SECONDS / observed_total_seconds, 2)
+
+
+def _bottleneck_warnings(
+    *,
+    missing_stages: list[str],
+    score_count: int,
+    observed_total_seconds: float,
+    projected_packages_per_business_day: float,
+) -> list[str]:
+    warnings = []
+    if missing_stages:
+        warnings.append(f"missing timing evidence for stages: {', '.join(missing_stages)}")
+    if score_count < 1:
+        warnings.append("scoring stage produced no verifiable scores")
+    if observed_total_seconds <= 0:
+        warnings.append("readiness run produced no measurable elapsed time")
+    if observed_total_seconds > SAME_BUSINESS_DAY_SECONDS:
+        warnings.append("fixture batch exceeds same-business-day target")
+    if projected_packages_per_business_day < MIN_PACKAGES_PER_WEEK:
+        warnings.append("projected same-day capacity is below 10 packages/week target")
+    return warnings
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/inv_man_intake/readiness/throughput.py
+++ b/src/inv_man_intake/readiness/throughput.py
@@ -23,6 +23,7 @@ DEFAULT_DOCUMENT_IDS = (
 DEFAULT_OUTPUT_PATH = Path("reports/readiness/throughput_readiness.json")
 MIN_PACKAGES_PER_WEEK = 10
 TARGET_PACKAGES_PER_WEEK = 15
+BUSINESS_DAYS_PER_WEEK = 5
 SAME_BUSINESS_DAY_SECONDS = 8 * 60 * 60
 STAGE_EVENT_NAMES = {
     "intake": ("v1_acceptance.intake_register",),
@@ -161,20 +162,31 @@ def _report_payload(report: ReadinessReport) -> dict[str, Any]:
 def _duration_for_events(trace_events: list[TraceEvent], names: tuple[str, ...]) -> float:
     durations = []
     for name in names:
-        start = next(
-            (event for event in trace_events if event.name == name and event.ended_at is None),
-            None,
-        )
-        end = next(
-            (event for event in trace_events if event.name == name and event.ended_at is not None),
-            None,
-        )
-        if start is None or end is None:
+        duration = _first_completed_duration_ms(trace_events, name)
+        if duration <= 0:
             return 0.0
-        started_at = datetime.fromisoformat(start.started_at)
-        ended_at = datetime.fromisoformat(end.ended_at or "")
-        durations.append((ended_at - started_at).total_seconds() * 1000)
+        durations.append(duration)
     return round(sum(durations), 3)
+
+
+def _first_completed_duration_ms(trace_events: list[TraceEvent], name: str) -> float:
+    starts_by_span_id: dict[str, list[TraceEvent]] = {}
+    for event in trace_events:
+        if event.name != name:
+            continue
+        if event.ended_at is None:
+            starts_by_span_id.setdefault(event.span_id, []).append(event)
+            continue
+        starts = starts_by_span_id.get(event.span_id)
+        if not starts:
+            continue
+        start = starts.pop(0)
+        started_at = datetime.fromisoformat(start.started_at)
+        ended_at = datetime.fromisoformat(event.ended_at)
+        duration = (ended_at - started_at).total_seconds() * 1000
+        if duration > 0:
+            return duration
+    return 0.0
 
 
 def _escalation_count(
@@ -212,8 +224,9 @@ def _bottleneck_warnings(
         warnings.append("readiness run produced no measurable elapsed time")
     if observed_total_seconds > SAME_BUSINESS_DAY_SECONDS:
         warnings.append("fixture batch exceeds same-business-day target")
-    if projected_packages_per_business_day < MIN_PACKAGES_PER_WEEK:
-        warnings.append("projected same-day capacity is below 10 packages/week target")
+    projected_packages_per_week = projected_packages_per_business_day * BUSINESS_DAYS_PER_WEEK
+    if projected_packages_per_week < MIN_PACKAGES_PER_WEEK:
+        warnings.append("projected weekly capacity is below 10 packages/week target")
     return warnings
 
 

--- a/src/inv_man_intake/v1_smoke.py
+++ b/src/inv_man_intake/v1_smoke.py
@@ -126,28 +126,33 @@ def run_v1_smoke_pipeline(
         source_doc_id=record.document_ids[1],
         content=_fixture_bytes(fixture_root=fixture_root, file_name="summit_arc_track_record.xlsx"),
     )
-    threshold_config = ThresholdConfig(
-        field_auto_accept_min=0.85,
-        key_field_confidence_min=0.75,
-        document_key_field_coverage_min=0.80,
-        mandatory_field_min=0.60,
-        mandatory_fields=("operations.aum",),
-    )
-    threshold_decision = evaluate_thresholds(
-        result=extraction_result,
-        key_fields=(
-            "strategy.asset_class",
-            "terms.management_fee",
-            "performance.net_return_1y",
-            "operations.aum",
-            "team.key_person_risk",
-        ),
-        config=threshold_config,
-    )
-    extraction_with_thresholds = attach_threshold_summary(
-        result=extraction_result,
-        decision=threshold_decision,
-    )
+    with tracer.start_span(
+        name="v1_acceptance.threshold_handling",
+        context=extraction_context,
+        metadata={"package_id": record.package_id},
+    ):
+        threshold_config = ThresholdConfig(
+            field_auto_accept_min=0.85,
+            key_field_confidence_min=0.75,
+            document_key_field_coverage_min=0.80,
+            mandatory_field_min=0.60,
+            mandatory_fields=("operations.aum",),
+        )
+        threshold_decision = evaluate_thresholds(
+            result=extraction_result,
+            key_fields=(
+                "strategy.asset_class",
+                "terms.management_fee",
+                "performance.net_return_1y",
+                "operations.aum",
+                "team.key_person_risk",
+            ),
+            config=threshold_config,
+        )
+        extraction_with_thresholds = attach_threshold_summary(
+            result=extraction_result,
+            decision=threshold_decision,
+        )
 
     extraction_start = _start_event(sink, "extraction_orchestrator.run")
     performance_context = child_trace_context(
@@ -171,13 +176,23 @@ def run_v1_smoke_pipeline(
             benchmark_monthly=benchmark_series,
         )
 
-    queue_assignment = create_analyst_first_assignment(
-        item_id=f"{record.package_id}:validation:performance_conflict",
-        analyst_id="analyst_001",
-        created_at=datetime(2026, 3, 4, 10, 0, tzinfo=UTC),
-    )
-
     performance_start = _start_event(sink, "v1_acceptance.performance_normalize")
+    queue_context = child_trace_context(
+        performance_context,
+        parent_span_id=performance_start.span_id,
+        tags={"stage": "queue"},
+    )
+    with tracer.start_span(
+        name="v1_acceptance.queue_audit_output",
+        context=queue_context,
+        metadata={"package_id": record.package_id},
+    ):
+        queue_assignment = create_analyst_first_assignment(
+            item_id=f"{record.package_id}:validation:performance_conflict",
+            analyst_id="analyst_001",
+            created_at=datetime(2026, 3, 4, 10, 0, tzinfo=UTC),
+        )
+
     scoring_context = child_trace_context(
         performance_context,
         parent_span_id=performance_start.span_id,

--- a/src/inv_man_intake/v1_smoke.py
+++ b/src/inv_man_intake/v1_smoke.py
@@ -76,6 +76,7 @@ class V1SmokeArtifacts:
 def run_v1_smoke_pipeline(
     *,
     fixture_root: Path,
+    intake_bundle_file: str = "pdf_primary_mixed_bundle.json",
     package_id: str,
     expected_document_ids: tuple[str, ...],
 ) -> V1SmokeArtifacts:
@@ -89,10 +90,10 @@ def run_v1_smoke_pipeline(
     with tracer.start_span(
         name="v1_acceptance.intake_register",
         context=trace_context,
-        metadata={"fixture": "pdf_primary_mixed_bundle.json"},
+        metadata={"fixture": intake_bundle_file},
     ):
         registration = register_intake_bundle_file(
-            fixture_root / "pdf_primary_mixed_bundle.json",
+            fixture_root / intake_bundle_file,
             service,
             core_repository=core_repository,
             document_store=document_store,

--- a/tests/readiness/test_throughput_readiness.py
+++ b/tests/readiness/test_throughput_readiness.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from inv_man_intake.readiness.throughput import (
+    STAGE_EVENT_NAMES,
+    build_readiness_report,
+    main,
+    run_readiness_check,
+)
+
+
+def test_throughput_readiness_writes_report_with_required_fields(tmp_path: Path) -> None:
+    output_path = tmp_path / "throughput_readiness.json"
+
+    report = run_readiness_check(output_path=output_path)
+
+    payload = json.loads(output_path.read_text(encoding="utf-8"))
+    assert report.passed is True
+    assert payload["status"] == "pass"
+    assert payload["package_count"] == 1
+    assert payload["document_count"] == 4
+    assert payload["score_count"] == 1
+    assert payload["escalation_count"] == 3
+    assert {item["stage"] for item in payload["stage_timings"]} == set(STAGE_EVENT_NAMES)
+    assert all(item["duration_ms"] > 0 for item in payload["stage_timings"])
+    assert payload["target_packages_per_week"] == "10-15"
+    assert payload["same_business_day_target_seconds"] == 28800
+    assert payload["projected_packages_per_business_day"] >= 10
+
+
+def test_throughput_readiness_fails_when_stage_output_is_missing(tmp_path: Path) -> None:
+    report = build_readiness_report(
+        trace_events=[],
+        document_count=0,
+        score_count=0,
+        escalation_count=0,
+        output_path=tmp_path / "missing.json",
+    )
+
+    assert report.status == "fail"
+    assert "scoring stage produced no verifiable scores" in report.bottleneck_warnings
+    assert any("missing timing evidence" in warning for warning in report.bottleneck_warnings)
+
+
+def test_throughput_readiness_cli_returns_success(tmp_path: Path, capsys) -> None:
+    output_path = tmp_path / "cli_readiness.json"
+
+    exit_code = main(["--output", str(output_path)])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert output_path.exists()
+    assert '"status": "pass"' in captured.out

--- a/tests/readiness/test_throughput_readiness.py
+++ b/tests/readiness/test_throughput_readiness.py
@@ -22,10 +22,10 @@ def test_throughput_readiness_writes_report_with_required_fields(tmp_path: Path)
     payload = json.loads(output_path.read_text(encoding="utf-8"))
     assert report.passed is True
     assert payload["status"] == "pass"
-    assert payload["package_count"] == 1
-    assert payload["document_count"] == 4
-    assert payload["score_count"] == 1
-    assert payload["escalation_count"] == 3
+    assert payload["package_count"] == 2
+    assert payload["document_count"] == 7
+    assert payload["score_count"] == 2
+    assert payload["escalation_count"] == 6
     assert {item["stage"] for item in payload["stage_timings"]} == set(STAGE_EVENT_NAMES)
     assert all(item["duration_ms"] > 0 for item in payload["stage_timings"])
     assert payload["target_packages_per_week"] == "10-15"
@@ -51,8 +51,12 @@ def test_duration_for_events_pairs_repeated_span_names_by_span_id() -> None:
     events = [
         _trace_event("shared-stage", "span-a", "2026-05-10T00:00:00+00:00"),
         _trace_event("shared-stage", "span-b", "2026-05-10T00:00:10+00:00"),
-        _trace_event("shared-stage", "span-b", "2026-05-10T00:00:10+00:00", "2026-05-10T00:00:11+00:00"),
-        _trace_event("shared-stage", "span-a", "2026-05-10T00:00:00+00:00", "2026-05-10T00:00:30+00:00"),
+        _trace_event(
+            "shared-stage", "span-b", "2026-05-10T00:00:10+00:00", "2026-05-10T00:00:11+00:00"
+        ),
+        _trace_event(
+            "shared-stage", "span-a", "2026-05-10T00:00:00+00:00", "2026-05-10T00:00:30+00:00"
+        ),
     ]
 
     assert _duration_for_events(events, ("shared-stage",)) == 1000.0

--- a/tests/readiness/test_throughput_readiness.py
+++ b/tests/readiness/test_throughput_readiness.py
@@ -3,8 +3,11 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from inv_man_intake.observability import TraceEvent
 from inv_man_intake.readiness.throughput import (
     STAGE_EVENT_NAMES,
+    _bottleneck_warnings,
+    _duration_for_events,
     build_readiness_report,
     main,
     run_readiness_check,
@@ -44,6 +47,28 @@ def test_throughput_readiness_fails_when_stage_output_is_missing(tmp_path: Path)
     assert any("missing timing evidence" in warning for warning in report.bottleneck_warnings)
 
 
+def test_duration_for_events_pairs_repeated_span_names_by_span_id() -> None:
+    events = [
+        _trace_event("shared-stage", "span-a", "2026-05-10T00:00:00+00:00"),
+        _trace_event("shared-stage", "span-b", "2026-05-10T00:00:10+00:00"),
+        _trace_event("shared-stage", "span-b", "2026-05-10T00:00:10+00:00", "2026-05-10T00:00:11+00:00"),
+        _trace_event("shared-stage", "span-a", "2026-05-10T00:00:00+00:00", "2026-05-10T00:00:30+00:00"),
+    ]
+
+    assert _duration_for_events(events, ("shared-stage",)) == 1000.0
+
+
+def test_bottleneck_warning_projects_business_day_capacity_to_weekly_target() -> None:
+    warnings = _bottleneck_warnings(
+        missing_stages=[],
+        score_count=1,
+        observed_total_seconds=1,
+        projected_packages_per_business_day=2,
+    )
+
+    assert "projected weekly capacity is below 10 packages/week target" not in warnings
+
+
 def test_throughput_readiness_cli_returns_success(tmp_path: Path, capsys) -> None:
     output_path = tmp_path / "cli_readiness.json"
 
@@ -53,3 +78,23 @@ def test_throughput_readiness_cli_returns_success(tmp_path: Path, capsys) -> Non
     assert exit_code == 0
     assert output_path.exists()
     assert '"status": "pass"' in captured.out
+
+
+def _trace_event(
+    name: str,
+    span_id: str,
+    started_at: str,
+    ended_at: str | None = None,
+) -> TraceEvent:
+    return TraceEvent(
+        kind="span",
+        span_id=span_id,
+        trace_id="trace-1",
+        run_id=None,
+        name=name,
+        parent_run_id=None,
+        parent_span_id=None,
+        metadata={},
+        started_at=started_at,
+        ended_at=ended_at,
+    )

--- a/tests/readiness/test_throughput_readiness.py
+++ b/tests/readiness/test_throughput_readiness.py
@@ -47,7 +47,7 @@ def test_throughput_readiness_fails_when_stage_output_is_missing(tmp_path: Path)
     assert any("missing timing evidence" in warning for warning in report.bottleneck_warnings)
 
 
-def test_duration_for_events_pairs_repeated_span_names_by_span_id() -> None:
+def test_duration_for_events_sums_completed_spans_by_name() -> None:
     events = [
         _trace_event("shared-stage", "span-a", "2026-05-10T00:00:00+00:00"),
         _trace_event("shared-stage", "span-b", "2026-05-10T00:00:10+00:00"),
@@ -59,7 +59,7 @@ def test_duration_for_events_pairs_repeated_span_names_by_span_id() -> None:
         ),
     ]
 
-    assert _duration_for_events(events, ("shared-stage",)) == 1000.0
+    assert _duration_for_events(events, ("shared-stage",)) == 31000.0
 
 
 def test_bottleneck_warning_projects_business_day_capacity_to_weekly_target() -> None:

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,5 +1,29 @@
 # Workloop State
 
+## 2026-05-10T04:20:00Z - opener lane issue #313 PR materialization
+
+- Automation: `pd-workloop-resume` (codex opener lane).
+- Source repo: `stranske/Inv-Man-Intake`.
+- Source issue: `#313` (`Add same-business-day throughput readiness check`, `priority:low`, `repo-review-approved`).
+- Branch: `codex/issue-313-throughput-readiness`.
+- Selection:
+  - ACTION A succeeded from the neutral Code workspace and full fleet discovery ran across supported repos using `priority:high`, `priority:normal`, and `priority:low`.
+  - Cap-health after infra repair reported `total_opener_owned=3`, `raw_cap_reached=false`, `normal_cap_reached=false`, and `non_drainable_cap_blocker=false`.
+  - Skipped `Workflows#2073` as an operational auth-expiry alert, `Inv-Man-Intake#381/#382`, `Manager-Database#910`, `Trend_Model_Project#5168/#5169/#5170/#5172`, `Counter_Risk#476`, and `Pension-Data#320/#321` because they are already linked to existing PRs or verifier/closer disposition.
+  - Selected `Inv-Man-Intake#313` as the oldest remaining eligible low-priority implementation issue with no linked PR.
+- Implementation:
+  - Added `inv_man_intake.readiness.throughput`, a local deterministic CLI that runs the offline v1 fixture batch and writes `reports/readiness/throughput_readiness.json`.
+  - Added threshold-handling and queue/audit timing spans to the v1 smoke pipeline while preserving the existing scoring parent-span contract.
+  - Added readiness tests for successful report generation, failure on missing stage/scoring evidence, and CLI exit behavior.
+  - Documented the command in the v1 plan, README, and `docs/runbooks/throughput_readiness.md`; ignored the generated readiness report path.
+- Validation passed:
+  - `UV_CACHE_DIR=/private/tmp/uv-cache-inv-313 uv run --extra dev python -m inv_man_intake.readiness.throughput --output reports/readiness/throughput_readiness.json`.
+  - `UV_CACHE_DIR=/private/tmp/uv-cache-inv-313 uv run --extra dev python -m pytest tests/readiness/test_throughput_readiness.py tests/test_v1_acceptance_smoke.py --no-cov` (9 passed).
+  - `UV_CACHE_DIR=/private/tmp/uv-cache-inv-313 uv run --extra dev ruff check src/inv_man_intake/readiness src/inv_man_intake/v1_smoke.py tests/readiness/test_throughput_readiness.py`.
+  - `UV_CACHE_DIR=/private/tmp/uv-cache-inv-313 uv run --extra dev black --check src/inv_man_intake/readiness src/inv_man_intake/v1_smoke.py tests/readiness/test_throughput_readiness.py`.
+  - `UV_CACHE_DIR=/private/tmp/uv-cache-inv-313 uv run --extra dev mypy src/inv_man_intake/readiness src/inv_man_intake/v1_smoke.py`.
+- Next action: commit, push, open a ready-for-review PR with `agent:codex`, `agents:keepalive`, and `autofix`.
+
 ## 2026-05-09T15:43:30Z - opener lane PR #404 export toggle remediation
 
 - Source repo: `stranske/Inv-Man-Intake`.

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -5,6 +5,7 @@
 - Automation: `pd-workloop-resume` (codex opener lane).
 - Source repo: `stranske/Inv-Man-Intake`.
 - Source issue: `#313` (`Add same-business-day throughput readiness check`, `priority:low`, `repo-review-approved`).
+- Source PR: `#406` (`https://github.com/stranske/Inv-Man-Intake/pull/406`), non-draft, labels `agent:codex` + `agents:keepalive` + `autofix`; `agent:retry` added by infra repair after initial dispatch evidence was missing.
 - Branch: `codex/issue-313-throughput-readiness`.
 - Selection:
   - ACTION A succeeded from the neutral Code workspace and full fleet discovery ran across supported repos using `priority:high`, `priority:normal`, and `priority:low`.
@@ -22,7 +23,9 @@
   - `UV_CACHE_DIR=/private/tmp/uv-cache-inv-313 uv run --extra dev ruff check src/inv_man_intake/readiness src/inv_man_intake/v1_smoke.py tests/readiness/test_throughput_readiness.py`.
   - `UV_CACHE_DIR=/private/tmp/uv-cache-inv-313 uv run --extra dev black --check src/inv_man_intake/readiness src/inv_man_intake/v1_smoke.py tests/readiness/test_throughput_readiness.py`.
   - `UV_CACHE_DIR=/private/tmp/uv-cache-inv-313 uv run --extra dev mypy src/inv_man_intake/readiness src/inv_man_intake/v1_smoke.py`.
-- Next action: commit, push, open a ready-for-review PR with `agent:codex`, `agents:keepalive`, and `autofix`.
+- Relay event emitted: `pr_opened active.source_repo=stranske/Inv-Man-Intake active.source_issue=313 active.source_pr=406 active.next_action=wait_for_keepalive`.
+- Post-open cap-health: infra repair added `agent:retry` and dispatched Gate Followups; fresh cap-health at `2026-05-10T04:11:10Z` reported `#406` as `draining` with an active Gate run, `total_opener_owned=4`, `raw_cap_reached=false`, `normal_cap_reached=false`, and `non_drainable_cap_blocker=false`.
+- Next action: keepalive's Codex runner takes over for CI fixups or review-comment work; opener is done with this lane.
 
 ## 2026-05-09T15:43:30Z - opener lane PR #404 export toggle remediation
 


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:313 -->
> **Source:** Issue #313

Closes #313

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The v1 plan sets two operational targets: same-business-day intake-to-scored-output service and an initial throughput of 10 to 15 manager packages per week. The repo has functional tests, but it does not yet provide an operator-facing readiness check that estimates whether the local pipeline can meet those service targets or where the expected bottlenecks are.

#### Tasks
- [x] Add a local readiness script or pytest-marked smoke that processes a small batch of fixture packages through the available pipeline stages.
- [x] Capture per-stage timing for intake, extraction/threshold handling, performance normalization, scoring, and queue/audit output.
- [x] Report whether the fixture batch is consistent with the 10 to 15 packages/week and same-business-day design targets.
- [x] Add runbook documentation explaining how to run the check, how to interpret the output, and what would block live testing.
- [x] Keep the readiness output ephemeral and out of version control.

#### Acceptance criteria
- [x] A single documented command runs the readiness check locally.
- [x] The output includes package count, stage timing, score count, escalation count, and pass/fail readiness status.
- [x] The command exits non-zero when a required stage is unavailable or produces no verifiable output.
- [x] The runbook connects each readiness field to the v1 design targets.
- [x] The generated readiness report is ignored or written under an ignored reports path.

<!-- auto-status-summary:end -->