### PR TITLE
chore: sync workflow templates

### DIFF
--- a/.github/workflows/maint-76-claude-code-review.yml
+++ b/.github/workflows/maint-76-claude-code-review.yml
@@ -188,7 +188,7 @@ jobs:
       - name: Run Claude Code Review
         id: claude
         continue-on-error: true
-        uses: anthropics/claude-code-action@567fe954a4527e81f132d87d1bdbcc94f7737434 # v1
+        uses: anthropics/claude-code-action@dde2242db6af13460b916652159b6ba19a598f30 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_bots: '*'


### PR DESCRIPTION
## Sync Summary

### Files Updated
- maint-76-claude-code-review.yml: Claude Code review (opt-in) - runs only on labeled PRs or manual dispatch

### Files Skipped
- pr-00-gate.yml: File exists and sync_mode is create_only
- ci.yml: File exists and sync_mode is create_only
- dependabot.yml: File exists and sync_mode is create_only
- llm_slots.json: None

---

### Review Checklist
- [ ] CI passes with updated workflows
- [ ] No repo-specific customizations were overwritten

**Source:** stranske/Workflows
**Source SHA:** `3365ea99cf254fdbe7ec244041a32209cbf42dd9`
**Template hash:** `6d4ecf413c7c`
**Sync branch:** `sync/workflows-6d4ecf413c7c`
**Consumer repo:** `stranske/Inv-Man-Intake`
**Manifest:** `.github/sync-manifest.yml`

<!-- workflows-consumer-sync:v1 {"schema":"workflows-consumer-sync-pr/v1","consumer_repo":"stranske/Inv-Man-Intake","source_repository":"stranske/Workflows","source_sha":"3365ea99cf254fdbe7ec244041a32209cbf42dd9","template_hash":"6d4ecf413c7c","sync_branch":"sync/workflows-6d4ecf413c7c","manifest":".github/sync-manifest.yml","lifecycle_state":"opened","run_id":"25733646443","run_attempt":"1","changes_count":1} -->