### PR TITLE
Issue #423: add image classification to smoke audit inventory

### DIFF
--- a/docs/reports/v1_smoke_contract_audit.md
+++ b/docs/reports/v1_smoke_contract_audit.md
@@ -32,6 +32,7 @@ The v1 smoke audit enumerates every contract under `docs/contracts/` and marks w
 | `docs/contracts/provenance_history.md` | yes | Source-location trace row in scope; correction history row outside v1 smoke. |
 | `docs/contracts/core_schema_migration.md` | yes | Audited as outside v1 smoke because migration runner is not invoked. |
 | `docs/contracts/agent-runner-output.md` | yes | Audited as outside v1 smoke because runner artifact contract is not invoked. |
+| `docs/contracts/image_classification.md` | yes | Audited as not-exercised by v1 acceptance smoke; dedicated coverage lives in `tests/images/` for classifier, feedback, extractor, service, and report behavior. |
 
 ## Converged Follow-Up Mapping
 

--- a/tests/v1/test_smoke_contract_coverage.py
+++ b/tests/v1/test_smoke_contract_coverage.py
@@ -177,6 +177,7 @@ def test_v1_smoke_contract_audit_enumerates_contract_files_in_scope() -> None:
         "docs/contracts/provenance_history.md",
         "docs/contracts/core_schema_migration.md",
         "docs/contracts/agent-runner-output.md",
+        "docs/contracts/image_classification.md",
     )
     for contract_file in expected_contract_files:
         assert contract_file in audit


### PR DESCRIPTION
Closes #423

## Summary
- Add `docs/contracts/image_classification.md` to the v1 smoke audit contract inventory.
- Extend the regression guard so omitted contract files are caught.
- Mark image classification as not exercised by v1 acceptance smoke while citing dedicated `tests/images/` coverage.

## Validation
- `pytest tests/v1/test_smoke_contract_coverage.py::test_v1_smoke_contract_audit_enumerates_contract_files_in_scope -x` failed after the guard-only change, as expected.
- `pytest tests/v1/test_smoke_contract_coverage.py::test_v1_smoke_contract_audit_enumerates_contract_files_in_scope --no-cov` passed after the audit row.
- `pytest tests/v1/test_smoke_contract_coverage.py --no-cov` passed.
- `find docs/contracts -maxdepth 1 -type f | wc -l` returned 12.
- `rg 'image_classification' docs/reports/v1_smoke_contract_audit.md` returns the new row.
- `git diff --check` passed.