### PR TITLE
Issue #27: add image feedback report export

### DIFF
--- a/docs/runbooks/image_feedback_tuning.md
+++ b/docs/runbooks/image_feedback_tuning.md
@@ -1,0 +1,22 @@
+# Image Feedback Tuning Report
+
+Visual artifact feedback can be exported as a tuning report after
+`visual_artifact_feedback` has been populated by reviewer workflows.
+
+Generate JSON:
+
+```bash
+python scripts/image_feedback_report.py --database path/to/intake.sqlite --format json --output reports/image-feedback.json
+```
+
+Generate artifact-level CSV:
+
+```bash
+python scripts/image_feedback_report.py --database path/to/intake.sqlite --format csv --output reports/image-feedback.csv
+```
+
+Use `--reviewed-from` and `--reviewed-to` with UTC ISO-8601 timestamps to limit the report
+window. The JSON summary includes informative rate, quality-rank distribution, reviewer
+counts, timestamp range, and disagreement rate. An artifact is counted as a disagreement
+when multiple reviewers disagree on informative-vs-boilerplate classification or their
+quality ranks differ by two or more points.

--- a/docs/runbooks/image_feedback_tuning.md
+++ b/docs/runbooks/image_feedback_tuning.md
@@ -29,3 +29,42 @@ window. The JSON summary includes informative rate, quality-rank distribution, r
 counts, timestamp range, and disagreement rate. An artifact is counted as a disagreement
 when multiple reviewers disagree on informative-vs-boilerplate classification or their
 quality ranks differ by two or more points.
+
+## Interpretation guidance for tuning decisions
+
+Use a minimum sample-size guard before acting on metrics. As a default baseline, require
+at least 30 feedback records and at least 10 multi-reviewer artifacts in the selected window.
+If volume is lower, continue collecting feedback before changing extraction heuristics.
+
+Interpret `informative_rate` as recall pressure for extraction and ranking quality:
+
+- Rising informative rate with stable disagreement rate indicates the current extraction profile
+  is surfacing useful artifacts consistently.
+- Falling informative rate suggests the pipeline is surfacing more boilerplate than signal.
+  Prioritize threshold and filtering adjustments for source types with the lowest artifact-level
+  informative fractions.
+
+Interpret `quality_rank_distribution` as severity and prioritization signal:
+
+- A shift toward ranks 1-2 indicates quality regressions. Review the affected artifacts and
+  tune extraction thresholds or source-specific normalization first.
+- Concentration at rank 3 suggests marginal quality where small prompt or weighting updates may
+  produce gains.
+- Growth in ranks 4-5 indicates changes are likely improving practical usefulness.
+
+Interpret `disagreement_rate` as rubric clarity and reviewer calibration signal:
+
+- High disagreement rate (for example >0.30 over a stable sample) means either rubric ambiguity
+  or unstable model behavior. Run reviewer calibration and inspect disagreement artifacts before
+  model updates.
+- Low disagreement rate with low informative rate indicates reviewers agree the output is weak,
+  which is a stronger signal to prioritize heuristic/model tuning.
+
+Recommended tuning loop:
+
+1. Generate a bounded-window report (`--reviewed-from/--reviewed-to`) and archive JSON+CSV.
+2. Identify the worst-performing segment from artifact-level rows (low informative fraction,
+   low average quality rank, high disagreement flag).
+3. Apply one focused change (threshold, extraction prompt, ranking weight, or model version).
+4. Re-run the report on the next comparable window and compare informative rate,
+   rank distribution, and disagreement rate before rolling out broadly.

--- a/docs/runbooks/image_feedback_tuning.md
+++ b/docs/runbooks/image_feedback_tuning.md
@@ -15,6 +15,15 @@ Generate artifact-level CSV:
 python scripts/image_feedback_report.py --database path/to/intake.sqlite --format csv --output reports/image-feedback.csv
 ```
 
+Generate a schedule/manual bundle (JSON + CSV in one run):
+
+```bash
+python scripts/image_feedback_report.py --database path/to/intake.sqlite --bundle-dir reports/image-feedback/
+```
+
+This creates timestamped files (`image-feedback-<generated_at>.json` and
+`image-feedback-<generated_at>.csv`) suitable for cron or nightly job archives.
+
 Use `--reviewed-from` and `--reviewed-to` with UTC ISO-8601 timestamps to limit the report
 window. The JSON summary includes informative rate, quality-rank distribution, reviewer
 counts, timestamp range, and disagreement rate. An artifact is counted as a disagreement

--- a/docs/runbooks/visual_artifact_extraction.md
+++ b/docs/runbooks/visual_artifact_extraction.md
@@ -62,6 +62,10 @@ review. `quality_rank` is an integer scale from 1 to 5:
 Repeated reviews from the same reviewer update the prior record. Preserve notes
 when they explain disagreements between the classifier output and human judgment.
 
+Generate tuning exports with `scripts/image_feedback_report.py`. The report summarizes
+informative rate, rank distribution, timestamp range, and reviewer disagreement for stored
+feedback records; see `docs/runbooks/image_feedback_tuning.md` for JSON and CSV commands.
+
 ## Limitations And Fallback Behavior
 
 - PDF parsing is stream/object oriented and does not decode embedded image compression.

--- a/scripts/image_feedback_report.py
+++ b/scripts/image_feedback_report.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Generate visual-artifact feedback summary exports."""
+
+from __future__ import annotations
+
+import argparse
+import sqlite3
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from inv_man_intake.data.repository import VisualArtifactRepository
+from inv_man_intake.images.feedback_report import (
+    generate_feedback_summary_report,
+    render_feedback_summary_csv,
+    render_feedback_summary_json,
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--database",
+        type=Path,
+        required=True,
+        help="SQLite database containing visual_artifact_feedback.",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("json", "csv"),
+        default="json",
+        help="Export format.",
+    )
+    parser.add_argument(
+        "--reviewed-from",
+        default=None,
+        help="Inclusive ISO-8601 lower bound for reviewed_at.",
+    )
+    parser.add_argument(
+        "--reviewed-to",
+        default=None,
+        help="Inclusive ISO-8601 upper bound for reviewed_at.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Optional output file. Defaults to stdout.",
+    )
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+
+    with sqlite3.connect(args.database) as connection:
+        repository = VisualArtifactRepository(connection)
+        report = generate_feedback_summary_report(
+            repository,
+            generated_at=datetime.now(UTC).isoformat(timespec="seconds").replace("+00:00", "Z"),
+            reviewed_from=args.reviewed_from,
+            reviewed_to=args.reviewed_to,
+        )
+
+    rendered = (
+        render_feedback_summary_json(report)
+        if args.format == "json"
+        else render_feedback_summary_csv(report)
+    )
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered, encoding="utf-8")
+    else:
+        print(rendered, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/image_feedback_report.py
+++ b/scripts/image_feedback_report.py
@@ -49,6 +49,15 @@ def build_parser() -> argparse.ArgumentParser:
         default=None,
         help="Optional output file. Defaults to stdout.",
     )
+    parser.add_argument(
+        "--bundle-dir",
+        type=Path,
+        default=None,
+        help=(
+            "Optional output directory for schedule/manual bundles. "
+            "Writes both JSON and CSV exports with generated-at timestamp names."
+        ),
+    )
     return parser
 
 
@@ -63,6 +72,19 @@ def main() -> int:
             reviewed_from=args.reviewed_from,
             reviewed_to=args.reviewed_to,
         )
+
+    if args.bundle_dir is not None:
+        bundle_stamp = report.generated_at.replace(":", "").replace("-", "")
+        args.bundle_dir.mkdir(parents=True, exist_ok=True)
+        (args.bundle_dir / f"image-feedback-{bundle_stamp}.json").write_text(
+            render_feedback_summary_json(report),
+            encoding="utf-8",
+        )
+        (args.bundle_dir / f"image-feedback-{bundle_stamp}.csv").write_text(
+            render_feedback_summary_csv(report),
+            encoding="utf-8",
+        )
+        return 0
 
     rendered = (
         render_feedback_summary_json(report)

--- a/scripts/image_feedback_report.py
+++ b/scripts/image_feedback_report.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import argparse
 import sqlite3
 import sys
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
@@ -58,19 +58,47 @@ def build_parser() -> argparse.ArgumentParser:
             "Writes both JSON and CSV exports with generated-at timestamp names."
         ),
     )
+    parser.add_argument(
+        "--scheduled-daily",
+        action="store_true",
+        help=(
+            "Run in scheduled mode with bundle output and a default 24-hour review window "
+            "ending at generated_at unless reviewed-from/reviewed-to are explicitly provided."
+        ),
+    )
     return parser
+
+
+def _parse_iso8601(value: str) -> datetime:
+    normalized = value.replace("Z", "+00:00")
+    parsed = datetime.fromisoformat(normalized)
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
 
 
 def main() -> int:
     args = build_parser().parse_args()
+    generated_at = datetime.now(UTC).isoformat(timespec="seconds").replace("+00:00", "Z")
+    reviewed_from = args.reviewed_from
+    reviewed_to = args.reviewed_to
+
+    if args.scheduled_daily:
+        if args.bundle_dir is None:
+            raise SystemExit("--scheduled-daily requires --bundle-dir")
+        window_end = _parse_iso8601(reviewed_to) if reviewed_to else _parse_iso8601(generated_at)
+        if reviewed_from is None:
+            reviewed_from = (window_end - timedelta(hours=24)).isoformat().replace("+00:00", "Z")
+        if reviewed_to is None:
+            reviewed_to = window_end.isoformat().replace("+00:00", "Z")
 
     with sqlite3.connect(args.database) as connection:
         repository = VisualArtifactRepository(connection)
         report = generate_feedback_summary_report(
             repository,
-            generated_at=datetime.now(UTC).isoformat(timespec="seconds").replace("+00:00", "Z"),
-            reviewed_from=args.reviewed_from,
-            reviewed_to=args.reviewed_to,
+            generated_at=generated_at,
+            reviewed_from=reviewed_from,
+            reviewed_to=reviewed_to,
         )
 
     if args.bundle_dir is not None:

--- a/src/inv_man_intake/data/repository.py
+++ b/src/inv_man_intake/data/repository.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import sqlite3
+from datetime import UTC, datetime
 from typing import Any
 
 from inv_man_intake.data.models import Document, Firm, Fund
@@ -514,16 +515,24 @@ class VisualArtifactRepository:
     def list_all_feedback(
         self, *, reviewed_from: str | None = None, reviewed_to: str | None = None
     ) -> tuple[VisualArtifactFeedbackRecord, ...]:
-        """Return feedback records across artifacts, optionally filtered by review time."""
+        """Return feedback records across artifacts, optionally filtered by review time.
+
+        ``reviewed_from`` and ``reviewed_to`` are normalized to the canonical
+        UTC ``...Z`` form used by stored ``reviewed_at`` values before being
+        compared, so callers can pass any ISO-8601 timestamp with timezone
+        information (e.g. ``2026-03-01T10:00:00+00:00``) without producing
+        silently incorrect TEXT comparisons. Invalid ISO-8601 or naive
+        timestamps raise ``ValueError``.
+        """
 
         predicates: list[str] = []
         params: list[str] = []
         if reviewed_from is not None:
             predicates.append("reviewed_at >= ?")
-            params.append(reviewed_from)
+            params.append(_normalize_reviewed_bound(reviewed_from, field="reviewed_from"))
         if reviewed_to is not None:
             predicates.append("reviewed_at <= ?")
-            params.append(reviewed_to)
+            params.append(_normalize_reviewed_bound(reviewed_to, field="reviewed_to"))
 
         where_clause = f" WHERE {' AND '.join(predicates)}" if predicates else ""
         rows = self._connection.execute(
@@ -546,3 +555,17 @@ def _feedback_from_row(row: sqlite3.Row | tuple[Any, ...]) -> VisualArtifactFeed
         reviewed_at=str(row[4]),
         notes=None if row[5] is None else str(row[5]),
     )
+
+
+def _normalize_reviewed_bound(value: str, *, field: str) -> str:
+    candidate = value.strip()
+    if not candidate:
+        raise ValueError(f"{field} must be a non-empty ISO-8601 timestamp")
+    iso = candidate.removesuffix("Z") + "+00:00" if candidate.endswith("Z") else candidate
+    try:
+        parsed = datetime.fromisoformat(iso)
+    except ValueError as exc:
+        raise ValueError(f"{field} must be ISO-8601 (got {value!r})") from exc
+    if parsed.tzinfo is None:
+        raise ValueError(f"{field} must include timezone information (got {value!r})")
+    return parsed.astimezone(UTC).isoformat(timespec="seconds").replace("+00:00", "Z")

--- a/src/inv_man_intake/data/repository.py
+++ b/src/inv_man_intake/data/repository.py
@@ -511,6 +511,31 @@ class VisualArtifactRepository:
         ).fetchall()
         return tuple(_feedback_from_row(row) for row in rows)
 
+    def list_all_feedback(
+        self, *, reviewed_from: str | None = None, reviewed_to: str | None = None
+    ) -> tuple[VisualArtifactFeedbackRecord, ...]:
+        """Return feedback records across artifacts, optionally filtered by review time."""
+
+        predicates: list[str] = []
+        params: list[str] = []
+        if reviewed_from is not None:
+            predicates.append("reviewed_at >= ?")
+            params.append(reviewed_from)
+        if reviewed_to is not None:
+            predicates.append("reviewed_at <= ?")
+            params.append(reviewed_to)
+
+        where_clause = f" WHERE {' AND '.join(predicates)}" if predicates else ""
+        rows = self._connection.execute(
+            (
+                "SELECT artifact_id, is_informative, quality_rank, reviewer, reviewed_at, notes "
+                f"FROM visual_artifact_feedback{where_clause} "
+                "ORDER BY reviewed_at ASC, artifact_id ASC, reviewer ASC"
+            ),
+            tuple(params),
+        ).fetchall()
+        return tuple(_feedback_from_row(row) for row in rows)
+
 
 def _feedback_from_row(row: sqlite3.Row | tuple[Any, ...]) -> VisualArtifactFeedbackRecord:
     return VisualArtifactFeedbackRecord(

--- a/src/inv_man_intake/images/__init__.py
+++ b/src/inv_man_intake/images/__init__.py
@@ -8,7 +8,9 @@ from inv_man_intake.images.classifier import (
 from inv_man_intake.images.extractor import UnsupportedVisualSourceError, extract_visual_artifacts
 from inv_man_intake.images.feedback_report import (
     ArtifactFeedbackSummary,
+    FeedbackMetricDefinition,
     FeedbackSummaryReport,
+    feedback_summary_metric_definitions,
     generate_feedback_summary_report,
     render_feedback_summary_csv,
     render_feedback_summary_json,
@@ -29,6 +31,7 @@ __all__ = [
     "ArtifactFeedbackSummary",
     "ClassifiedVisualArtifact",
     "FeedbackWriteResult",
+    "FeedbackMetricDefinition",
     "FeedbackSummaryReport",
     "UnsupportedVisualSourceError",
     "VisualArtifactFeedbackService",
@@ -39,6 +42,7 @@ __all__ = [
     "classify_visual_artifacts",
     "extract_visual_artifacts",
     "extract_and_classify_visual_artifacts",
+    "feedback_summary_metric_definitions",
     "generate_feedback_summary_report",
     "render_feedback_summary_csv",
     "render_feedback_summary_json",

--- a/src/inv_man_intake/images/__init__.py
+++ b/src/inv_man_intake/images/__init__.py
@@ -6,6 +6,13 @@ from inv_man_intake.images.classifier import (
     classify_visual_artifact,
 )
 from inv_man_intake.images.extractor import UnsupportedVisualSourceError, extract_visual_artifacts
+from inv_man_intake.images.feedback_report import (
+    ArtifactFeedbackSummary,
+    FeedbackSummaryReport,
+    generate_feedback_summary_report,
+    render_feedback_summary_csv,
+    render_feedback_summary_json,
+)
 from inv_man_intake.images.feedback_service import (
     FeedbackWriteResult,
     VisualArtifactFeedbackService,
@@ -19,8 +26,10 @@ from inv_man_intake.images.service import (
 
 __all__ = [
     "ArtifactSource",
+    "ArtifactFeedbackSummary",
     "ClassifiedVisualArtifact",
     "FeedbackWriteResult",
+    "FeedbackSummaryReport",
     "UnsupportedVisualSourceError",
     "VisualArtifactFeedbackService",
     "VisualArtifactClassification",
@@ -30,4 +39,7 @@ __all__ = [
     "classify_visual_artifacts",
     "extract_visual_artifacts",
     "extract_and_classify_visual_artifacts",
+    "generate_feedback_summary_report",
+    "render_feedback_summary_csv",
+    "render_feedback_summary_json",
 ]

--- a/src/inv_man_intake/images/feedback_report.py
+++ b/src/inv_man_intake/images/feedback_report.py
@@ -53,6 +53,47 @@ class FeedbackSummaryReport:
     artifacts: tuple[ArtifactFeedbackSummary, ...]
 
 
+@dataclass(frozen=True)
+class FeedbackMetricDefinition:
+    """Canonical definition for one summary metric in feedback reports."""
+
+    key: str
+    description: str
+    level: str
+    formula: str
+
+
+SUMMARY_METRIC_DEFINITIONS: tuple[FeedbackMetricDefinition, ...] = (
+    FeedbackMetricDefinition(
+        key="informative_rate",
+        description="Share of feedback records marked informative.",
+        level="report,artifact",
+        formula="informative_count / feedback_count",
+    ),
+    FeedbackMetricDefinition(
+        key="quality_rank_distribution",
+        description="Count of feedback records by quality rank bucket (1-5).",
+        level="report,artifact",
+        formula="count(records where quality_rank == bucket) for each bucket",
+    ),
+    FeedbackMetricDefinition(
+        key="disagreement_rate",
+        description=(
+            "Share of multi-reviewer artifacts where reviewers disagree on informativeness "
+            "or differ by 2+ quality-rank points."
+        ),
+        level="report",
+        formula="disagreement_artifact_count / multi_reviewer_artifact_count",
+    ),
+)
+
+
+def feedback_summary_metric_definitions() -> tuple[FeedbackMetricDefinition, ...]:
+    """Return the canonical summary-metric definitions used by report consumers."""
+
+    return SUMMARY_METRIC_DEFINITIONS
+
+
 def generate_feedback_summary_report(
     repository: VisualArtifactRepository,
     *,

--- a/src/inv_man_intake/images/feedback_report.py
+++ b/src/inv_man_intake/images/feedback_report.py
@@ -1,0 +1,246 @@
+"""Aggregate visual-artifact feedback into tuning reports."""
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+from dataclasses import dataclass
+from statistics import mean
+
+from inv_man_intake.contracts.image_feedback_contract import MAX_QUALITY_RANK, MIN_QUALITY_RANK
+from inv_man_intake.data.provenance import VisualArtifactFeedbackRecord
+from inv_man_intake.data.repository import VisualArtifactRepository
+
+
+@dataclass(frozen=True)
+class ArtifactFeedbackSummary:
+    """Summary metrics for feedback attached to one visual artifact."""
+
+    artifact_id: str
+    feedback_count: int
+    reviewer_count: int
+    informative_count: int
+    boilerplate_count: int
+    informative_rate: float
+    average_quality_rank: float
+    quality_rank_distribution: dict[int, int]
+    first_reviewed_at: str
+    last_reviewed_at: str
+    disagreement: bool
+
+
+@dataclass(frozen=True)
+class FeedbackSummaryReport:
+    """Repository-wide feedback report for tuning workflows."""
+
+    generated_at: str
+    reviewed_from: str | None
+    reviewed_to: str | None
+    total_feedback_records: int
+    unique_artifacts_reviewed: int
+    reviewer_count: int
+    informative_count: int
+    boilerplate_count: int
+    informative_rate: float
+    average_quality_rank: float | None
+    quality_rank_distribution: dict[int, int]
+    first_reviewed_at: str | None
+    last_reviewed_at: str | None
+    multi_reviewer_artifact_count: int
+    disagreement_artifact_count: int
+    disagreement_rate: float
+    artifacts: tuple[ArtifactFeedbackSummary, ...]
+
+
+def generate_feedback_summary_report(
+    repository: VisualArtifactRepository,
+    *,
+    generated_at: str,
+    reviewed_from: str | None = None,
+    reviewed_to: str | None = None,
+) -> FeedbackSummaryReport:
+    """Generate aggregate feedback metrics from persisted reviewer records."""
+
+    records = repository.list_all_feedback(reviewed_from=reviewed_from, reviewed_to=reviewed_to)
+    artifacts = _summarize_artifacts(records)
+    informative_count = sum(1 for record in records if record.is_informative)
+    boilerplate_count = len(records) - informative_count
+    rank_distribution = _empty_rank_distribution()
+    for record in records:
+        rank_distribution[record.quality_rank] += 1
+
+    multi_reviewer_artifact_count = sum(1 for artifact in artifacts if artifact.reviewer_count > 1)
+    disagreement_artifact_count = sum(1 for artifact in artifacts if artifact.disagreement)
+
+    return FeedbackSummaryReport(
+        generated_at=generated_at,
+        reviewed_from=reviewed_from,
+        reviewed_to=reviewed_to,
+        total_feedback_records=len(records),
+        unique_artifacts_reviewed=len(artifacts),
+        reviewer_count=len({record.reviewer for record in records}),
+        informative_count=informative_count,
+        boilerplate_count=boilerplate_count,
+        informative_rate=_rate(informative_count, len(records)),
+        average_quality_rank=_average_rank(records),
+        quality_rank_distribution=rank_distribution,
+        first_reviewed_at=records[0].reviewed_at if records else None,
+        last_reviewed_at=records[-1].reviewed_at if records else None,
+        multi_reviewer_artifact_count=multi_reviewer_artifact_count,
+        disagreement_artifact_count=disagreement_artifact_count,
+        disagreement_rate=_rate(disagreement_artifact_count, multi_reviewer_artifact_count),
+        artifacts=artifacts,
+    )
+
+
+def render_feedback_summary_json(report: FeedbackSummaryReport) -> str:
+    """Render a feedback report as stable JSON."""
+
+    return json.dumps(_report_to_dict(report), indent=2, sort_keys=True) + "\n"
+
+
+def render_feedback_summary_csv(report: FeedbackSummaryReport) -> str:
+    """Render artifact-level feedback summary rows as CSV."""
+
+    output = io.StringIO()
+    writer = csv.DictWriter(
+        output,
+        fieldnames=[
+            "artifact_id",
+            "feedback_count",
+            "reviewer_count",
+            "informative_count",
+            "boilerplate_count",
+            "informative_rate",
+            "average_quality_rank",
+            "quality_rank_distribution",
+            "first_reviewed_at",
+            "last_reviewed_at",
+            "disagreement",
+        ],
+    )
+    writer.writeheader()
+    for artifact in report.artifacts:
+        writer.writerow(
+            {
+                "artifact_id": artifact.artifact_id,
+                "feedback_count": artifact.feedback_count,
+                "reviewer_count": artifact.reviewer_count,
+                "informative_count": artifact.informative_count,
+                "boilerplate_count": artifact.boilerplate_count,
+                "informative_rate": f"{artifact.informative_rate:.4f}",
+                "average_quality_rank": f"{artifact.average_quality_rank:.2f}",
+                "quality_rank_distribution": json.dumps(
+                    _rank_distribution_to_json(artifact.quality_rank_distribution),
+                    sort_keys=True,
+                ),
+                "first_reviewed_at": artifact.first_reviewed_at,
+                "last_reviewed_at": artifact.last_reviewed_at,
+                "disagreement": "true" if artifact.disagreement else "false",
+            }
+        )
+    return output.getvalue()
+
+
+def _summarize_artifacts(
+    records: tuple[VisualArtifactFeedbackRecord, ...],
+) -> tuple[ArtifactFeedbackSummary, ...]:
+    grouped: dict[str, list[VisualArtifactFeedbackRecord]] = {}
+    for record in records:
+        grouped.setdefault(record.artifact_id, []).append(record)
+
+    summaries: list[ArtifactFeedbackSummary] = []
+    for artifact_id in sorted(grouped):
+        artifact_records = sorted(
+            grouped[artifact_id], key=lambda item: (item.reviewed_at, item.reviewer)
+        )
+        informative_count = sum(1 for record in artifact_records if record.is_informative)
+        boilerplate_count = len(artifact_records) - informative_count
+        rank_distribution = _empty_rank_distribution()
+        for record in artifact_records:
+            rank_distribution[record.quality_rank] += 1
+        ranks = [record.quality_rank for record in artifact_records]
+        labels = {record.is_informative for record in artifact_records}
+        disagreement = len(artifact_records) > 1 and (
+            len(labels) > 1 or max(ranks) - min(ranks) >= 2
+        )
+        summaries.append(
+            ArtifactFeedbackSummary(
+                artifact_id=artifact_id,
+                feedback_count=len(artifact_records),
+                reviewer_count=len({record.reviewer for record in artifact_records}),
+                informative_count=informative_count,
+                boilerplate_count=boilerplate_count,
+                informative_rate=_rate(informative_count, len(artifact_records)),
+                average_quality_rank=mean(ranks),
+                quality_rank_distribution=rank_distribution,
+                first_reviewed_at=artifact_records[0].reviewed_at,
+                last_reviewed_at=artifact_records[-1].reviewed_at,
+                disagreement=disagreement,
+            )
+        )
+    return tuple(summaries)
+
+
+def _average_rank(records: tuple[VisualArtifactFeedbackRecord, ...]) -> float | None:
+    if not records:
+        return None
+    return mean(record.quality_rank for record in records)
+
+
+def _empty_rank_distribution() -> dict[int, int]:
+    return dict.fromkeys(range(MIN_QUALITY_RANK, MAX_QUALITY_RANK + 1), 0)
+
+
+def _rate(numerator: int, denominator: int) -> float:
+    if denominator == 0:
+        return 0.0
+    return numerator / denominator
+
+
+def _rank_distribution_to_json(distribution: dict[int, int]) -> dict[str, int]:
+    return {str(rank): count for rank, count in distribution.items()}
+
+
+def _report_to_dict(report: FeedbackSummaryReport) -> dict[str, object]:
+    return {
+        "generated_at": report.generated_at,
+        "reviewed_from": report.reviewed_from,
+        "reviewed_to": report.reviewed_to,
+        "summary": {
+            "total_feedback_records": report.total_feedback_records,
+            "unique_artifacts_reviewed": report.unique_artifacts_reviewed,
+            "reviewer_count": report.reviewer_count,
+            "informative_count": report.informative_count,
+            "boilerplate_count": report.boilerplate_count,
+            "informative_rate": report.informative_rate,
+            "average_quality_rank": report.average_quality_rank,
+            "quality_rank_distribution": _rank_distribution_to_json(
+                report.quality_rank_distribution
+            ),
+            "first_reviewed_at": report.first_reviewed_at,
+            "last_reviewed_at": report.last_reviewed_at,
+            "multi_reviewer_artifact_count": report.multi_reviewer_artifact_count,
+            "disagreement_artifact_count": report.disagreement_artifact_count,
+            "disagreement_rate": report.disagreement_rate,
+        },
+        "artifacts": [
+            {
+                "artifact_id": artifact.artifact_id,
+                "feedback_count": artifact.feedback_count,
+                "reviewer_count": artifact.reviewer_count,
+                "informative_count": artifact.informative_count,
+                "boilerplate_count": artifact.boilerplate_count,
+                "informative_rate": artifact.informative_rate,
+                "average_quality_rank": artifact.average_quality_rank,
+                "quality_rank_distribution": _rank_distribution_to_json(
+                    artifact.quality_rank_distribution
+                ),
+                "first_reviewed_at": artifact.first_reviewed_at,
+                "last_reviewed_at": artifact.last_reviewed_at,
+                "disagreement": artifact.disagreement,
+            }
+            for artifact in report.artifacts
+        ],
+    }

--- a/tests/data/test_visual_artifact_repository.py
+++ b/tests/data/test_visual_artifact_repository.py
@@ -7,7 +7,7 @@ import sqlite3
 import pytest
 
 from inv_man_intake.data.migrations.core_schema import apply_core_schema
-from inv_man_intake.data.provenance import VisualArtifactRecord
+from inv_man_intake.data.provenance import VisualArtifactFeedbackRecord, VisualArtifactRecord
 from inv_man_intake.data.repository import VisualArtifactRepository
 
 
@@ -146,3 +146,108 @@ def test_visual_artifact_repository_insert_is_idempotent_for_same_artifact() -> 
 
     rows = repo.list_artifacts("doc_1")
     assert [row.artifact_id for row in rows] == ["va_dup_1"]
+
+
+def _seed_feedback_for_bound_tests(repo: VisualArtifactRepository) -> None:
+    repo.ensure_schema()
+    repo.ensure_feedback_schema()
+    repo.insert_artifact(
+        VisualArtifactRecord(
+            artifact_id="va_bound_1",
+            document_id="doc_1",
+            source_type="pdf",
+            source_page=1,
+            source_slide=None,
+            source_ref="pdf-object-1",
+            storage_path="artifacts/doc_1/pdf/page-1/object.bin",
+            sha256="hash-bound-1",
+            mime_type="image/jpeg",
+            byte_size=1024,
+            extracted_at="2026-03-01T09:00:00Z",
+        )
+    )
+    for reviewed_at, reviewer in (
+        ("2026-03-01T09:30:00Z", "analyst-a"),
+        ("2026-03-01T10:30:00Z", "analyst-b"),
+        ("2026-03-01T11:30:00Z", "analyst-c"),
+    ):
+        repo.upsert_feedback(
+            VisualArtifactFeedbackRecord(
+                artifact_id="va_bound_1",
+                is_informative=True,
+                quality_rank=3,
+                reviewer=reviewer,
+                reviewed_at=reviewed_at,
+                notes=None,
+            )
+        )
+
+
+def test_list_all_feedback_normalizes_offset_bounds_to_canonical_utc() -> None:
+    repo = VisualArtifactRepository(_connection())
+    _seed_feedback_for_bound_tests(repo)
+
+    # Stored values are canonical `...Z`. Bounds passed as `+00:00` would
+    # otherwise lose the 10:30:00Z row to a raw TEXT comparison, since
+    # "2026-03-01T10:00:00+00:00" > "2026-03-01T10:00:00Z" lexicographically.
+    rows = repo.list_all_feedback(
+        reviewed_from="2026-03-01T10:00:00+00:00",
+        reviewed_to="2026-03-01T11:00:00+00:00",
+    )
+
+    assert [row.reviewer for row in rows] == ["analyst-b"]
+
+
+def test_list_all_feedback_normalizes_non_utc_offset_to_utc() -> None:
+    repo = VisualArtifactRepository(_connection())
+    _seed_feedback_for_bound_tests(repo)
+
+    # 11:30+02:00 == 09:30Z, 13:30+02:00 == 11:30Z; full inclusive range covers
+    # all three stored rows (09:30Z, 10:30Z, 11:30Z). The point of the test is
+    # that the +02:00 bounds are normalized rather than text-compared against
+    # the canonical `...Z` stored values.
+    rows = repo.list_all_feedback(
+        reviewed_from="2026-03-01T11:30:00+02:00",
+        reviewed_to="2026-03-01T13:30:00+02:00",
+    )
+
+    assert [row.reviewer for row in rows] == ["analyst-a", "analyst-b", "analyst-c"]
+
+    # Narrower window: 12:00+02:00 == 10:00Z, 13:00+02:00 == 11:00Z → only analyst-b.
+    rows = repo.list_all_feedback(
+        reviewed_from="2026-03-01T12:00:00+02:00",
+        reviewed_to="2026-03-01T13:00:00+02:00",
+    )
+
+    assert [row.reviewer for row in rows] == ["analyst-b"]
+
+
+def test_list_all_feedback_rejects_invalid_iso8601_bound() -> None:
+    repo = VisualArtifactRepository(_connection())
+    repo.ensure_schema()
+    repo.ensure_feedback_schema()
+
+    with pytest.raises(ValueError, match="reviewed_from must be ISO-8601"):
+        repo.list_all_feedback(reviewed_from="not-a-timestamp")
+    with pytest.raises(ValueError, match="reviewed_to must be ISO-8601"):
+        repo.list_all_feedback(reviewed_to="2026-13-99T99:99:99Z")
+
+
+def test_list_all_feedback_rejects_naive_bound() -> None:
+    repo = VisualArtifactRepository(_connection())
+    repo.ensure_schema()
+    repo.ensure_feedback_schema()
+
+    with pytest.raises(ValueError, match="reviewed_from must include timezone"):
+        repo.list_all_feedback(reviewed_from="2026-03-01T10:00:00")
+    with pytest.raises(ValueError, match="reviewed_to must include timezone"):
+        repo.list_all_feedback(reviewed_to="2026-03-01T11:00:00")
+
+
+def test_list_all_feedback_rejects_empty_bound() -> None:
+    repo = VisualArtifactRepository(_connection())
+    repo.ensure_schema()
+    repo.ensure_feedback_schema()
+
+    with pytest.raises(ValueError, match="reviewed_from must be a non-empty"):
+        repo.list_all_feedback(reviewed_from="   ")

--- a/tests/images/test_feedback_report.py
+++ b/tests/images/test_feedback_report.py
@@ -1,0 +1,161 @@
+"""Tests for visual-artifact feedback summary exports."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+
+from inv_man_intake.contracts.image_feedback_contract import ImageFeedbackRecord
+from inv_man_intake.data.migrations.core_schema import apply_core_schema
+from inv_man_intake.data.provenance import VisualArtifactRecord
+from inv_man_intake.data.repository import VisualArtifactRepository
+from inv_man_intake.images.feedback_report import (
+    generate_feedback_summary_report,
+    render_feedback_summary_csv,
+    render_feedback_summary_json,
+)
+from inv_man_intake.images.feedback_service import VisualArtifactFeedbackService
+
+
+def _repository() -> VisualArtifactRepository:
+    conn = sqlite3.connect(":memory:")
+    conn.execute("PRAGMA foreign_keys = ON")
+    apply_core_schema(conn)
+    conn.execute(
+        "INSERT INTO firms (firm_id, legal_name, aliases_json, created_at) VALUES (?, ?, ?, ?)",
+        ("firm_1", "Alpha Capital", None, "2026-03-01T08:00:00Z"),
+    )
+    conn.execute(
+        (
+            "INSERT INTO funds (fund_id, firm_id, fund_name, strategy, asset_class, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?)"
+        ),
+        (
+            "fund_1",
+            "firm_1",
+            "Alpha Fund",
+            "market_neutral",
+            "equity_market_neutral",
+            "2026-03-01T08:30:00Z",
+        ),
+    )
+    conn.execute(
+        (
+            "INSERT INTO documents (document_id, fund_id, file_name, file_hash, received_at, "
+            "version_date, source_channel, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
+        ),
+        (
+            "doc_1",
+            "fund_1",
+            "manager_deck.pdf",
+            "hash_doc_1",
+            "2026-03-01T09:00:00Z",
+            "2026-03-01",
+            "email",
+            "2026-03-01T09:00:00Z",
+        ),
+    )
+    conn.commit()
+    repo = VisualArtifactRepository(conn)
+    repo.ensure_schema()
+    for artifact_id, page in (("va_1", 2), ("va_2", 3)):
+        repo.insert_artifact(
+            VisualArtifactRecord(
+                artifact_id=artifact_id,
+                document_id="doc_1",
+                source_type="pdf",
+                source_page=page,
+                source_slide=None,
+                source_ref=f"pdf-object-{page}",
+                storage_path=f"artifacts/doc_1/pdf/page-{page}/object.bin",
+                sha256=f"hash-{artifact_id}",
+                mime_type="image/jpeg",
+                byte_size=1240,
+                extracted_at="2026-03-01T09:10:00Z",
+            )
+        )
+    repo.ensure_feedback_schema()
+    return repo
+
+
+def test_feedback_summary_report_calculates_metrics_and_disagreement() -> None:
+    repo = _repository()
+    service = VisualArtifactFeedbackService(repo)
+    for record in (
+        ImageFeedbackRecord(
+            artifact_id="va_1",
+            is_informative=True,
+            quality_rank=5,
+            reviewer="analyst-a",
+            timestamp="2026-03-01T10:00:00Z",
+        ),
+        ImageFeedbackRecord(
+            artifact_id="va_1",
+            is_informative=False,
+            quality_rank=2,
+            reviewer="analyst-b",
+            timestamp="2026-03-01T10:05:00Z",
+        ),
+        ImageFeedbackRecord(
+            artifact_id="va_2",
+            is_informative=True,
+            quality_rank=4,
+            reviewer="analyst-a",
+            timestamp="2026-03-01T11:00:00Z",
+        ),
+    ):
+        service.record_feedback(record)
+
+    report = generate_feedback_summary_report(repo, generated_at="2026-03-01T12:00:00Z")
+
+    assert report.total_feedback_records == 3
+    assert report.unique_artifacts_reviewed == 2
+    assert report.reviewer_count == 2
+    assert report.informative_rate == 2 / 3
+    assert report.quality_rank_distribution == {1: 0, 2: 1, 3: 0, 4: 1, 5: 1}
+    assert report.first_reviewed_at == "2026-03-01T10:00:00Z"
+    assert report.last_reviewed_at == "2026-03-01T11:00:00Z"
+    assert report.multi_reviewer_artifact_count == 1
+    assert report.disagreement_artifact_count == 1
+    assert report.disagreement_rate == 1.0
+    assert report.artifacts[0].artifact_id == "va_1"
+    assert report.artifacts[0].disagreement is True
+
+
+def test_feedback_summary_filters_by_review_timestamp_and_renders_exports() -> None:
+    repo = _repository()
+    service = VisualArtifactFeedbackService(repo)
+    service.record_feedback(
+        ImageFeedbackRecord(
+            artifact_id="va_1",
+            is_informative=True,
+            quality_rank=5,
+            reviewer="analyst-a",
+            timestamp="2026-03-01T09:59:00Z",
+        )
+    )
+    service.record_feedback(
+        ImageFeedbackRecord(
+            artifact_id="va_2",
+            is_informative=False,
+            quality_rank=1,
+            reviewer="analyst-b",
+            timestamp="2026-03-01T10:30:00Z",
+        )
+    )
+
+    report = generate_feedback_summary_report(
+        repo,
+        generated_at="2026-03-01T12:00:00Z",
+        reviewed_from="2026-03-01T10:00:00Z",
+        reviewed_to="2026-03-01T11:00:00Z",
+    )
+
+    payload = json.loads(render_feedback_summary_json(report))
+    csv_payload = render_feedback_summary_csv(report)
+
+    assert payload["summary"]["total_feedback_records"] == 1
+    assert payload["summary"]["quality_rank_distribution"]["1"] == 1
+    assert payload["artifacts"][0]["artifact_id"] == "va_2"
+    assert "artifact_id,feedback_count,reviewer_count" in csv_payload
+    assert "va_2,1,1,0,1,0.0000,1.00" in csv_payload

--- a/tests/images/test_feedback_report.py
+++ b/tests/images/test_feedback_report.py
@@ -177,3 +177,75 @@ def test_feedback_summary_metric_definitions_cover_required_summary_metrics() ->
         by_key["disagreement_rate"].formula
         == "disagreement_artifact_count / multi_reviewer_artifact_count"
     )
+
+
+def test_feedback_summary_aggregation_on_synthetic_dataset() -> None:
+    repo = _repository()
+    service = VisualArtifactFeedbackService(repo)
+    repo.insert_artifact(
+        VisualArtifactRecord(
+            artifact_id="va_3",
+            document_id="doc_1",
+            source_type="pdf",
+            source_page=4,
+            source_slide=None,
+            source_ref="pdf-object-4",
+            storage_path="artifacts/doc_1/pdf/page-4/object.bin",
+            sha256="hash-va_3",
+            mime_type="image/jpeg",
+            byte_size=1440,
+            extracted_at="2026-03-01T09:20:00Z",
+        )
+    )
+
+    for record in (
+        ImageFeedbackRecord(
+            artifact_id="va_1",
+            is_informative=True,
+            quality_rank=4,
+            reviewer="analyst-a",
+            timestamp="2026-03-01T10:00:00Z",
+        ),
+        ImageFeedbackRecord(
+            artifact_id="va_1",
+            is_informative=True,
+            quality_rank=5,
+            reviewer="analyst-b",
+            timestamp="2026-03-01T10:01:00Z",
+        ),
+        ImageFeedbackRecord(
+            artifact_id="va_2",
+            is_informative=False,
+            quality_rank=2,
+            reviewer="analyst-a",
+            timestamp="2026-03-01T10:02:00Z",
+        ),
+        ImageFeedbackRecord(
+            artifact_id="va_2",
+            is_informative=False,
+            quality_rank=3,
+            reviewer="analyst-b",
+            timestamp="2026-03-01T10:03:00Z",
+        ),
+        ImageFeedbackRecord(
+            artifact_id="va_3",
+            is_informative=True,
+            quality_rank=1,
+            reviewer="analyst-c",
+            timestamp="2026-03-01T10:04:00Z",
+        ),
+    ):
+        service.record_feedback(record)
+
+    report = generate_feedback_summary_report(repo, generated_at="2026-03-01T12:00:00Z")
+
+    assert report.total_feedback_records == 5
+    assert report.unique_artifacts_reviewed == 3
+    assert report.reviewer_count == 3
+    assert report.informative_count == 3
+    assert report.boilerplate_count == 2
+    assert report.informative_rate == 3 / 5
+    assert report.quality_rank_distribution == {1: 1, 2: 1, 3: 1, 4: 1, 5: 1}
+    assert report.multi_reviewer_artifact_count == 2
+    assert report.disagreement_artifact_count == 0
+    assert report.disagreement_rate == 0.0

--- a/tests/images/test_feedback_report.py
+++ b/tests/images/test_feedback_report.py
@@ -10,6 +10,7 @@ from inv_man_intake.data.migrations.core_schema import apply_core_schema
 from inv_man_intake.data.provenance import VisualArtifactRecord
 from inv_man_intake.data.repository import VisualArtifactRepository
 from inv_man_intake.images.feedback_report import (
+    feedback_summary_metric_definitions,
     generate_feedback_summary_report,
     render_feedback_summary_csv,
     render_feedback_summary_json,
@@ -159,3 +160,20 @@ def test_feedback_summary_filters_by_review_timestamp_and_renders_exports() -> N
     assert payload["artifacts"][0]["artifact_id"] == "va_2"
     assert "artifact_id,feedback_count,reviewer_count" in csv_payload
     assert "va_2,1,1,0,1,0.0000,1.00" in csv_payload
+
+
+def test_feedback_summary_metric_definitions_cover_required_summary_metrics() -> None:
+    definitions = feedback_summary_metric_definitions()
+    by_key = {definition.key: definition for definition in definitions}
+
+    assert tuple(by_key) == (
+        "informative_rate",
+        "quality_rank_distribution",
+        "disagreement_rate",
+    )
+    assert by_key["informative_rate"].formula == "informative_count / feedback_count"
+    assert by_key["quality_rank_distribution"].level == "report,artifact"
+    assert (
+        by_key["disagreement_rate"].formula
+        == "disagreement_artifact_count / multi_reviewer_artifact_count"
+    )

--- a/tests/images/test_image_feedback_report_script.py
+++ b/tests/images/test_image_feedback_report_script.py
@@ -113,3 +113,32 @@ def test_image_feedback_report_bundle_writes_json_and_csv(tmp_path: Path) -> Non
     payload = json.loads(json_files[0].read_text(encoding="utf-8"))
     assert payload["summary"]["total_feedback_records"] == 1
     assert "artifact_id,feedback_count,reviewer_count" in csv_files[0].read_text(encoding="utf-8")
+
+
+def test_image_feedback_report_scheduled_daily_defaults_to_last_24_hours(tmp_path: Path) -> None:
+    database_path = tmp_path / "feedback.sqlite"
+    _seed_database(database_path)
+    bundle_dir = tmp_path / "scheduled"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/image_feedback_report.py",
+            "--database",
+            str(database_path),
+            "--scheduled-daily",
+            "--bundle-dir",
+            str(bundle_dir),
+            "--reviewed-to",
+            "2026-03-01T11:00:00Z",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    payload = json.loads(sorted(bundle_dir.glob("image-feedback-*.json"))[0].read_text("utf-8"))
+    assert payload["reviewed_from"] == "2026-02-28T11:00:00Z"
+    assert payload["reviewed_to"] == "2026-03-01T11:00:00Z"
+    assert payload["summary"]["total_feedback_records"] == 1

--- a/tests/images/test_image_feedback_report_script.py
+++ b/tests/images/test_image_feedback_report_script.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+from inv_man_intake.contracts.image_feedback_contract import ImageFeedbackRecord
+from inv_man_intake.data.migrations.core_schema import apply_core_schema
+from inv_man_intake.data.provenance import VisualArtifactRecord
+from inv_man_intake.data.repository import VisualArtifactRepository
+from inv_man_intake.images.feedback_service import VisualArtifactFeedbackService
+
+
+def _seed_database(path: Path) -> None:
+    with sqlite3.connect(path) as conn:
+        conn.execute("PRAGMA foreign_keys = ON")
+        apply_core_schema(conn)
+        conn.execute(
+            "INSERT INTO firms (firm_id, legal_name, aliases_json, created_at) VALUES (?, ?, ?, ?)",
+            ("firm_1", "Alpha Capital", None, "2026-03-01T08:00:00Z"),
+        )
+        conn.execute(
+            (
+                "INSERT INTO funds (fund_id, firm_id, fund_name, strategy, asset_class, created_at) "
+                "VALUES (?, ?, ?, ?, ?, ?)"
+            ),
+            (
+                "fund_1",
+                "firm_1",
+                "Alpha Fund",
+                "market_neutral",
+                "equity_market_neutral",
+                "2026-03-01T08:30:00Z",
+            ),
+        )
+        conn.execute(
+            (
+                "INSERT INTO documents (document_id, fund_id, file_name, file_hash, received_at, "
+                "version_date, source_channel, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
+            ),
+            (
+                "doc_1",
+                "fund_1",
+                "manager_deck.pdf",
+                "hash_doc_1",
+                "2026-03-01T09:00:00Z",
+                "2026-03-01",
+                "email",
+                "2026-03-01T09:00:00Z",
+            ),
+        )
+        conn.commit()
+
+        repo = VisualArtifactRepository(conn)
+        repo.ensure_schema()
+        repo.insert_artifact(
+            VisualArtifactRecord(
+                artifact_id="va_1",
+                document_id="doc_1",
+                source_type="pdf",
+                source_page=1,
+                source_slide=None,
+                source_ref="pdf-object-1",
+                storage_path="artifacts/doc_1/pdf/page-1/object.bin",
+                sha256="hash-va-1",
+                mime_type="image/jpeg",
+                byte_size=128,
+                extracted_at="2026-03-01T09:10:00Z",
+            )
+        )
+        repo.ensure_feedback_schema()
+        service = VisualArtifactFeedbackService(repo)
+        service.record_feedback(
+            ImageFeedbackRecord(
+                artifact_id="va_1",
+                is_informative=True,
+                quality_rank=5,
+                reviewer="analyst-a",
+                timestamp="2026-03-01T10:00:00Z",
+            )
+        )
+
+
+def test_image_feedback_report_bundle_writes_json_and_csv(tmp_path: Path) -> None:
+    database_path = tmp_path / "feedback.sqlite"
+    _seed_database(database_path)
+    bundle_dir = tmp_path / "reports"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/image_feedback_report.py",
+            "--database",
+            str(database_path),
+            "--bundle-dir",
+            str(bundle_dir),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert result.stdout == ""
+
+    json_files = sorted(bundle_dir.glob("image-feedback-*.json"))
+    csv_files = sorted(bundle_dir.glob("image-feedback-*.csv"))
+    assert len(json_files) == 1
+    assert len(csv_files) == 1
+
+    payload = json.loads(json_files[0].read_text(encoding="utf-8"))
+    assert payload["summary"]["total_feedback_records"] == 1
+    assert "artifact_id,feedback_count,reviewer_count" in csv_files[0].read_text(encoding="utf-8")

--- a/tests/images/test_image_feedback_tuning_runbook.py
+++ b/tests/images/test_image_feedback_tuning_runbook.py
@@ -1,0 +1,27 @@
+"""Guardrails for image feedback tuning runbook completeness."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+DOC_PATH = Path("docs/runbooks/image_feedback_tuning.md")
+
+
+REQUIRED_TOKENS = (
+    "python scripts/image_feedback_report.py",
+    "--reviewed-from",
+    "--reviewed-to",
+    "informative_rate",
+    "quality_rank_distribution",
+    "disagreement_rate",
+    "Interpretation guidance for tuning decisions",
+    "minimum sample-size guard",
+    "Recommended tuning loop",
+)
+
+
+def test_image_feedback_tuning_runbook_covers_generation_and_consumption() -> None:
+    text = DOC_PATH.read_text(encoding="utf-8")
+
+    for token in REQUIRED_TOKENS:
+        assert token in text

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,5 +1,39 @@
 # Workloop State
 
+## 2026-05-11T03:18:00Z - opener lane issue #27 feedback report materialization
+
+- Automation: `pd-workloop-resume` (codex opener lane).
+- Source repo: `stranske/Inv-Man-Intake`.
+- Source issue: `#27` (`Image feedback summary export and tuning report`, `priority:normal`).
+- Source PR: `#415` (`https://github.com/stranske/Inv-Man-Intake/pull/415`), non-draft, labels `agent:codex` + `agents:keepalive` + `autofix`.
+- Branch: `codex/issue-27-feedback-report`.
+- Selection:
+  - ACTION A succeeded from the neutral Code workspace; sentinel `active.*` pointed at closer/verifier state and was treated as cross-lane informational state only.
+  - Required priority discovery ran across supported repos. High-priority only contained the Workflows auth-expiry ops alert, which was skipped. `Inv-Man-Intake#27` was selected as the oldest actionable normal-priority issue after dependency PR `#413/#26` merged to main at `2026-05-11T02:53:23Z`.
+  - Cap-health after infra repair reported `total_opener_owned=2`, `raw_cap_reached=false`, `normal_cap_reached=false`, and `non_drainable_cap_blocker=false`. The repair helper removed stale `agent:needs-attention` from `#411`.
+- Implementation:
+  - Added repository-wide feedback listing with optional timestamp bounds.
+  - Added feedback summary aggregation for informative rate, rank distribution, timestamp range, reviewer count, and disagreement rate.
+  - Added JSON and artifact-level CSV renderers plus `scripts/image_feedback_report.py` for manual report generation.
+  - Added `docs/runbooks/image_feedback_tuning.md` and linked it from the visual artifact extraction runbook.
+- Validation passed:
+  - `python -m pytest tests/images/test_feedback_report.py tests/images/test_feedback_service.py tests/data/test_visual_artifact_repository.py --no-cov` (`12 passed`).
+  - `python -m ruff check src/inv_man_intake/images/feedback_report.py src/inv_man_intake/images/__init__.py src/inv_man_intake/data/repository.py tests/images/test_feedback_report.py scripts/image_feedback_report.py`.
+  - `python -m black --check --line-length 100 src/inv_man_intake/images/feedback_report.py src/inv_man_intake/images/__init__.py src/inv_man_intake/data/repository.py tests/images/test_feedback_report.py scripts/image_feedback_report.py`.
+  - `python -m mypy src/inv_man_intake/images/feedback_report.py src/inv_man_intake/images/__init__.py src/inv_man_intake/data/repository.py`.
+- Relay event emitted: `pr_opened active.source_repo=stranske/Inv-Man-Intake active.source_issue=27 active.source_pr=415 active.next_action=wait_for_keepalive`.
+- Next action: keepalive's Codex runner takes over for CI fixups or review-comment work; opener is done with this lane.
+
+## 2026-05-11T03:05:00Z - closer merged #413 (feedback service) and #411 (epic delivery container)
+
+- Automation: `imi-merge-verify-closer` (claude_code closer lane, user-directed "take care of remaining Inv-Man-Intake work").
+- Two PRs merged this round:
+  - **`#413/#26`** (visual artifact feedback service) MERGED at `2026-05-11T02:53:23Z` (commit `0f813ce`). Resolved 4 Copilot review threads. Pushed `35f60e4 Fix #413: validate required fields before timestamp normalization` to fix a test that codex's prior commit had broken (whitespace timestamp now needs to surface "is required" not "must be ISO-8601"). Applied `verify:compare`; emitted `pr_merged` + `verify_label_applied`; reopened `#26` with sequencing comment.
+  - **`#411/#7`** (epic v1 delivery container) MERGED at `2026-05-11T03:03:56Z` (commit `fc57ef8`). Updated issue #7 body to add child-issue task links (validator confirmed). Pushed `4896e25 Fix #411: make epic-task-links test hermetic` to monkeypatch `_load_issue_body_from_github` (the test was implicitly depending on remote state of issue #7, which I just fixed). Rebased on main; merged on CLEAN. Applied `verify:compare`; emitted `pr_merged` + `verify_label_applied`; removed `agent:codex` from #7 then reopened with sequencing + remaining-human-deferred comment.
+- Remaining human-deferred work on `#7`: AC `docs/INV_MAN_INTAKE_PLAN_V1.md` section "Dependency Graph" or "Execution Order" with dependency arrows between #8-#15. This explicitly requires a technical lead / architect decision per the issue body.
+- Relay events: `pr_merged` x2, `verify_label_applied` x2, `record-batch-sweep`.
+- Next closer action: watch verifier on `#413` and `#411`. For `#413`, close `#26` on PASS/PASS. For `#411`, even with verifier PASS, leave `#7` open until the human-deferred dependency-graph AC is addressed.
+
 ## 2026-05-11T02:34:30Z - opener lane issue #26 PR materialization
 
 - Automation: `pd-workloop-resume` (codex opener lane).


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:27 -->
> **Source:** Issue #27

Closes #27

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Feedback data must be operationalized into a reportable artifact so heuristics and future model updates are evidence-based.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#10](https://github.com/stranske/Inv-Man-Intake/issues/10)
- [#7](https://github.com/stranske/Inv-Man-Intake/issues/7)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [x] Define summary metrics (informative rate, rank distribution, disagreement rate)
- [x] Implement export generator (CSV/JSON)
- [x] Add scheduled/manual execution path for report generation
- [x] Add tests for aggregation correctness
- [x] Document interpretation guidance for tuning decisions

#### Acceptance criteria
- [x] Summary export is generated from stored feedback records
- [x] Export includes agreed key metrics and timestamp range
- [x] Aggregation tests validate calculations on synthetic datasets
- [x] Runbook documents how to generate and consume reports

<!-- auto-status-summary:end -->