### PR TITLE
Issue #26: add visual artifact feedback service

### DIFF
--- a/docs/runbooks/visual_artifact_extraction.md
+++ b/docs/runbooks/visual_artifact_extraction.md
@@ -38,6 +38,30 @@ override path.
 - `byte_size`
 - `extracted_at`
 
+`VisualArtifactRepository.ensure_feedback_schema()` also creates
+`visual_artifact_feedback` for human quality review. Feedback is keyed by
+`artifact_id` + `reviewer`, so a reviewer can update the same artifact without
+duplicating rows. Each record stores:
+- `artifact_id`
+- `is_informative`
+- `quality_rank`
+- `reviewer`
+- `reviewed_at`
+- `notes`
+
+## Feedback Governance
+
+Use `ImageFeedbackRecord` and `VisualArtifactFeedbackService` to capture analyst
+review. `quality_rank` is an integer scale from 1 to 5:
+- `1`: unusable or misleading visual
+- `2`: low usefulness; mostly decorative or too unclear
+- `3`: usable context but not decision-grade
+- `4`: useful evidence with minor limitations
+- `5`: high-value visual evidence for review or tuning
+
+Repeated reviews from the same reviewer update the prior record. Preserve notes
+when they explain disagreements between the classifier output and human judgment.
+
 ## Limitations And Fallback Behavior
 
 - PDF parsing is stream/object oriented and does not decode embedded image compression.

--- a/src/inv_man_intake/contracts/__init__.py
+++ b/src/inv_man_intake/contracts/__init__.py
@@ -1,5 +1,9 @@
-"""Contracts for inbound intake payloads and validation."""
+"""Contracts for inbound intake payloads, validation, and feedback."""
 
+from inv_man_intake.contracts.image_feedback_contract import (
+    ImageFeedbackRecord,
+    validate_image_feedback,
+)
 from inv_man_intake.contracts.intake_contract import (
     IntakeValidationIssue,
     IntakeValidationResult,
@@ -7,7 +11,9 @@ from inv_man_intake.contracts.intake_contract import (
 )
 
 __all__ = [
+    "ImageFeedbackRecord",
     "IntakeValidationIssue",
     "IntakeValidationResult",
+    "validate_image_feedback",
     "validate_intake_payload",
 ]

--- a/src/inv_man_intake/contracts/image_feedback_contract.py
+++ b/src/inv_man_intake/contracts/image_feedback_contract.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import UTC, datetime
 
 MIN_QUALITY_RANK = 1
 MAX_QUALITY_RANK = 5
@@ -21,6 +21,9 @@ class ImageFeedbackRecord:
     notes: str | None = None
 
     def __post_init__(self) -> None:
+        object.__setattr__(self, "artifact_id", self.artifact_id.strip())
+        object.__setattr__(self, "reviewer", self.reviewer.strip())
+        object.__setattr__(self, "timestamp", _normalize_timestamp(self.timestamp))
         validate_image_feedback(self)
 
 
@@ -41,14 +44,16 @@ def validate_image_feedback(record: ImageFeedbackRecord) -> None:
         raise ValueError("notes must be a string when provided")
     if not MIN_QUALITY_RANK <= record.quality_rank <= MAX_QUALITY_RANK:
         raise ValueError(f"quality_rank must be between {MIN_QUALITY_RANK} and {MAX_QUALITY_RANK}")
-    _parse_timestamp(record.timestamp)
+    _normalize_timestamp(record.timestamp)
 
 
-def _parse_timestamp(value: str) -> None:
-    normalized = value.removesuffix("Z") + "+00:00" if value.endswith("Z") else value
+def _normalize_timestamp(value: str) -> str:
+    normalized = value.strip()
+    normalized = normalized.removesuffix("Z") + "+00:00" if normalized.endswith("Z") else normalized
     try:
         parsed = datetime.fromisoformat(normalized)
     except ValueError as exc:
         raise ValueError("timestamp must be ISO-8601") from exc
     if parsed.tzinfo is None:
         raise ValueError("timestamp must include timezone information")
+    return parsed.astimezone(UTC).isoformat(timespec="seconds").replace("+00:00", "Z")

--- a/src/inv_man_intake/contracts/image_feedback_contract.py
+++ b/src/inv_man_intake/contracts/image_feedback_contract.py
@@ -23,8 +23,12 @@ class ImageFeedbackRecord:
     def __post_init__(self) -> None:
         object.__setattr__(self, "artifact_id", self.artifact_id.strip())
         object.__setattr__(self, "reviewer", self.reviewer.strip())
-        object.__setattr__(self, "timestamp", _normalize_timestamp(self.timestamp))
+        object.__setattr__(self, "timestamp", self.timestamp.strip())
+        # Required-field validation runs first so blank strings surface the
+        # "X is required" message; normalization then canonicalizes the
+        # timestamp to a stable UTC ISO-8601 form for TEXT-column sort order.
         validate_image_feedback(self)
+        object.__setattr__(self, "timestamp", _normalize_timestamp(self.timestamp))
 
 
 def validate_image_feedback(record: ImageFeedbackRecord) -> None:

--- a/src/inv_man_intake/contracts/image_feedback_contract.py
+++ b/src/inv_man_intake/contracts/image_feedback_contract.py
@@ -1,0 +1,46 @@
+"""Contract for human visual-artifact feedback records."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+MIN_QUALITY_RANK = 1
+MAX_QUALITY_RANK = 5
+
+
+@dataclass(frozen=True)
+class ImageFeedbackRecord:
+    """Human review feedback for one extracted visual artifact."""
+
+    artifact_id: str
+    is_informative: bool
+    quality_rank: int
+    reviewer: str
+    timestamp: str
+    notes: str | None = None
+
+    def __post_init__(self) -> None:
+        validate_image_feedback(self)
+
+
+def validate_image_feedback(record: ImageFeedbackRecord) -> None:
+    """Validate required feedback fields and the supported rank scale."""
+
+    if not record.artifact_id.strip():
+        raise ValueError("artifact_id is required")
+    if not record.reviewer.strip():
+        raise ValueError("reviewer is required")
+    if not record.timestamp.strip():
+        raise ValueError("timestamp is required")
+    if not MIN_QUALITY_RANK <= record.quality_rank <= MAX_QUALITY_RANK:
+        raise ValueError(f"quality_rank must be between {MIN_QUALITY_RANK} and {MAX_QUALITY_RANK}")
+    _parse_timestamp(record.timestamp)
+
+
+def _parse_timestamp(value: str) -> None:
+    normalized = value.removesuffix("Z") + "+00:00" if value.endswith("Z") else value
+    try:
+        datetime.fromisoformat(normalized)
+    except ValueError as exc:
+        raise ValueError("timestamp must be ISO-8601") from exc

--- a/src/inv_man_intake/contracts/image_feedback_contract.py
+++ b/src/inv_man_intake/contracts/image_feedback_contract.py
@@ -53,6 +53,8 @@ def validate_image_feedback(record: ImageFeedbackRecord) -> None:
 
 def _normalize_timestamp(value: str) -> str:
     normalized = value.strip()
+    if not normalized:
+        raise ValueError("timestamp is required")
     normalized = normalized.removesuffix("Z") + "+00:00" if normalized.endswith("Z") else normalized
     try:
         parsed = datetime.fromisoformat(normalized)

--- a/src/inv_man_intake/contracts/image_feedback_contract.py
+++ b/src/inv_man_intake/contracts/image_feedback_contract.py
@@ -27,12 +27,18 @@ class ImageFeedbackRecord:
 def validate_image_feedback(record: ImageFeedbackRecord) -> None:
     """Validate required feedback fields and the supported rank scale."""
 
+    if isinstance(record.is_informative, bool) is False:
+        raise ValueError("is_informative must be a boolean")
+    if isinstance(record.quality_rank, bool) or isinstance(record.quality_rank, int) is False:
+        raise ValueError("quality_rank must be an integer")
     if not record.artifact_id.strip():
         raise ValueError("artifact_id is required")
     if not record.reviewer.strip():
         raise ValueError("reviewer is required")
     if not record.timestamp.strip():
         raise ValueError("timestamp is required")
+    if record.notes is not None and isinstance(record.notes, str) is False:
+        raise ValueError("notes must be a string when provided")
     if not MIN_QUALITY_RANK <= record.quality_rank <= MAX_QUALITY_RANK:
         raise ValueError(f"quality_rank must be between {MIN_QUALITY_RANK} and {MAX_QUALITY_RANK}")
     _parse_timestamp(record.timestamp)
@@ -41,6 +47,8 @@ def validate_image_feedback(record: ImageFeedbackRecord) -> None:
 def _parse_timestamp(value: str) -> None:
     normalized = value.removesuffix("Z") + "+00:00" if value.endswith("Z") else value
     try:
-        datetime.fromisoformat(normalized)
+        parsed = datetime.fromisoformat(normalized)
     except ValueError as exc:
         raise ValueError("timestamp must be ISO-8601") from exc
+    if parsed.tzinfo is None:
+        raise ValueError("timestamp must include timezone information")

--- a/src/inv_man_intake/data/provenance.py
+++ b/src/inv_man_intake/data/provenance.py
@@ -56,5 +56,5 @@ class VisualArtifactFeedbackRecord:
     is_informative: bool
     quality_rank: int
     reviewer: str
-    timestamp: str
+    reviewed_at: str
     notes: str | None

--- a/src/inv_man_intake/data/provenance.py
+++ b/src/inv_man_intake/data/provenance.py
@@ -46,3 +46,15 @@ class VisualArtifactRecord:
     mime_type: str
     byte_size: int
     extracted_at: str
+
+
+@dataclass(frozen=True)
+class VisualArtifactFeedbackRecord:
+    """Persisted reviewer feedback for one visual artifact."""
+
+    artifact_id: str
+    is_informative: bool
+    quality_rank: int
+    reviewer: str
+    timestamp: str
+    notes: str | None

--- a/src/inv_man_intake/data/repository.py
+++ b/src/inv_man_intake/data/repository.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import sqlite3
+from typing import Any
 
 from inv_man_intake.data.models import Document, Firm, Fund
 from inv_man_intake.data.provenance import (
     CorrectionRecord,
     ExtractedFieldRecord,
+    VisualArtifactFeedbackRecord,
     VisualArtifactRecord,
 )
 
@@ -376,9 +378,40 @@ class VisualArtifactRepository:
             """)
         self._connection.commit()
 
+    def ensure_feedback_schema(self) -> None:
+        if not self._visual_artifacts_table_exists():
+            raise RuntimeError(
+                "visual_artifacts table missing; apply visual artifact schema before feedback schema"
+            )
+        self._connection.executescript("""
+            CREATE TABLE IF NOT EXISTS visual_artifact_feedback (
+                artifact_id TEXT NOT NULL,
+                reviewer TEXT NOT NULL,
+                is_informative INTEGER NOT NULL CHECK (is_informative IN (0, 1)),
+                quality_rank INTEGER NOT NULL CHECK (quality_rank BETWEEN 1 AND 5),
+                reviewed_at TEXT NOT NULL,
+                notes TEXT,
+                PRIMARY KEY (artifact_id, reviewer),
+                FOREIGN KEY (artifact_id) REFERENCES visual_artifacts (artifact_id)
+                    ON DELETE CASCADE
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_visual_artifact_feedback_artifact_id
+                ON visual_artifact_feedback (artifact_id);
+            CREATE INDEX IF NOT EXISTS idx_visual_artifact_feedback_reviewed_at
+                ON visual_artifact_feedback (reviewed_at);
+            """)
+        self._connection.commit()
+
     def _documents_table_exists(self) -> bool:
         row = self._connection.execute(
             "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'documents'"
+        ).fetchone()
+        return row is not None
+
+    def _visual_artifacts_table_exists(self) -> bool:
+        row = self._connection.execute(
+            "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'visual_artifacts'"
         ).fetchone()
         return row is not None
 
@@ -431,3 +464,59 @@ class VisualArtifactRepository:
             )
             for row in rows
         )
+
+    def upsert_feedback(self, record: VisualArtifactFeedbackRecord) -> None:
+        self._connection.execute(
+            (
+                "INSERT INTO visual_artifact_feedback (artifact_id, reviewer, is_informative, "
+                "quality_rank, reviewed_at, notes) VALUES (?, ?, ?, ?, ?, ?) "
+                "ON CONFLICT(artifact_id, reviewer) DO UPDATE SET "
+                "is_informative = excluded.is_informative, "
+                "quality_rank = excluded.quality_rank, "
+                "reviewed_at = excluded.reviewed_at, "
+                "notes = excluded.notes"
+            ),
+            (
+                record.artifact_id,
+                record.reviewer,
+                1 if record.is_informative else 0,
+                record.quality_rank,
+                record.timestamp,
+                record.notes,
+            ),
+        )
+        self._connection.commit()
+
+    def get_feedback(self, artifact_id: str, reviewer: str) -> VisualArtifactFeedbackRecord | None:
+        row = self._connection.execute(
+            (
+                "SELECT artifact_id, is_informative, quality_rank, reviewer, reviewed_at, notes "
+                "FROM visual_artifact_feedback WHERE artifact_id = ? AND reviewer = ?"
+            ),
+            (artifact_id, reviewer),
+        ).fetchone()
+        if row is None:
+            return None
+        return _feedback_from_row(row)
+
+    def list_feedback(self, artifact_id: str) -> tuple[VisualArtifactFeedbackRecord, ...]:
+        rows = self._connection.execute(
+            (
+                "SELECT artifact_id, is_informative, quality_rank, reviewer, reviewed_at, notes "
+                "FROM visual_artifact_feedback WHERE artifact_id = ? "
+                "ORDER BY reviewed_at ASC, reviewer ASC"
+            ),
+            (artifact_id,),
+        ).fetchall()
+        return tuple(_feedback_from_row(row) for row in rows)
+
+
+def _feedback_from_row(row: sqlite3.Row | tuple[Any, ...]) -> VisualArtifactFeedbackRecord:
+    return VisualArtifactFeedbackRecord(
+        artifact_id=str(row[0]),
+        is_informative=bool(row[1]),
+        quality_rank=int(row[2]),
+        reviewer=str(row[3]),
+        timestamp=str(row[4]),
+        notes=None if row[5] is None else str(row[5]),
+    )

--- a/src/inv_man_intake/data/repository.py
+++ b/src/inv_man_intake/data/repository.py
@@ -396,8 +396,9 @@ class VisualArtifactRepository:
                     ON DELETE CASCADE
             );
 
-            CREATE INDEX IF NOT EXISTS idx_visual_artifact_feedback_artifact_id
-                ON visual_artifact_feedback (artifact_id);
+            DROP INDEX IF EXISTS idx_visual_artifact_feedback_artifact_id;
+            CREATE INDEX IF NOT EXISTS idx_visual_artifact_feedback_artifact_reviewed_at
+                ON visual_artifact_feedback (artifact_id, reviewed_at, reviewer);
             CREATE INDEX IF NOT EXISTS idx_visual_artifact_feedback_reviewed_at
                 ON visual_artifact_feedback (reviewed_at);
             """)
@@ -481,7 +482,7 @@ class VisualArtifactRepository:
                 record.reviewer,
                 1 if record.is_informative else 0,
                 record.quality_rank,
-                record.timestamp,
+                record.reviewed_at,
                 record.notes,
             ),
         )
@@ -517,6 +518,6 @@ def _feedback_from_row(row: sqlite3.Row | tuple[Any, ...]) -> VisualArtifactFeed
         is_informative=bool(row[1]),
         quality_rank=int(row[2]),
         reviewer=str(row[3]),
-        timestamp=str(row[4]),
+        reviewed_at=str(row[4]),
         notes=None if row[5] is None else str(row[5]),
     )

--- a/src/inv_man_intake/images/__init__.py
+++ b/src/inv_man_intake/images/__init__.py
@@ -6,6 +6,10 @@ from inv_man_intake.images.classifier import (
     classify_visual_artifact,
 )
 from inv_man_intake.images.extractor import UnsupportedVisualSourceError, extract_visual_artifacts
+from inv_man_intake.images.feedback_service import (
+    FeedbackWriteResult,
+    VisualArtifactFeedbackService,
+)
 from inv_man_intake.images.models import ArtifactSource, VisualArtifact
 from inv_man_intake.images.service import (
     ClassifiedVisualArtifact,
@@ -16,7 +20,9 @@ from inv_man_intake.images.service import (
 __all__ = [
     "ArtifactSource",
     "ClassifiedVisualArtifact",
+    "FeedbackWriteResult",
     "UnsupportedVisualSourceError",
+    "VisualArtifactFeedbackService",
     "VisualArtifactClassification",
     "VisualClassificationLabel",
     "VisualArtifact",

--- a/src/inv_man_intake/images/feedback_service.py
+++ b/src/inv_man_intake/images/feedback_service.py
@@ -1,0 +1,68 @@
+"""Service helpers for visual-artifact feedback capture."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from inv_man_intake.contracts.image_feedback_contract import ImageFeedbackRecord
+from inv_man_intake.data.provenance import VisualArtifactFeedbackRecord
+from inv_man_intake.data.repository import VisualArtifactRepository
+
+
+@dataclass(frozen=True)
+class FeedbackWriteResult:
+    """Result returned after a reviewer feedback upsert."""
+
+    record: ImageFeedbackRecord
+    replaced_existing: bool
+
+
+class VisualArtifactFeedbackService:
+    """Create, read, and upsert feedback for extracted visual artifacts."""
+
+    def __init__(self, repository: VisualArtifactRepository) -> None:
+        self._repository = repository
+
+    def record_feedback(self, record: ImageFeedbackRecord) -> FeedbackWriteResult:
+        """Persist feedback, replacing the same reviewer's prior record for the artifact."""
+
+        replaced_existing = (
+            self._repository.get_feedback(record.artifact_id, record.reviewer) is not None
+        )
+        self._repository.upsert_feedback(
+            VisualArtifactFeedbackRecord(
+                artifact_id=record.artifact_id,
+                is_informative=record.is_informative,
+                quality_rank=record.quality_rank,
+                reviewer=record.reviewer,
+                timestamp=record.timestamp,
+                notes=record.notes,
+            )
+        )
+        return FeedbackWriteResult(record=record, replaced_existing=replaced_existing)
+
+    def get_feedback(self, artifact_id: str, reviewer: str) -> ImageFeedbackRecord | None:
+        """Return one reviewer's feedback for an artifact when present."""
+
+        record = self._repository.get_feedback(artifact_id, reviewer)
+        if record is None:
+            return None
+        return _to_contract_record(record)
+
+    def list_feedback(self, artifact_id: str) -> tuple[ImageFeedbackRecord, ...]:
+        """Return all feedback for an artifact in review-time order."""
+
+        return tuple(
+            _to_contract_record(record) for record in self._repository.list_feedback(artifact_id)
+        )
+
+
+def _to_contract_record(record: VisualArtifactFeedbackRecord) -> ImageFeedbackRecord:
+    return ImageFeedbackRecord(
+        artifact_id=record.artifact_id,
+        is_informative=record.is_informative,
+        quality_rank=record.quality_rank,
+        reviewer=record.reviewer,
+        timestamp=record.timestamp,
+        notes=record.notes,
+    )

--- a/src/inv_man_intake/images/feedback_service.py
+++ b/src/inv_man_intake/images/feedback_service.py
@@ -35,7 +35,7 @@ class VisualArtifactFeedbackService:
                 is_informative=record.is_informative,
                 quality_rank=record.quality_rank,
                 reviewer=record.reviewer,
-                timestamp=record.timestamp,
+                reviewed_at=record.timestamp,
                 notes=record.notes,
             )
         )
@@ -63,6 +63,6 @@ def _to_contract_record(record: VisualArtifactFeedbackRecord) -> ImageFeedbackRe
         is_informative=record.is_informative,
         quality_rank=record.quality_rank,
         reviewer=record.reviewer,
-        timestamp=record.timestamp,
+        timestamp=record.reviewed_at,
         notes=record.notes,
     )

--- a/tests/contracts/test_image_feedback_contract.py
+++ b/tests/contracts/test_image_feedback_contract.py
@@ -1,0 +1,99 @@
+"""Tests for image feedback contract validation."""
+
+from __future__ import annotations
+
+import pytest
+
+from inv_man_intake.contracts.image_feedback_contract import ImageFeedbackRecord
+
+
+def test_valid_feedback_contract_record_is_accepted() -> None:
+    record = ImageFeedbackRecord(
+        artifact_id="va_1",
+        is_informative=True,
+        quality_rank=4,
+        reviewer="analyst-a",
+        timestamp="2026-03-01T10:00:00Z",
+        notes="Useful chart with labels.",
+    )
+
+    assert record.artifact_id == "va_1"
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "match"),
+    (
+        ("artifact_id", " ", "artifact_id is required"),
+        ("reviewer", " ", "reviewer is required"),
+        ("timestamp", " ", "timestamp is required"),
+    ),
+)
+def test_required_contract_fields_are_enforced(field: str, value: str, match: str) -> None:
+    payload = {
+        "artifact_id": "va_1",
+        "is_informative": True,
+        "quality_rank": 3,
+        "reviewer": "analyst-a",
+        "timestamp": "2026-03-01T10:00:00Z",
+        "notes": None,
+    }
+    payload[field] = value
+
+    with pytest.raises(ValueError, match=match):
+        ImageFeedbackRecord(**payload)
+
+
+def test_quality_rank_scale_is_enforced() -> None:
+    with pytest.raises(ValueError, match="quality_rank must be between 1 and 5"):
+        ImageFeedbackRecord(
+            artifact_id="va_1",
+            is_informative=True,
+            quality_rank=6,
+            reviewer="analyst-a",
+            timestamp="2026-03-01T10:00:00Z",
+        )
+
+
+def test_quality_rank_must_be_integer() -> None:
+    with pytest.raises(ValueError, match="quality_rank must be an integer"):
+        ImageFeedbackRecord(
+            artifact_id="va_1",
+            is_informative=True,
+            quality_rank=3.5,  # type: ignore[arg-type]
+            reviewer="analyst-a",
+            timestamp="2026-03-01T10:00:00Z",
+        )
+
+
+def test_is_informative_must_be_boolean() -> None:
+    with pytest.raises(ValueError, match="is_informative must be a boolean"):
+        ImageFeedbackRecord(
+            artifact_id="va_1",
+            is_informative="yes",  # type: ignore[arg-type]
+            quality_rank=3,
+            reviewer="analyst-a",
+            timestamp="2026-03-01T10:00:00Z",
+        )
+
+
+def test_timestamp_must_be_iso8601_with_timezone() -> None:
+    with pytest.raises(ValueError, match="timestamp must include timezone information"):
+        ImageFeedbackRecord(
+            artifact_id="va_1",
+            is_informative=True,
+            quality_rank=3,
+            reviewer="analyst-a",
+            timestamp="2026-03-01T10:00:00",
+        )
+
+
+def test_notes_must_be_string_when_present() -> None:
+    with pytest.raises(ValueError, match="notes must be a string when provided"):
+        ImageFeedbackRecord(
+            artifact_id="va_1",
+            is_informative=True,
+            quality_rank=3,
+            reviewer="analyst-a",
+            timestamp="2026-03-01T10:00:00Z",
+            notes=123,  # type: ignore[arg-type]
+        )

--- a/tests/images/test_feedback_service.py
+++ b/tests/images/test_feedback_service.py
@@ -1,0 +1,152 @@
+"""Tests for visual artifact feedback capture and persistence."""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from inv_man_intake.contracts.image_feedback_contract import ImageFeedbackRecord
+from inv_man_intake.data.migrations.core_schema import apply_core_schema
+from inv_man_intake.data.provenance import VisualArtifactRecord
+from inv_man_intake.data.repository import VisualArtifactRepository
+from inv_man_intake.images.feedback_service import VisualArtifactFeedbackService
+
+
+def _connection() -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.execute("PRAGMA foreign_keys = ON")
+    apply_core_schema(conn)
+    conn.execute(
+        "INSERT INTO firms (firm_id, legal_name, aliases_json, created_at) VALUES (?, ?, ?, ?)",
+        ("firm_1", "Alpha Capital", None, "2026-03-01T08:00:00Z"),
+    )
+    conn.execute(
+        (
+            "INSERT INTO funds (fund_id, firm_id, fund_name, strategy, asset_class, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?)"
+        ),
+        (
+            "fund_1",
+            "firm_1",
+            "Alpha Fund",
+            "market_neutral",
+            "equity_market_neutral",
+            "2026-03-01T08:30:00Z",
+        ),
+    )
+    conn.execute(
+        (
+            "INSERT INTO documents (document_id, fund_id, file_name, file_hash, received_at, "
+            "version_date, source_channel, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
+        ),
+        (
+            "doc_1",
+            "fund_1",
+            "manager_deck.pdf",
+            "hash_doc_1",
+            "2026-03-01T09:00:00Z",
+            "2026-03-01",
+            "email",
+            "2026-03-01T09:00:00Z",
+        ),
+    )
+    conn.commit()
+    return conn
+
+
+def _repository() -> VisualArtifactRepository:
+    repo = VisualArtifactRepository(_connection())
+    repo.ensure_schema()
+    repo.insert_artifact(
+        VisualArtifactRecord(
+            artifact_id="va_1",
+            document_id="doc_1",
+            source_type="pdf",
+            source_page=2,
+            source_slide=None,
+            source_ref="pdf-object-12",
+            storage_path="artifacts/doc_1/pdf/page-2/object-12.bin",
+            sha256="abc123",
+            mime_type="image/jpeg",
+            byte_size=1240,
+            extracted_at="2026-03-01T09:10:00Z",
+        )
+    )
+    repo.ensure_feedback_schema()
+    return repo
+
+
+def test_feedback_records_can_be_created_and_retrieved_per_artifact() -> None:
+    service = VisualArtifactFeedbackService(_repository())
+    record = ImageFeedbackRecord(
+        artifact_id="va_1",
+        is_informative=True,
+        quality_rank=5,
+        reviewer="analyst-a",
+        timestamp="2026-03-01T10:00:00Z",
+        notes="Useful exposure chart.",
+    )
+
+    result = service.record_feedback(record)
+
+    assert result.replaced_existing is False
+    assert service.get_feedback("va_1", "analyst-a") == record
+    assert service.list_feedback("va_1") == (record,)
+
+
+def test_repeated_reviewer_feedback_updates_without_duplicate_rows() -> None:
+    service = VisualArtifactFeedbackService(_repository())
+    original = ImageFeedbackRecord(
+        artifact_id="va_1",
+        is_informative=False,
+        quality_rank=2,
+        reviewer="analyst-a",
+        timestamp="2026-03-01T10:00:00Z",
+        notes="Mostly decorative.",
+    )
+    update = ImageFeedbackRecord(
+        artifact_id="va_1",
+        is_informative=True,
+        quality_rank=4,
+        reviewer="analyst-a",
+        timestamp="2026-03-01T10:05:00Z",
+        notes="Actually useful after zooming in.",
+    )
+
+    assert service.record_feedback(original).replaced_existing is False
+    assert service.record_feedback(update).replaced_existing is True
+
+    assert service.list_feedback("va_1") == (update,)
+
+
+def test_feedback_validation_enforces_rank_scale_required_fields_and_fk() -> None:
+    with pytest.raises(ValueError, match="quality_rank must be between 1 and 5"):
+        ImageFeedbackRecord(
+            artifact_id="va_1",
+            is_informative=True,
+            quality_rank=6,
+            reviewer="analyst-a",
+            timestamp="2026-03-01T10:00:00Z",
+        )
+
+    with pytest.raises(ValueError, match="reviewer is required"):
+        ImageFeedbackRecord(
+            artifact_id="va_1",
+            is_informative=True,
+            quality_rank=3,
+            reviewer=" ",
+            timestamp="2026-03-01T10:00:00Z",
+        )
+
+    service = VisualArtifactFeedbackService(_repository())
+    with pytest.raises(sqlite3.IntegrityError):
+        service.record_feedback(
+            ImageFeedbackRecord(
+                artifact_id="missing",
+                is_informative=True,
+                quality_rank=3,
+                reviewer="analyst-a",
+                timestamp="2026-03-01T10:00:00Z",
+            )
+        )

--- a/tests/images/test_feedback_service.py
+++ b/tests/images/test_feedback_service.py
@@ -120,6 +120,49 @@ def test_repeated_reviewer_feedback_updates_without_duplicate_rows() -> None:
     assert service.list_feedback("va_1") == (update,)
 
 
+def test_feedback_normalizes_identity_and_review_time_before_persistence() -> None:
+    service = VisualArtifactFeedbackService(_repository())
+    record = ImageFeedbackRecord(
+        artifact_id=" va_1 ",
+        is_informative=True,
+        quality_rank=5,
+        reviewer=" analyst-a ",
+        timestamp="2026-03-01T05:00:00-05:00",
+        notes="Useful exposure chart.",
+    )
+
+    result = service.record_feedback(record)
+
+    assert result.replaced_existing is False
+    assert result.record.artifact_id == "va_1"
+    assert result.record.reviewer == "analyst-a"
+    assert result.record.timestamp == "2026-03-01T10:00:00Z"
+    assert service.get_feedback("va_1", "analyst-a") == result.record
+
+
+def test_feedback_list_sorts_by_normalized_review_time() -> None:
+    service = VisualArtifactFeedbackService(_repository())
+    later = ImageFeedbackRecord(
+        artifact_id="va_1",
+        is_informative=True,
+        quality_rank=5,
+        reviewer="analyst-b",
+        timestamp="2026-03-01T10:30:00Z",
+    )
+    earlier = ImageFeedbackRecord(
+        artifact_id="va_1",
+        is_informative=True,
+        quality_rank=4,
+        reviewer="analyst-a",
+        timestamp="2026-03-01T05:00:00-05:00",
+    )
+
+    service.record_feedback(later)
+    service.record_feedback(earlier)
+
+    assert service.list_feedback("va_1") == (earlier, later)
+
+
 def test_feedback_validation_enforces_rank_scale_required_fields_and_fk() -> None:
     with pytest.raises(ValueError, match="quality_rank must be between 1 and 5"):
         ImageFeedbackRecord(

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,5 +1,34 @@
 # Workloop State
 
+## 2026-05-11T02:34:30Z - opener lane issue #26 PR materialization
+
+- Automation: `pd-workloop-resume` (codex opener lane).
+- Source repo: `stranske/Inv-Man-Intake`.
+- Source issue: `#26` (`Image feedback capture contract and service`, `priority:normal`).
+- Source PR: `#413` (`https://github.com/stranske/Inv-Man-Intake/pull/413`), non-draft, labels `agent:codex` + `agents:keepalive` + `autofix`.
+- Branch: `codex/issue-26-image-feedback`.
+- Selection:
+  - ACTION A succeeded from the neutral Code workspace; sentinel `active.*` pointed at closer/verifier state and was treated as cross-lane informational state only.
+  - Required discovery ran across `repo-review-approved`, `priority:high`, `priority:normal`, and `priority:low`.
+  - High-priority `trip-planner#1130` and `trip-planner#1129` were skipped because both are reopened for verifier sequencing after existing merged PRs.
+  - Cap-health after infra repair reported `total_opener_owned=2`, `raw_cap_reached=false`, `normal_cap_reached=false`, and `non_drainable_cap_blocker=false`; helper execution required Python 3.12 in `PATH` because the default Python 3.9 cannot import `datetime.UTC`.
+- Implementation:
+  - Added `ImageFeedbackRecord` with required-field, ISO timestamp, and 1-5 quality-rank validation.
+  - Added visual-artifact feedback persistence keyed by `(artifact_id, reviewer)` so repeated reviews update the previous row.
+  - Added `VisualArtifactFeedbackService` for create/read/list feedback operations and re-exported it from `inv_man_intake.images`.
+  - Documented feedback governance and the rank scale in `docs/runbooks/visual_artifact_extraction.md`.
+- Validation passed:
+  - `python -m pytest tests/images/test_feedback_service.py tests/data/test_visual_artifact_repository.py tests/images/test_service.py --no-cov` (`12 passed`).
+  - `python -m ruff check src/inv_man_intake/contracts/image_feedback_contract.py src/inv_man_intake/images/feedback_service.py src/inv_man_intake/data/provenance.py src/inv_man_intake/data/repository.py src/inv_man_intake/images/__init__.py tests/images/test_feedback_service.py`.
+  - `python -m black --check --line-length 100 src/inv_man_intake/contracts/image_feedback_contract.py src/inv_man_intake/images/feedback_service.py src/inv_man_intake/data/provenance.py src/inv_man_intake/data/repository.py src/inv_man_intake/images/__init__.py tests/images/test_feedback_service.py`.
+  - `python -m mypy src/inv_man_intake/contracts/image_feedback_contract.py src/inv_man_intake/images/feedback_service.py src/inv_man_intake/data/provenance.py src/inv_man_intake/data/repository.py`.
+  - `git diff --check`.
+- Relay event emitted: `pr_opened active.source_repo=stranske/Inv-Man-Intake active.source_issue=26 active.source_pr=413 active.next_action=wait_for_keepalive`.
+- Post-open state:
+  - PR `#413` is open and non-draft with required routing labels.
+  - Initial checks are mostly pending; one synthetic `Gate / gate` row reported `fail` because path classification was cancelled while newer Gate/CI jobs were still queued/pending.
+- Next action: keepalive's Codex runner takes over for CI fixups or review-comment work; opener is done with this lane.
+
 ## 2026-05-11T01:05:15Z - opener lane issue #25 PR materialization
 
 - Automation: `pd-workloop-resume` (codex opener lane).


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:26 -->
> **Source:** Issue #26

Closes #26

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
User feedback is required to improve image quality judgments over time and to quantify usefulness of extracted visuals.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#10](https://github.com/stranske/Inv-Man-Intake/issues/10)
- [#7](https://github.com/stranske/Inv-Man-Intake/issues/7)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [x] Define feedback contract (`is_informative`, `quality_rank`, `reviewer`, `timestamp`, `notes`)
- [x] Implement feedback write/read service endpoints
- [x] Implement upsert behavior for repeated reviewer updates
- [x] Add tests for persistence, updates, and validation
- [x] Document feedback governance and allowed rank scale

#### Acceptance criteria
- [x] Feedback records can be created and retrieved per artifact ID
- [x] Repeated reviews update records without data loss
- [x] Validation enforces rank scale and required fields
- [x] Tests cover create/update/error paths

<!-- auto-status-summary:end -->
