### PR TITLE
Issue #438: Add LangSmith fleet metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The v1 design target is documented in
 - Performance normalization, metric calculation, and source-conflict escalation.
 - Analyst-first validation queue states, ownership, SLA, audit, and API contracts.
 - Configurable scoring weights, score explainability, red-flag hooks, and regression fixtures.
-- Observability helpers for tracing, LangSmith export, logging, metrics, and setup validation.
+- Observability helpers for tracing, LangSmith export, fleet dashboard records, logging, metrics, and setup validation.
 
 ## Quick Start
 
@@ -64,10 +64,14 @@ Inv-Man-Intake/
 ```bash
 pytest
 pytest tests/observability/test_pipeline_smoke.py --no-cov
+pytest tests/observability/test_langsmith_fleet.py --no-cov
 python -m inv_man_intake.readiness.throughput --output reports/readiness/throughput_readiness.json
 ruff check src/ tests/
 mypy
 ```
+
+LangSmith runtime setup and dashboard artifact fields are documented in
+[`docs/runbooks/langsmith_tracing.md`](docs/runbooks/langsmith_tracing.md).
 
 For the current implementation sequence and milestone traceability, see
 [`docs/ISSUE_EXECUTION_SEQUENCE.md`](docs/ISSUE_EXECUTION_SEQUENCE.md).

--- a/docs/runbooks/langsmith_tracing.md
+++ b/docs/runbooks/langsmith_tracing.md
@@ -10,6 +10,8 @@ Provide reusable tracing wrappers that can be enabled or disabled without changi
 - `Tracer`: starts spans when enabled
 - `InMemoryTraceSink`: local sink for tests/dev
 - `LangSmithTraceSink`: runtime sink that exports spans through `langsmith.Client`
+- `langsmith_fleet`: builds dashboard-safe `langsmith-fleet/v1` records for
+  package-level intake, extraction, validation/escalation, and scoring summaries
 - `NoopSpan`: safe no-op when tracing is disabled
 
 ## Usage Pattern
@@ -60,10 +62,29 @@ Example shell setup:
 
 ```bash
 export LANGSMITH_API_KEY="lsv2_pt_..."
-export LANGSMITH_PROJECT="inv-man-intake-dev"
+export LANGSMITH_PROJECT="inv-man-intake"
 export LANGCHAIN_TRACING_V2="true"
 export INV_MAN_TRACING_ENABLED="true"
 ```
+
+When `LANGSMITH_API_KEY` is present, the repository defaults `LANGSMITH_PROJECT`
+and `LANGCHAIN_PROJECT` to `inv-man-intake` and mirrors the key into
+`LANGCHAIN_API_KEY` for LangChain-compatible clients. Without a key, tracing
+and fleet record creation stay offline-safe and records use status `no_secret`.
+
+## Fleet Dashboard Artifact
+
+Package-level runs can emit `langsmith-fleet.ndjson` records that match the
+Workflows-owned `langsmith-fleet/v1` contract for
+`stranske/Inv-Man-Intake#438`. Records include shared fields (`repo`, `surface`,
+`operation`, `run_id`, `status`, `trace_id`) plus a `domain` block with package,
+document, redaction, extraction-count, validation, confidence/escalation, retry,
+score, and review queue outcome fields.
+
+The artifact intentionally avoids raw manager documents, source text, extracted
+values, prompts, or model outputs. Use stable document/package identifiers,
+counts, statuses, trace references, and `artifact:<relative-path>` pointers
+instead.
 
 Optional explicit toggle (equivalent behavior):
 
@@ -94,7 +115,7 @@ export LANGSMITH_TRACING_ENABLED="true"
 2. Re-run setup validation with the probe enabled:
    - `python -m inv_man_intake.observability.setup_validation --require-project --probe`
 3. Confirm toggles and mocked client export resolve as enabled in tests:
-   - `pytest -q tests/observability/test_setup_validation.py tests/observability/test_langsmith_export.py tests/observability/test_tracing_toggle.py --no-cov`
+   - `pytest -q tests/observability/test_setup_validation.py tests/observability/test_langsmith_export.py tests/observability/test_langsmith_fleet.py tests/observability/test_tracing_toggle.py --no-cov`
 4. Verify application code uses `Tracer.from_env(...)`; local/offline smoke code may still pass an explicit `InMemoryTraceSink`.
 
 ## Missing Metrics Troubleshooting

--- a/src/inv_man_intake/extraction/orchestrator.py
+++ b/src/inv_man_intake/extraction/orchestrator.py
@@ -43,6 +43,7 @@ class OrchestrationResult:
     attempts: list[AttemptRecord]
     retry_count: int
     failure_count: int
+    correlation_id: str | None = None
     escalation_route: str | None = None
     escalation_reason: str | None = None
     escalation_payload: dict[str, Any] | None = None
@@ -82,16 +83,17 @@ class ExtractionOrchestrator:
         fallback_attempts = 0
         last_error: str | None = None
         context = trace_context or new_trace_context(tags={"pipeline_stage": "extract"})
+        correlation_id = self._resolve_correlation_id(payload=payload, context=context)
 
         with self._tracer.start_run(
             name="extraction_orchestrator.run",
             context=context,
-            metadata={"item_id": payload.get("id")},
+            metadata={"item_id": payload.get("id"), "correlation_id": correlation_id},
         ):
             with self._tracer.start_span(
                 name="extraction_orchestrator.primary_attempt",
                 context=context,
-                metadata={"provider": self._primary.name},
+                metadata={"provider": self._primary.name, "correlation_id": correlation_id},
             ):
                 primary_result, primary_error = self._attempt(self._primary, payload)
             attempts.append(
@@ -109,6 +111,7 @@ class ExtractionOrchestrator:
                     attempts=attempts,
                     retry_count=retry_count,
                     failure_count=0,
+                    correlation_id=correlation_id,
                 )
                 self._emit_metrics(result)
                 return result
@@ -122,6 +125,7 @@ class ExtractionOrchestrator:
                     attempts=attempts,
                     retry_count=retry_count,
                     reason=last_error,
+                    correlation_id=correlation_id,
                 )
                 self._emit_metrics(result)
                 return result
@@ -132,7 +136,7 @@ class ExtractionOrchestrator:
                 with self._tracer.start_span(
                     name="extraction_orchestrator.fallback_attempt",
                     context=context,
-                    metadata={"provider": self._fallback.name},
+                    metadata={"provider": self._fallback.name, "correlation_id": correlation_id},
                 ):
                     fallback_result, fallback_error = self._attempt(self._fallback, payload)
                 fallback_attempts += 1
@@ -153,6 +157,7 @@ class ExtractionOrchestrator:
                         attempts=attempts,
                         retry_count=retry_count,
                         failure_count=len(failed_attempts),
+                        correlation_id=correlation_id,
                     )
                     self._emit_metrics(result)
                     return result
@@ -163,6 +168,7 @@ class ExtractionOrchestrator:
                 attempts=attempts,
                 retry_count=retry_count,
                 reason=last_error,
+                correlation_id=correlation_id,
             )
             self._emit_metrics(result)
             return result
@@ -193,6 +199,7 @@ class ExtractionOrchestrator:
         attempts: list[AttemptRecord],
         retry_count: int,
         reason: str | None,
+        correlation_id: str | None,
     ) -> OrchestrationResult:
         escalation_reason = reason or "extraction-unresolved"
         escalation_route = ExtractionOrchestrator._resolve_escalation_route(attempts=attempts)
@@ -203,6 +210,7 @@ class ExtractionOrchestrator:
             attempts=attempts,
             retry_count=retry_count,
             failure_count=len(attempts),
+            correlation_id=correlation_id,
             escalation_route=escalation_route,
             escalation_reason=escalation_reason,
             escalation_payload=ExtractionOrchestrator._build_escalation_payload(
@@ -211,6 +219,7 @@ class ExtractionOrchestrator:
                 retry_count=retry_count,
                 escalation_route=escalation_route,
                 escalation_reason=escalation_reason,
+                correlation_id=correlation_id,
             ),
         )
 
@@ -222,6 +231,7 @@ class ExtractionOrchestrator:
         retry_count: int,
         escalation_route: str,
         escalation_reason: str,
+        correlation_id: str | None,
     ) -> dict[str, Any]:
         failed_attempts = [attempt for attempt in attempts if not attempt.success]
         return {
@@ -231,9 +241,20 @@ class ExtractionOrchestrator:
             "escalation_reason": escalation_reason,
             "retry_count": retry_count,
             "failure_count": len(failed_attempts),
+            "correlation_id": correlation_id,
             "failed_providers": [attempt.provider for attempt in failed_attempts],
             "errors": [attempt.error for attempt in failed_attempts if attempt.error],
         }
+
+    @staticmethod
+    def _resolve_correlation_id(*, payload: dict[str, Any], context: TraceContext) -> str | None:
+        from_payload = payload.get("correlation_id")
+        if isinstance(from_payload, str) and from_payload.strip():
+            return from_payload.strip()
+        from_tags = context.tags.get("correlation_id")
+        if isinstance(from_tags, str) and from_tags.strip():
+            return from_tags.strip()
+        return None
 
     @staticmethod
     def _resolve_escalation_route(*, attempts: list[AttemptRecord]) -> str:
@@ -253,5 +274,6 @@ class ExtractionOrchestrator:
                 "provider_used": result.provider_used,
                 "retry_count": result.retry_count,
                 "failure_count": result.failure_count,
+                "correlation_id": result.correlation_id,
             }
         )

--- a/src/inv_man_intake/observability/__init__.py
+++ b/src/inv_man_intake/observability/__init__.py
@@ -1,5 +1,19 @@
 """Observability utilities for trace and metric instrumentation."""
 
+from .langsmith_fleet import (
+    ARTIFACT_NAME,
+    DEFAULT_PROJECT,
+    GITHUB_ISSUE,
+    REPO,
+    SCHEMA_VERSION,
+    SURFACE,
+    FleetRunContext,
+    IntakeFleetSummary,
+    build_fleet_records,
+    build_summary_from_pipeline,
+    ensure_langsmith_project_defaults,
+    write_fleet_records,
+)
 from .langsmith_sink import LangSmithTraceSink
 from .logging import (
     CORRELATION_ID_KEY,
@@ -45,6 +59,11 @@ __all__ = [
     "FALLBACK_COUNT",
     "InMemoryMetrics",
     "InMemoryTraceSink",
+    "ARTIFACT_NAME",
+    "DEFAULT_PROJECT",
+    "FleetRunContext",
+    "GITHUB_ISSUE",
+    "IntakeFleetSummary",
     "LANGSMITH_API_KEY_ENV_KEY",
     "LANGSMITH_PROJECT_ENV_KEY",
     "LangSmithTraceSink",
@@ -53,14 +72,20 @@ __all__ = [
     "LATENCY_MS",
     "LogContext",
     "MetricPoint",
+    "REPO",
+    "SCHEMA_VERSION",
+    "SURFACE",
     "TRACE_ENABLED_ENV_KEY",
     "TraceContext",
     "TraceEvent",
     "Tracer",
+    "build_fleet_records",
+    "build_summary_from_pipeline",
     "build_log_record",
     "child_run_context",
     "child_trace_context",
     "ensure_correlation_id",
+    "ensure_langsmith_project_defaults",
     "extract_correlation_id",
     "extract_trace_context",
     "inject_correlation_id",
@@ -70,4 +95,5 @@ __all__ = [
     "traced_run",
     "traced_span",
     "tracing_enabled_from_env",
+    "write_fleet_records",
 ]

--- a/src/inv_man_intake/observability/__init__.py
+++ b/src/inv_man_intake/observability/__init__.py
@@ -1,5 +1,6 @@
 """Observability utilities for trace and metric instrumentation."""
 
+from .entrypoints import PipelineEntrypoint, audit_intake_extraction_entrypoints
 from .langsmith_fleet import (
     ARTIFACT_NAME,
     DEFAULT_PROJECT,
@@ -14,7 +15,6 @@ from .langsmith_fleet import (
     ensure_langsmith_project_defaults,
     write_fleet_records,
 )
-from .entrypoints import PipelineEntrypoint, audit_intake_extraction_entrypoints
 from .langsmith_sink import LangSmithTraceSink
 from .logging import (
     CORRELATION_ID_KEY,

--- a/src/inv_man_intake/observability/__init__.py
+++ b/src/inv_man_intake/observability/__init__.py
@@ -14,6 +14,7 @@ from .langsmith_fleet import (
     ensure_langsmith_project_defaults,
     write_fleet_records,
 )
+from .entrypoints import PipelineEntrypoint, audit_intake_extraction_entrypoints
 from .langsmith_sink import LangSmithTraceSink
 from .logging import (
     CORRELATION_ID_KEY,
@@ -75,12 +76,14 @@ __all__ = [
     "REPO",
     "SCHEMA_VERSION",
     "SURFACE",
+    "PipelineEntrypoint",
     "TRACE_ENABLED_ENV_KEY",
     "TraceContext",
     "TraceEvent",
     "Tracer",
     "build_fleet_records",
     "build_summary_from_pipeline",
+    "audit_intake_extraction_entrypoints",
     "build_log_record",
     "child_run_context",
     "child_trace_context",

--- a/src/inv_man_intake/observability/entrypoints.py
+++ b/src/inv_man_intake/observability/entrypoints.py
@@ -1,0 +1,40 @@
+"""Audited intake/extraction entry points used by operators and automation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class PipelineEntrypoint:
+    """One production or manual entry point that executes intake and extraction."""
+
+    name: str
+    module: str
+    function: str
+    mode: str
+    intake_surface: str
+    extraction_surface: str
+
+
+def audit_intake_extraction_entrypoints() -> tuple[PipelineEntrypoint, ...]:
+    """Return the current audited entry points for intake + extraction execution."""
+
+    return (
+        PipelineEntrypoint(
+            name="v1_smoke_pipeline",
+            module="inv_man_intake.v1_smoke",
+            function="run_v1_smoke_pipeline",
+            mode="manual",
+            intake_surface="register_intake_bundle_file",
+            extraction_surface="ExtractionOrchestrator.run",
+        ),
+        PipelineEntrypoint(
+            name="throughput_readiness_batch",
+            module="inv_man_intake.readiness.throughput",
+            function="run_readiness_check",
+            mode="production",
+            intake_surface="run_v1_smoke_pipeline -> register_intake_bundle_file",
+            extraction_surface="run_v1_smoke_pipeline -> ExtractionOrchestrator.run",
+        ),
+    )

--- a/src/inv_man_intake/observability/langsmith_fleet.py
+++ b/src/inv_man_intake/observability/langsmith_fleet.py
@@ -55,6 +55,7 @@ class IntakeFleetSummary:
     score_count: int
     review_queue_outcome: str
     artifact_refs: tuple[str, ...] = ()
+    trace_refs: tuple[str, ...] = ()
     error_category: str | None = None
 
 
@@ -152,6 +153,7 @@ def build_summary_from_pipeline(
     score_count: int,
     review_queue_outcome: str,
     artifact_refs: Iterable[str] = (),
+    trace_refs: Iterable[str] = (),
     document_types: Iterable[str] | None = None,
 ) -> IntakeFleetSummary:
     """Create dashboard-safe domain metadata from pipeline outputs.
@@ -181,6 +183,7 @@ def build_summary_from_pipeline(
         score_count=score_count,
         review_queue_outcome=review_queue_outcome,
         artifact_refs=tuple(sorted(str(item) for item in artifact_refs if str(item).strip())),
+        trace_refs=tuple(sorted(str(item) for item in trace_refs if str(item).strip())),
         error_category=str(escalation_reason) if escalation_reason else None,
     )
 
@@ -202,6 +205,7 @@ def _shared_domain(*, context: FleetRunContext, summary: IntakeFleetSummary) -> 
         "document_ids": list(summary.document_ids),
         "document_types": list(summary.document_types),
         "redaction_status": summary.redaction_status,
+        "trace_refs": list(summary.trace_refs),
         "validation_status": summary.validation_status,
         "error_category": summary.error_category or "none",
     }

--- a/src/inv_man_intake/observability/langsmith_fleet.py
+++ b/src/inv_man_intake/observability/langsmith_fleet.py
@@ -1,0 +1,248 @@
+"""Build dashboard-safe LangSmith fleet records for intake and extraction runs."""
+
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Final, Literal
+
+SCHEMA_VERSION: Final = "langsmith-fleet/v1"
+REPO: Final = "stranske/Inv-Man-Intake"
+SURFACE: Final = "intake-extraction"
+GITHUB_ISSUE: Final = "stranske/Inv-Man-Intake#438"
+ARTIFACT_NAME: Final = "langsmith-fleet.ndjson"
+DEFAULT_PROJECT: Final = "inv-man-intake"
+ENV_LANGSMITH_KEY: Final = "LANGSMITH_API_KEY"
+ENV_LANGCHAIN_PROJECT: Final = "LANGCHAIN_PROJECT"
+ENV_LANGSMITH_PROJECT: Final = "LANGSMITH_PROJECT"
+ENV_LANGCHAIN_TRACING_V2: Final = "LANGCHAIN_TRACING_V2"
+ENV_LANGCHAIN_API_KEY: Final = "LANGCHAIN_API_KEY"
+
+Status = Literal["success", "error", "fallback", "no_secret", "skipped"]
+
+
+@dataclass(frozen=True)
+class FleetRunContext:
+    """Shared metadata for an intake package run."""
+
+    run_id: str
+    package_id: str
+    provider: str | None = None
+    model: str | None = None
+    trace_id: str | None = None
+    trace_url: str | None = None
+    recorded_at: str | None = None
+    github_pr: str | None = None
+
+
+@dataclass(frozen=True)
+class IntakeFleetSummary:
+    """Dashboard-safe summary of a package intake/extraction pipeline run."""
+
+    document_ids: tuple[str, ...]
+    document_types: tuple[str, ...]
+    extraction_count: int
+    validation_status: str
+    redaction_status: str
+    confidence_state: str
+    escalation_state: str
+    retry_count: int
+    score_count: int
+    review_queue_outcome: str
+    artifact_refs: tuple[str, ...] = ()
+    error_category: str | None = None
+
+
+def ensure_langsmith_project_defaults(env: Mapping[str, str] | None = None) -> bool:
+    """Apply Inv-Man-Intake LangSmith defaults when a key is present."""
+
+    if env is not None and env is not os.environ:
+        return bool(env.get(ENV_LANGSMITH_KEY, "").strip())
+    api_key = os.environ.get(ENV_LANGSMITH_KEY, "").strip()
+    if not api_key:
+        return False
+    os.environ.setdefault(ENV_LANGCHAIN_TRACING_V2, "true")
+    os.environ.setdefault(ENV_LANGCHAIN_PROJECT, DEFAULT_PROJECT)
+    os.environ.setdefault(ENV_LANGSMITH_PROJECT, DEFAULT_PROJECT)
+    os.environ.setdefault(ENV_LANGCHAIN_API_KEY, api_key)
+    return True
+
+
+def build_fleet_records(
+    *,
+    context: FleetRunContext,
+    summary: IntakeFleetSummary,
+    artifact_ref: str | None = None,
+) -> list[dict[str, Any]]:
+    """Return Workflows-compatible records for the major intake pipeline stages."""
+
+    tracing_enabled = ensure_langsmith_project_defaults()
+    base_status: Status = "success" if tracing_enabled else "no_secret"
+    recorded_at = context.recorded_at or _utc_timestamp()
+    shared_domain = _shared_domain(context=context, summary=summary)
+    return [
+        _record(
+            context=context,
+            operation="package-intake",
+            status=base_status,
+            recorded_at=recorded_at,
+            domain={
+                **shared_domain,
+                "stage_status": "accepted",
+                "artifact_refs": list(summary.artifact_refs),
+            },
+            artifact_ref=artifact_ref,
+        ),
+        _record(
+            context=context,
+            operation="document-extraction",
+            status=_extraction_status(base_status, summary),
+            recorded_at=recorded_at,
+            domain={
+                **shared_domain,
+                "extraction_count": summary.extraction_count,
+                "confidence_state": summary.confidence_state,
+                "retry_count": summary.retry_count,
+            },
+            artifact_ref=artifact_ref,
+        ),
+        _record(
+            context=context,
+            operation="validation-escalation",
+            status=base_status if summary.validation_status != "error" else "error",
+            recorded_at=recorded_at,
+            domain={
+                **shared_domain,
+                "validation_status": summary.validation_status,
+                "escalation_state": summary.escalation_state,
+                "review_queue_outcome": summary.review_queue_outcome,
+            },
+            artifact_ref=artifact_ref,
+        ),
+        _record(
+            context=context,
+            operation="scoring-summary",
+            status=base_status,
+            recorded_at=recorded_at,
+            domain={
+                **shared_domain,
+                "score_count": summary.score_count,
+                "review_queue_outcome": summary.review_queue_outcome,
+            },
+            artifact_ref=artifact_ref,
+        ),
+    ]
+
+
+def build_summary_from_pipeline(
+    *,
+    document_ids: Iterable[str],
+    extraction: object,
+    secondary_extraction: object,
+    validation_status: str,
+    score_count: int,
+    review_queue_outcome: str,
+    artifact_refs: Iterable[str] = (),
+) -> IntakeFleetSummary:
+    """Create dashboard-safe domain metadata from pipeline outputs."""
+
+    extraction_fields = tuple(getattr(extraction, "fields", ()))
+    confidence_escalation = _field_value(extraction_fields, "confidence.document.escalation")
+    escalation_reason = _field_value(extraction_fields, "confidence.document.escalation_reason")
+    secondary_retry_count = getattr(secondary_extraction, "retry_count", 0)
+    secondary_route = getattr(secondary_extraction, "escalation_route", None)
+    return IntakeFleetSummary(
+        document_ids=tuple(str(item) for item in document_ids),
+        document_types=("pdf", "xlsx", "unsupported"),
+        extraction_count=len(extraction_fields),
+        validation_status=validation_status,
+        redaction_status="redacted_metadata_only",
+        confidence_state="escalated" if confidence_escalation is True else "accepted",
+        escalation_state=str(secondary_route or escalation_reason or "none"),
+        retry_count=int(secondary_retry_count or 0),
+        score_count=score_count,
+        review_queue_outcome=review_queue_outcome,
+        artifact_refs=tuple(sorted(str(item) for item in artifact_refs if str(item).strip())),
+        error_category=str(escalation_reason) if escalation_reason else None,
+    )
+
+
+def write_fleet_records(path: Path, records: Iterable[Mapping[str, Any]]) -> Path:
+    """Write records as deterministic NDJSON and return the artifact path."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [json.dumps(dict(record), sort_keys=True, separators=(",", ":")) for record in records]
+    path.write_text("\n".join(lines) + ("\n" if lines else ""), encoding="utf-8")
+    return path
+
+
+def _shared_domain(
+    *, context: FleetRunContext, summary: IntakeFleetSummary
+) -> dict[str, Any]:
+    return {
+        "package_id": context.package_id,
+        "document_count": len(summary.document_ids),
+        "document_ids": list(summary.document_ids),
+        "document_types": list(summary.document_types),
+        "redaction_status": summary.redaction_status,
+        "validation_status": summary.validation_status,
+        "error_category": summary.error_category or "none",
+    }
+
+
+def _record(
+    *,
+    context: FleetRunContext,
+    operation: str,
+    status: Status,
+    recorded_at: str,
+    domain: Mapping[str, Any],
+    artifact_ref: str | None,
+) -> dict[str, Any]:
+    record: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "repo": REPO,
+        "surface": SURFACE,
+        "operation": operation,
+        "run_id": context.run_id,
+        "status": status,
+        "github_issue": GITHUB_ISSUE,
+        "recorded_at": recorded_at,
+        "domain": dict(domain),
+    }
+    if context.github_pr:
+        record["github_pr"] = context.github_pr
+    if context.provider:
+        record["provider"] = context.provider
+    if context.model:
+        record["model"] = context.model
+    if context.trace_id:
+        record["trace_id"] = context.trace_id
+    if context.trace_url:
+        record["trace_url"] = context.trace_url
+    if artifact_ref:
+        record["artifact_ref"] = artifact_ref
+    return record
+
+
+def _extraction_status(base_status: Status, summary: IntakeFleetSummary) -> Status:
+    if summary.validation_status == "error":
+        return "error"
+    if summary.retry_count > 0 or summary.escalation_state not in {"none", "accepted"}:
+        return "fallback"
+    return base_status
+
+
+def _field_value(fields: Iterable[object], key: str) -> object | None:
+    for field in fields:
+        if getattr(field, "key", None) == key:
+            return getattr(field, "value", None)
+    return None
+
+
+def _utc_timestamp() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")

--- a/src/inv_man_intake/observability/langsmith_fleet.py
+++ b/src/inv_man_intake/observability/langsmith_fleet.py
@@ -35,6 +35,7 @@ class FleetRunContext:
     model: str | None = None
     trace_id: str | None = None
     trace_url: str | None = None
+    correlation_id: str | None = None
     recorded_at: str | None = None
     github_pr: str | None = None
 
@@ -180,11 +181,10 @@ def write_fleet_records(path: Path, records: Iterable[Mapping[str, Any]]) -> Pat
     return path
 
 
-def _shared_domain(
-    *, context: FleetRunContext, summary: IntakeFleetSummary
-) -> dict[str, Any]:
+def _shared_domain(*, context: FleetRunContext, summary: IntakeFleetSummary) -> dict[str, Any]:
     return {
         "package_id": context.package_id,
+        "correlation_id": context.correlation_id or "none",
         "document_count": len(summary.document_ids),
         "document_ids": list(summary.document_ids),
         "document_types": list(summary.document_types),

--- a/src/inv_man_intake/observability/langsmith_fleet.py
+++ b/src/inv_man_intake/observability/langsmith_fleet.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 import os
-from collections.abc import Iterable, Mapping
+from collections.abc import Iterable, Mapping, MutableMapping
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -58,18 +58,22 @@ class IntakeFleetSummary:
     error_category: str | None = None
 
 
-def ensure_langsmith_project_defaults(env: Mapping[str, str] | None = None) -> bool:
-    """Apply Inv-Man-Intake LangSmith defaults when a key is present."""
+def ensure_langsmith_project_defaults(
+    env: MutableMapping[str, str] | None = None,
+) -> bool:
+    """Apply Inv-Man-Intake LangSmith defaults to ``env`` (defaults to ``os.environ``).
 
-    if env is not None and env is not os.environ:
-        return bool(env.get(ENV_LANGSMITH_KEY, "").strip())
-    api_key = os.environ.get(ENV_LANGSMITH_KEY, "").strip()
+    Returns True when an API key is present and defaults were applied to ``env``.
+    """
+
+    target: MutableMapping[str, str] = env if env is not None else os.environ
+    api_key = target.get(ENV_LANGSMITH_KEY, "").strip()
     if not api_key:
         return False
-    os.environ.setdefault(ENV_LANGCHAIN_TRACING_V2, "true")
-    os.environ.setdefault(ENV_LANGCHAIN_PROJECT, DEFAULT_PROJECT)
-    os.environ.setdefault(ENV_LANGSMITH_PROJECT, DEFAULT_PROJECT)
-    os.environ.setdefault(ENV_LANGCHAIN_API_KEY, api_key)
+    target.setdefault(ENV_LANGCHAIN_TRACING_V2, "true")
+    target.setdefault(ENV_LANGCHAIN_PROJECT, DEFAULT_PROJECT)
+    target.setdefault(ENV_LANGSMITH_PROJECT, DEFAULT_PROJECT)
+    target.setdefault(ENV_LANGCHAIN_API_KEY, api_key)
     return True
 
 
@@ -148,17 +152,26 @@ def build_summary_from_pipeline(
     score_count: int,
     review_queue_outcome: str,
     artifact_refs: Iterable[str] = (),
+    document_types: Iterable[str] | None = None,
 ) -> IntakeFleetSummary:
-    """Create dashboard-safe domain metadata from pipeline outputs."""
+    """Create dashboard-safe domain metadata from pipeline outputs.
+
+    ``document_types`` should be supplied by the caller when known (e.g. derived
+    from per-document file metadata). When not provided, an empty tuple is used
+    so the dashboard reports ``unknown`` rather than a fixed placeholder.
+    """
 
     extraction_fields = tuple(getattr(extraction, "fields", ()))
     confidence_escalation = _field_value(extraction_fields, "confidence.document.escalation")
     escalation_reason = _field_value(extraction_fields, "confidence.document.escalation_reason")
     secondary_retry_count = getattr(secondary_extraction, "retry_count", 0)
     secondary_route = getattr(secondary_extraction, "escalation_route", None)
+    derived_types: tuple[str, ...] = (
+        tuple(str(item) for item in document_types) if document_types is not None else ()
+    )
     return IntakeFleetSummary(
         document_ids=tuple(str(item) for item in document_ids),
-        document_types=("pdf", "xlsx", "unsupported"),
+        document_types=derived_types,
         extraction_count=len(extraction_fields),
         validation_status=validation_status,
         redaction_status="redacted_metadata_only",

--- a/src/inv_man_intake/observability/langsmith_sink.py
+++ b/src/inv_man_intake/observability/langsmith_sink.py
@@ -7,6 +7,7 @@ from collections.abc import Callable, Mapping
 from typing import Any, Literal, Protocol
 from uuid import NAMESPACE_URL, UUID, uuid5
 
+from .langsmith_fleet import DEFAULT_PROJECT
 from .tracing import LANGSMITH_PROJECT_ENV_KEY, TraceEvent
 
 
@@ -46,7 +47,7 @@ class LangSmithTraceSink:
     def from_env(cls, env: Mapping[str, str] | None = None) -> LangSmithTraceSink:
         """Create a sink using the LangSmith project configured in env."""
         source = env if env is not None else os.environ
-        project_name = source.get(LANGSMITH_PROJECT_ENV_KEY, "").strip() or None
+        project_name = source.get(LANGSMITH_PROJECT_ENV_KEY, "").strip() or DEFAULT_PROJECT
         return cls(project_name=project_name)
 
     def on_span_start(self, event: TraceEvent) -> None:

--- a/src/inv_man_intake/observability/tracing.py
+++ b/src/inv_man_intake/observability/tracing.py
@@ -152,11 +152,11 @@ class Tracer:
     def from_env(
         cls,
         sink: TraceSink | None = None,
-        env: Mapping[str, str] | None = None,
+        env: MutableMapping[str, str] | None = None,
         default_enabled: bool = False,
     ) -> Tracer:
         """Construct tracer using environment-based enable toggles."""
-        source = env if env is not None else os.environ
+        source: MutableMapping[str, str] = env if env is not None else os.environ
         enabled = tracing_enabled_from_env(env=env, default_enabled=default_enabled)
         if sink is None and enabled:
             api_key = source.get(LANGSMITH_API_KEY_ENV_KEY, "").strip()
@@ -164,7 +164,7 @@ class Tracer:
                 from .langsmith_fleet import ensure_langsmith_project_defaults
                 from .langsmith_sink import LangSmithTraceSink
 
-                ensure_langsmith_project_defaults()
+                ensure_langsmith_project_defaults(env=source)
                 sink = LangSmithTraceSink.from_env(env=source)
             elif api_key:
                 sink = InMemoryTraceSink()

--- a/src/inv_man_intake/observability/tracing.py
+++ b/src/inv_man_intake/observability/tracing.py
@@ -161,8 +161,10 @@ class Tracer:
         if sink is None and enabled:
             api_key = source.get(LANGSMITH_API_KEY_ENV_KEY, "").strip()
             if api_key and langsmith_export_enabled_from_env(env=source):
+                from .langsmith_fleet import ensure_langsmith_project_defaults
                 from .langsmith_sink import LangSmithTraceSink
 
+                ensure_langsmith_project_defaults()
                 sink = LangSmithTraceSink.from_env(env=source)
             elif api_key:
                 sink = InMemoryTraceSink()

--- a/src/inv_man_intake/v1_smoke.py
+++ b/src/inv_man_intake/v1_smoke.py
@@ -286,6 +286,7 @@ def run_v1_smoke_pipeline(
             "artifact:extraction/threshold-summary.json",
             "artifact:scoring/explainability.json",
         ),
+        trace_refs=(f"trace:{trace_context.trace_id}",),
         document_types=_derive_document_types(
             repository=core_repository, document_ids=record.document_ids
         ),

--- a/src/inv_man_intake/v1_smoke.py
+++ b/src/inv_man_intake/v1_smoke.py
@@ -22,10 +22,13 @@ from inv_man_intake.intake.integration import register_intake_bundle_file
 from inv_man_intake.intake.models import IngestRecord
 from inv_man_intake.intake.service import IngestionService
 from inv_man_intake.observability import (
+    FleetRunContext,
     InMemoryTraceSink,
     TraceContext,
     TraceEvent,
     Tracer,
+    build_fleet_records,
+    build_summary_from_pipeline,
     child_trace_context,
     extract_trace_context,
     inject_trace_context,
@@ -71,6 +74,7 @@ class V1SmokeArtifacts:
     queue_assignment: object
     score: object
     formatted_explainability: dict[str, object]
+    langsmith_fleet_records: list[dict[str, Any]]
 
 
 def run_v1_smoke_pipeline(
@@ -217,6 +221,29 @@ def run_v1_smoke_pipeline(
             overall_score=score.final_score,
         )
         formatted_explainability = format_explainability_payload(explainability)
+    fleet_summary = build_summary_from_pipeline(
+        document_ids=record.document_ids,
+        extraction=extraction_with_thresholds,
+        secondary_extraction=secondary_extraction_result,
+        validation_status="escalated" if threshold_decision.escalate else "accepted",
+        score_count=len(score.contributions),
+        review_queue_outcome=queue_assignment.owner_role,
+        artifact_refs=(
+            f"artifact:packages/{record.package_id}/metadata.json",
+            "artifact:extraction/threshold-summary.json",
+            "artifact:scoring/explainability.json",
+        ),
+    )
+    langsmith_fleet_records = build_fleet_records(
+        context=FleetRunContext(
+            run_id=trace_context.run_id or trace_context.trace_id,
+            package_id=record.package_id,
+            provider=extraction_with_thresholds.provider_name,
+            trace_id=trace_context.trace_id,
+        ),
+        summary=fleet_summary,
+        artifact_ref="artifact:langsmith-fleet.ndjson",
+    )
 
     return V1SmokeArtifacts(
         service=service,
@@ -238,6 +265,7 @@ def run_v1_smoke_pipeline(
         queue_assignment=queue_assignment,
         score=score,
         formatted_explainability=formatted_explainability,
+        langsmith_fleet_records=langsmith_fleet_records,
     )
 
 

--- a/src/inv_man_intake/v1_smoke.py
+++ b/src/inv_man_intake/v1_smoke.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import sqlite3
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -53,6 +54,31 @@ from inv_man_intake.scoring.explainability import (
 from inv_man_intake.storage.document_store import InMemoryDocumentStore
 
 
+class _FanoutTraceSink:
+    """Emit trace events to all sinks while keeping tracing non-blocking."""
+
+    def __init__(self, *sinks: object) -> None:
+        self._sinks = sinks
+
+    def on_span_start(self, event: TraceEvent) -> None:
+        for sink in self._sinks:
+            on_span_start = getattr(sink, "on_span_start", None)
+            if callable(on_span_start):
+                try:
+                    on_span_start(event)
+                except Exception:
+                    continue
+
+    def on_span_end(self, event: TraceEvent) -> None:
+        for sink in self._sinks:
+            on_span_end = getattr(sink, "on_span_end", None)
+            if callable(on_span_end):
+                try:
+                    on_span_end(event)
+                except Exception:
+                    continue
+
+
 @dataclass(frozen=True)
 class V1SmokeArtifacts:
     service: IngestionService
@@ -86,6 +112,18 @@ def run_v1_smoke_pipeline(
 ) -> V1SmokeArtifacts:
     sink = InMemoryTraceSink()
     tracer = Tracer(enabled=True, sink=sink)
+    if os.getenv("LANGSMITH_API_KEY", "").strip():
+        from inv_man_intake.observability.langsmith_fleet import ensure_langsmith_project_defaults
+        from inv_man_intake.observability.langsmith_sink import LangSmithTraceSink
+
+        ensure_langsmith_project_defaults()
+        tracer = Tracer(
+            enabled=True,
+            sink=_FanoutTraceSink(
+                sink,
+                LangSmithTraceSink.from_env(),
+            ),
+        )
     trace_context = new_trace_context(tags={"package_id": package_id, "stage": "intake"})
 
     service = IngestionService()

--- a/src/inv_man_intake/v1_smoke.py
+++ b/src/inv_man_intake/v1_smoke.py
@@ -286,6 +286,9 @@ def run_v1_smoke_pipeline(
             "artifact:extraction/threshold-summary.json",
             "artifact:scoring/explainability.json",
         ),
+        document_types=_derive_document_types(
+            repository=core_repository, document_ids=record.document_ids
+        ),
     )
     langsmith_fleet_records = build_fleet_records(
         context=FleetRunContext(
@@ -501,6 +504,20 @@ def _start_event(sink: InMemoryTraceSink, name: str) -> TraceEvent:
     matches = [event for event in sink.events if event.name == name and event.ended_at is None]
     assert matches, f"missing trace start event {name}"
     return matches[0]
+
+
+def _derive_document_types(
+    *, repository: CoreRepository, document_ids: tuple[str, ...]
+) -> tuple[str, ...]:
+    types: list[str] = []
+    for document_id in document_ids:
+        document = repository.get_document(document_id)
+        if document is None:
+            types.append("unknown")
+            continue
+        suffix = Path(document.file_name).suffix.lstrip(".").lower()
+        types.append(suffix or "unknown")
+    return tuple(sorted(set(types)))
 
 
 def _assert_registered_package_state(

--- a/src/inv_man_intake/v1_smoke.py
+++ b/src/inv_man_intake/v1_smoke.py
@@ -31,6 +31,7 @@ from inv_man_intake.observability import (
     build_fleet_records,
     build_summary_from_pipeline,
     child_trace_context,
+    ensure_correlation_id,
     extract_trace_context,
     inject_trace_context,
     new_trace_context,
@@ -88,6 +89,7 @@ class V1SmokeArtifacts:
     record: object
     sink: InMemoryTraceSink
     trace_context: object
+    correlation_id: str
     intake_start: object
     extraction_start: object
     secondary_extraction_result: object
@@ -124,7 +126,14 @@ def run_v1_smoke_pipeline(
                 LangSmithTraceSink.from_env(),
             ),
         )
-    trace_context = new_trace_context(tags={"package_id": package_id, "stage": "intake"})
+    correlation_id = ensure_correlation_id()
+    trace_context = new_trace_context(
+        tags={
+            "package_id": package_id,
+            "stage": "intake",
+            "correlation_id": correlation_id,
+        }
+    )
 
     service = IngestionService()
     core_repository = CoreRepository(sqlite3.connect(":memory:"))
@@ -162,12 +171,14 @@ def run_v1_smoke_pipeline(
         content=_fixture_bytes(
             fixture_root=fixture_root, file_name="summit_arc_investment_update.pdf"
         ),
+        correlation_id=correlation_id,
     )
     secondary_extraction_result = _run_secondary_extraction_boundary_smoke(
         tracer=tracer,
         trace_context=extraction_context,
         source_doc_id=record.document_ids[1],
         content=_fixture_bytes(fixture_root=fixture_root, file_name="summit_arc_track_record.xlsx"),
+        correlation_id=correlation_id,
     )
     with tracer.start_span(
         name="v1_acceptance.threshold_handling",
@@ -231,7 +242,7 @@ def run_v1_smoke_pipeline(
         metadata={"package_id": record.package_id},
     ):
         queue_assignment = create_analyst_first_assignment(
-            item_id=f"{record.package_id}:validation:performance_conflict",
+            item_id=f"{record.package_id}:validation:performance_conflict:{correlation_id}",
             analyst_id="analyst_001",
             created_at=datetime(2026, 3, 4, 10, 0, tzinfo=UTC),
         )
@@ -244,7 +255,11 @@ def run_v1_smoke_pipeline(
     with tracer.start_span(
         name="v1_acceptance.scoring_compute",
         context=scoring_context,
-        metadata={"manager_id": record.fund_id, "queue_item_id": queue_assignment.item_id},
+        metadata={
+            "manager_id": record.fund_id,
+            "queue_item_id": queue_assignment.item_id,
+            "correlation_id": correlation_id,
+        },
     ):
         components = _score_components(metrics.benchmark_correlation)
         score = compute_score(
@@ -278,6 +293,7 @@ def run_v1_smoke_pipeline(
             package_id=record.package_id,
             provider=extraction_with_thresholds.provider_name,
             trace_id=trace_context.trace_id,
+            correlation_id=correlation_id,
         ),
         summary=fleet_summary,
         artifact_ref="artifact:langsmith-fleet.ndjson",
@@ -291,6 +307,7 @@ def run_v1_smoke_pipeline(
         record=record,
         sink=sink,
         trace_context=trace_context,
+        correlation_id=correlation_id,
         intake_start=intake_start,
         extraction_start=extraction_start,
         secondary_extraction_result=secondary_extraction_result,
@@ -313,6 +330,7 @@ def _run_extraction_smoke(
     trace_context: TraceContext,
     source_doc_id: str,
     content: bytes,
+    correlation_id: str,
 ) -> ExtractedDocumentResult:
     provider = PdfPrimaryExtractionProvider()
     extractor_key = "_".join(("primary", "extractor"))
@@ -328,6 +346,7 @@ def _run_extraction_smoke(
             "id": f"{source_doc_id}:extract",
             "document_id": source_doc_id,
             "content": content,
+            "correlation_id": correlation_id,
         },
         trace_context=trace_context,
     )
@@ -345,6 +364,7 @@ def _run_secondary_extraction_boundary_smoke(
     trace_context: TraceContext,
     source_doc_id: str,
     content: bytes,
+    correlation_id: str,
 ) -> object:
     provider = PdfPrimaryExtractionProvider()
     extractor_key = "_".join(("primary", "extractor"))
@@ -360,6 +380,7 @@ def _run_secondary_extraction_boundary_smoke(
             "id": f"{source_doc_id}:secondary-extract",
             "document_id": source_doc_id,
             "content": content,
+            "correlation_id": correlation_id,
         },
         trace_context=trace_context,
     )

--- a/tests/observability/test_entrypoints_audit.py
+++ b/tests/observability/test_entrypoints_audit.py
@@ -1,0 +1,32 @@
+"""Tests for audited intake/extraction entry points."""
+
+from __future__ import annotations
+
+from importlib import import_module
+
+from inv_man_intake.observability.entrypoints import audit_intake_extraction_entrypoints
+
+
+def test_audit_lists_manual_and_production_entrypoints() -> None:
+    entrypoints = audit_intake_extraction_entrypoints()
+
+    assert [entrypoint.name for entrypoint in entrypoints] == [
+        "v1_smoke_pipeline",
+        "throughput_readiness_batch",
+    ]
+    assert {entrypoint.mode for entrypoint in entrypoints} == {"manual", "production"}
+
+
+def test_audited_entrypoints_resolve_to_callables() -> None:
+    for entrypoint in audit_intake_extraction_entrypoints():
+        module = import_module(entrypoint.module)
+        target = getattr(module, entrypoint.function)
+        assert callable(target)
+
+
+def test_audit_requires_intake_and_extraction_surfaces() -> None:
+    for entrypoint in audit_intake_extraction_entrypoints():
+        assert entrypoint.intake_surface
+        assert "intake" in entrypoint.intake_surface
+        assert entrypoint.extraction_surface
+        assert "extract" in entrypoint.extraction_surface.casefold()

--- a/tests/observability/test_langsmith_fleet.py
+++ b/tests/observability/test_langsmith_fleet.py
@@ -53,7 +53,9 @@ def test_build_fleet_records_use_inv_man_project_and_no_secret_fallback(
     assert all(record["surface"] == "intake-extraction" for record in records)
     assert all(record["github_issue"] == "stranske/Inv-Man-Intake#438" for record in records)
     assert all(record["domain"]["package_id"] == "pkg_pdf_mixed_001" for record in records)
-    assert all(record["domain"]["redaction_status"] == "redacted_metadata_only" for record in records)
+    assert all(
+        record["domain"]["redaction_status"] == "redacted_metadata_only" for record in records
+    )
     assert all("raw" not in json.dumps(record).lower() for record in records)
 
 

--- a/tests/observability/test_langsmith_fleet.py
+++ b/tests/observability/test_langsmith_fleet.py
@@ -32,6 +32,7 @@ def test_build_fleet_records_use_inv_man_project_and_no_secret_fallback(
         score_count=5,
         review_queue_outcome="analyst",
         artifact_refs=("artifact:extraction/threshold-summary.json",),
+        trace_refs=("trace:trace-123",),
         error_category="low_key_field_coverage",
     )
 
@@ -53,6 +54,7 @@ def test_build_fleet_records_use_inv_man_project_and_no_secret_fallback(
     assert all(record["surface"] == "intake-extraction" for record in records)
     assert all(record["github_issue"] == "stranske/Inv-Man-Intake#438" for record in records)
     assert all(record["domain"]["package_id"] == "pkg_pdf_mixed_001" for record in records)
+    assert all(record["domain"]["trace_refs"] == ["trace:trace-123"] for record in records)
     assert all(
         record["domain"]["redaction_status"] == "redacted_metadata_only" for record in records
     )
@@ -86,6 +88,7 @@ def test_build_fleet_records_enable_langsmith_defaults_when_key_exists(
             retry_count=0,
             score_count=5,
             review_queue_outcome="completed",
+            trace_refs=("trace:trace-123",),
         ),
     )
 
@@ -121,6 +124,7 @@ def test_write_fleet_records_emits_deterministic_ndjson(tmp_path: Path) -> None:
                 "document_ids": ["doc-1"],
                 "document_types": ["pdf"],
                 "redaction_status": "redacted_metadata_only",
+                "trace_refs": ["trace:trace-123"],
                 "validation_status": "accepted",
                 "error_category": "none",
             },

--- a/tests/observability/test_langsmith_fleet.py
+++ b/tests/observability/test_langsmith_fleet.py
@@ -1,0 +1,132 @@
+"""Tests for LangSmith fleet artifact records."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from inv_man_intake.observability import langsmith_fleet
+
+
+def test_build_fleet_records_use_inv_man_project_and_no_secret_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv(langsmith_fleet.ENV_LANGSMITH_KEY, raising=False)
+    context = langsmith_fleet.FleetRunContext(
+        run_id="run-1",
+        package_id="pkg_pdf_mixed_001",
+        provider="pdf-primary",
+        trace_id="trace-123",
+    )
+    summary = langsmith_fleet.IntakeFleetSummary(
+        document_ids=("pkg_pdf_mixed_001:doc:0", "pkg_pdf_mixed_001:doc:1"),
+        document_types=("pdf", "xlsx"),
+        extraction_count=12,
+        validation_status="escalated",
+        redaction_status="redacted_metadata_only",
+        confidence_state="escalated",
+        escalation_state="ops_review",
+        retry_count=1,
+        score_count=5,
+        review_queue_outcome="analyst",
+        artifact_refs=("artifact:extraction/threshold-summary.json",),
+        error_category="low_key_field_coverage",
+    )
+
+    records = langsmith_fleet.build_fleet_records(
+        context=context,
+        summary=summary,
+        artifact_ref="artifact:langsmith-fleet.ndjson",
+    )
+
+    assert {record["operation"] for record in records} == {
+        "package-intake",
+        "document-extraction",
+        "validation-escalation",
+        "scoring-summary",
+    }
+    assert {record["status"] for record in records} == {"no_secret", "fallback"}
+    assert all(record["schema_version"] == langsmith_fleet.SCHEMA_VERSION for record in records)
+    assert all(record["repo"] == "stranske/Inv-Man-Intake" for record in records)
+    assert all(record["surface"] == "intake-extraction" for record in records)
+    assert all(record["github_issue"] == "stranske/Inv-Man-Intake#438" for record in records)
+    assert all(record["domain"]["package_id"] == "pkg_pdf_mixed_001" for record in records)
+    assert all(record["domain"]["redaction_status"] == "redacted_metadata_only" for record in records)
+    assert all("raw" not in json.dumps(record).lower() for record in records)
+
+
+def test_build_fleet_records_enable_langsmith_defaults_when_key_exists(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(langsmith_fleet.ENV_LANGSMITH_KEY, "test-key")
+    monkeypatch.delenv(langsmith_fleet.ENV_LANGCHAIN_TRACING_V2, raising=False)
+    monkeypatch.delenv(langsmith_fleet.ENV_LANGCHAIN_API_KEY, raising=False)
+    monkeypatch.delenv(langsmith_fleet.ENV_LANGCHAIN_PROJECT, raising=False)
+    monkeypatch.delenv(langsmith_fleet.ENV_LANGSMITH_PROJECT, raising=False)
+
+    records = langsmith_fleet.build_fleet_records(
+        context=langsmith_fleet.FleetRunContext(
+            run_id="run-1",
+            package_id="pkg-1",
+            trace_id="trace-123",
+            trace_url="https://smith.langchain.com/r/trace-123",
+        ),
+        summary=langsmith_fleet.IntakeFleetSummary(
+            document_ids=("doc-1",),
+            document_types=("pdf",),
+            extraction_count=2,
+            validation_status="accepted",
+            redaction_status="redacted_metadata_only",
+            confidence_state="accepted",
+            escalation_state="none",
+            retry_count=0,
+            score_count=5,
+            review_queue_outcome="completed",
+        ),
+    )
+
+    assert {record["status"] for record in records} == {"success"}
+    assert records[0]["trace_id"] == "trace-123"
+    assert records[0]["trace_url"] == "https://smith.langchain.com/r/trace-123"
+    assert (
+        langsmith_fleet.os.environ[langsmith_fleet.ENV_LANGCHAIN_PROJECT]
+        == langsmith_fleet.DEFAULT_PROJECT
+    )
+    assert (
+        langsmith_fleet.os.environ[langsmith_fleet.ENV_LANGSMITH_PROJECT]
+        == langsmith_fleet.DEFAULT_PROJECT
+    )
+    assert langsmith_fleet.os.environ[langsmith_fleet.ENV_LANGCHAIN_TRACING_V2] == "true"
+    assert langsmith_fleet.os.environ[langsmith_fleet.ENV_LANGCHAIN_API_KEY] == "test-key"
+
+
+def test_write_fleet_records_emits_deterministic_ndjson(tmp_path: Path) -> None:
+    path = tmp_path / langsmith_fleet.ARTIFACT_NAME
+    records = [
+        {
+            "schema_version": langsmith_fleet.SCHEMA_VERSION,
+            "repo": "stranske/Inv-Man-Intake",
+            "surface": "intake-extraction",
+            "operation": "package-intake",
+            "run_id": "run-1",
+            "status": "no_secret",
+            "github_issue": "stranske/Inv-Man-Intake#438",
+            "domain": {
+                "package_id": "pkg-1",
+                "document_count": 1,
+                "document_ids": ["doc-1"],
+                "document_types": ["pdf"],
+                "redaction_status": "redacted_metadata_only",
+                "validation_status": "accepted",
+                "error_category": "none",
+            },
+        }
+    ]
+
+    langsmith_fleet.write_fleet_records(path, records)
+
+    lines = path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    assert json.loads(lines[0]) == records[0]

--- a/tests/observability/test_pipeline_smoke.py
+++ b/tests/observability/test_pipeline_smoke.py
@@ -41,13 +41,16 @@ def test_pipeline_smoke_tracing_enabled_keeps_correlation_ids_stable() -> None:
         tracer=tracer,
     )
 
-    trace_context = new_trace_context(tags={"stage": "extract-smoke"})
+    trace_context = new_trace_context(
+        tags={"stage": "extract-smoke", "correlation_id": "corr_smoke_trace_1"}
+    )
     result = orchestrator.run({"id": "SMOKE-TRACE-1"}, trace_context=trace_context)
 
     assert result.resolved is True
     assert result.provider_used == "fallback-provider"
     assert result.retry_count == 1
     assert result.failure_count == 1
+    assert result.correlation_id == "corr_smoke_trace_1"
 
     assert len(sink.events) == 6
     assert {event.trace_id for event in sink.events} == {trace_context.trace_id}
@@ -86,12 +89,14 @@ def test_pipeline_smoke_tracing_disabled_and_escalation_metrics_path() -> None:
         tracer=tracer,
     )
 
-    result = orchestrator.run({"id": "SMOKE-TRACE-2"})
+    result = orchestrator.run({"id": "SMOKE-TRACE-2", "correlation_id": "corr_smoke_trace_2"})
 
     assert result.resolved is False
     assert result.escalation_payload is not None
     assert result.retry_count == 1
     assert result.failure_count == 2
+    assert result.correlation_id == "corr_smoke_trace_2"
+    assert result.escalation_payload["correlation_id"] == "corr_smoke_trace_2"
     assert sink.events == []
     assert counters == {
         "total": 1,

--- a/tests/test_extraction_orchestrator.py
+++ b/tests/test_extraction_orchestrator.py
@@ -45,6 +45,7 @@ def test_primary_success_skips_fallback() -> None:
             "provider_used": "primary-provider",
             "retry_count": 0,
             "failure_count": 0,
+            "correlation_id": None,
         }
     ]
 
@@ -88,6 +89,7 @@ def test_primary_failure_retries_once_with_fallback() -> None:
             "provider_used": "fallback-provider",
             "retry_count": 1,
             "failure_count": 1,
+            "correlation_id": None,
         }
     ]
 
@@ -129,6 +131,7 @@ def test_guardrail_blocks_repeated_fallback_attempts() -> None:
         "escalation_reason": "fallback-provider: fallback failed",
         "retry_count": 1,
         "failure_count": 2,
+        "correlation_id": None,
         "failed_providers": ["primary-provider", "fallback-provider"],
         "errors": [
             "primary-provider: primary failed",
@@ -141,6 +144,7 @@ def test_guardrail_blocks_repeated_fallback_attempts() -> None:
             "provider_used": None,
             "retry_count": 1,
             "failure_count": 2,
+            "correlation_id": None,
         }
     ]
 
@@ -238,6 +242,7 @@ def test_primary_failure_routes_to_pending_triage_when_fallback_is_disabled() ->
         "escalation_reason": "primary-provider: primary failed",
         "retry_count": 0,
         "failure_count": 1,
+        "correlation_id": None,
         "failed_providers": ["primary-provider"],
         "errors": ["primary-provider: primary failed"],
     }

--- a/tests/test_v1_acceptance_smoke.py
+++ b/tests/test_v1_acceptance_smoke.py
@@ -91,7 +91,9 @@ def test_v1_acceptance_smoke_exercises_intake_to_scoring_path(v1_smoke_artifacts
     assert metrics.benchmark_correlation is not None
 
     queue_assignment = artifacts.queue_assignment
-    assert queue_assignment.item_id == f"{record.package_id}:validation:performance_conflict"
+    assert queue_assignment.item_id == (
+        f"{record.package_id}:validation:performance_conflict:{artifacts.correlation_id}"
+    )
     assert queue_assignment.owner_role == "analyst"
     assert queue_assignment.events[0].note == "analyst-first default assignment"
     _assert_conflict_escalation_has_evidence(
@@ -126,6 +128,13 @@ def test_v1_acceptance_smoke_exercises_intake_to_scoring_path(v1_smoke_artifacts
     assert all(record["repo"] == "stranske/Inv-Man-Intake" for record in fleet_records)
     assert all(record["trace_id"] == trace_context.trace_id for record in fleet_records)
     assert all(item["domain"]["package_id"] == record.package_id for item in fleet_records)
+    assert all(
+        item["domain"]["correlation_id"] == artifacts.correlation_id for item in fleet_records
+    )
+    assert artifacts.secondary_extraction_result.correlation_id == artifacts.correlation_id
+    assert artifacts.secondary_extraction_result.escalation_payload["correlation_id"] == (
+        artifacts.correlation_id
+    )
     assert all("summit" not in str(item).lower() for item in fleet_records)
 
 

--- a/tests/test_v1_acceptance_smoke.py
+++ b/tests/test_v1_acceptance_smoke.py
@@ -127,6 +127,10 @@ def test_v1_acceptance_smoke_exercises_intake_to_scoring_path(v1_smoke_artifacts
     assert all(record["schema_version"] == "langsmith-fleet/v1" for record in fleet_records)
     assert all(record["repo"] == "stranske/Inv-Man-Intake" for record in fleet_records)
     assert all(record["trace_id"] == trace_context.trace_id for record in fleet_records)
+    assert all(
+        item["domain"]["trace_refs"] == [f"trace:{trace_context.trace_id}"]
+        for item in fleet_records
+    )
     assert all(item["domain"]["package_id"] == _SMOKE_PACKAGE_ID for item in fleet_records)
     assert all(
         item["domain"]["correlation_id"] == artifacts.correlation_id for item in fleet_records

--- a/tests/test_v1_acceptance_smoke.py
+++ b/tests/test_v1_acceptance_smoke.py
@@ -127,7 +127,7 @@ def test_v1_acceptance_smoke_exercises_intake_to_scoring_path(v1_smoke_artifacts
     assert all(record["schema_version"] == "langsmith-fleet/v1" for record in fleet_records)
     assert all(record["repo"] == "stranske/Inv-Man-Intake" for record in fleet_records)
     assert all(record["trace_id"] == trace_context.trace_id for record in fleet_records)
-    assert all(item["domain"]["package_id"] == record.package_id for item in fleet_records)
+    assert all(item["domain"]["package_id"] == _SMOKE_PACKAGE_ID for item in fleet_records)
     assert all(
         item["domain"]["correlation_id"] == artifacts.correlation_id for item in fleet_records
     )

--- a/tests/test_v1_acceptance_smoke.py
+++ b/tests/test_v1_acceptance_smoke.py
@@ -114,6 +114,18 @@ def test_v1_acceptance_smoke_exercises_intake_to_scoring_path(v1_smoke_artifacts
     assert _start_event(sink, "v1_acceptance.scoring_compute").parent_span_id == (
         artifacts.performance_start.span_id
     )
+    fleet_records = artifacts.langsmith_fleet_records
+    assert {record["operation"] for record in fleet_records} == {
+        "package-intake",
+        "document-extraction",
+        "validation-escalation",
+        "scoring-summary",
+    }
+    assert all(record["schema_version"] == "langsmith-fleet/v1" for record in fleet_records)
+    assert all(record["repo"] == "stranske/Inv-Man-Intake" for record in fleet_records)
+    assert all(record["trace_id"] == trace_context.trace_id for record in fleet_records)
+    assert all(item["domain"]["package_id"] == record.package_id for item in fleet_records)
+    assert all("summit" not in str(item).lower() for item in fleet_records)
 
 
 def test_v1_acceptance_smoke_fails_when_intake_registration_is_bypassed() -> None:

--- a/tests/test_v1_acceptance_smoke.py
+++ b/tests/test_v1_acceptance_smoke.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -185,8 +186,27 @@ def test_v1_acceptance_smoke_fails_when_conflict_case_lacks_queue_or_audit_evide
 
 
 def test_v1_smoke_pipeline_uses_inmemory_sink_even_with_langsmith_env(monkeypatch) -> None:
-    monkeypatch.setenv("INV_MAN_TRACING_ENABLED", "true")
-    monkeypatch.setenv("LANGCHAIN_TRACING_V2", "true")
+    class _FakeLangSmithClient:
+        def __init__(self) -> None:
+            self.create_calls: list[dict[str, Any]] = []
+
+        def create_run(self, **kwargs: Any) -> None:
+            self.create_calls.append(kwargs)
+
+        def update_run(self, run_id: Any, **kwargs: Any) -> None:
+            return None
+
+    clients: list[_FakeLangSmithClient] = []
+
+    def _fake_client_factory() -> _FakeLangSmithClient:
+        client = _FakeLangSmithClient()
+        clients.append(client)
+        return client
+
+    monkeypatch.setattr(
+        "inv_man_intake.observability.langsmith_sink._default_client_factory",
+        _fake_client_factory,
+    )
     monkeypatch.setenv("LANGSMITH_API_KEY", "lsv2_pt_test")
 
     artifacts = run_v1_smoke_pipeline(
@@ -196,6 +216,8 @@ def test_v1_smoke_pipeline_uses_inmemory_sink_even_with_langsmith_env(monkeypatc
     )
 
     assert isinstance(artifacts.sink, InMemoryTraceSink)
+    assert len(clients) == 1
+    assert len(clients[0].create_calls) > 0
 
 
 def _start_event(sink: InMemoryTraceSink, name: str):

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -5,6 +5,7 @@
 - Automation: `pd-workloop-resume` (codex opener lane).
 - Source repo: `stranske/Inv-Man-Intake`.
 - Source issue: `#438` (`Ensure extraction pipeline exports useful LangSmith metadata`).
+- Source PR: `#454` (`https://github.com/stranske/Inv-Man-Intake/pull/454`), non-draft, labels `agent:codex` + `agents:keepalive` + `autofix`.
 - Branch: `codex/issue-438-langsmith-intake-metadata`.
 - Selection:
   - ACTION A succeeded from the neutral Code workspace.
@@ -20,7 +21,8 @@
   - `python -m pytest tests/observability/test_langsmith_fleet.py tests/observability/test_langsmith_export.py tests/test_v1_acceptance_smoke.py -q --no-cov` (`15 passed`).
   - `python -m ruff check src/inv_man_intake/observability/langsmith_fleet.py src/inv_man_intake/observability/langsmith_sink.py src/inv_man_intake/observability/tracing.py src/inv_man_intake/observability/__init__.py src/inv_man_intake/v1_smoke.py tests/observability/test_langsmith_fleet.py tests/test_v1_acceptance_smoke.py`.
   - `git diff --check`.
-- Next action: commit, push, open a non-draft PR with `agent:codex`, `agents:keepalive`, and `autofix`; then keepalive owns any CI fixups or review-comment work.
+- Relay event emitted: `pr_opened active.source_repo=stranske/Inv-Man-Intake active.source_issue=438 active.source_pr=454 active.next_action=wait_for_keepalive`.
+- Next action: keepalive's Codex runner takes over for CI fixups or review-comment work; opener is done with this lane.
 
 ## 2026-05-11T03:18:00Z - opener lane issue #27 feedback report materialization
 

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,5 +1,27 @@
 # Workloop State
 
+## 2026-05-24T04:20:00Z - opener lane issue #438 LangSmith fleet metadata
+
+- Automation: `pd-workloop-resume` (codex opener lane).
+- Source repo: `stranske/Inv-Man-Intake`.
+- Source issue: `#438` (`Ensure extraction pipeline exports useful LangSmith metadata`).
+- Branch: `codex/issue-438-langsmith-intake-metadata`.
+- Selection:
+  - ACTION A succeeded from the neutral Code workspace.
+  - Required priority searches found only the Workflows auth-expiry ops alert, skipped as operational maintenance.
+  - Approved issue queue remains empty/stale for `2026-05-23`; open supported-repo issue sweep found remaining LangSmith child issues.
+  - Cap-health after infra repair reported `total_opener_owned=2`, `raw_cap_reached=false`, `normal_cap_reached=false`, and `non_drainable_cap_blocker=false`; existing PRs `Workflows#2151` and `Counter_Risk#629` were draining.
+- Implementation:
+  - Added `inv_man_intake.observability.langsmith_fleet` for Workflows-compatible `langsmith-fleet/v1` NDJSON records covering package intake, document extraction, validation/escalation, and scoring summary operations.
+  - Defaulted LangSmith project metadata to repo-specific `inv-man-intake` when `LANGSMITH_API_KEY` is present, while preserving clean `no_secret` behavior without credentials.
+  - Wired the v1 smoke pipeline artifacts to expose dashboard-safe fleet records with trace ID, package/document identifiers, redaction status, extraction count, validation/confidence state, retry count, score count, and review queue outcome.
+  - Updated the LangSmith runbook and README with fleet artifact validation guidance.
+- Validation passed:
+  - `python -m pytest tests/observability/test_langsmith_fleet.py tests/observability/test_langsmith_export.py tests/test_v1_acceptance_smoke.py -q --no-cov` (`15 passed`).
+  - `python -m ruff check src/inv_man_intake/observability/langsmith_fleet.py src/inv_man_intake/observability/langsmith_sink.py src/inv_man_intake/observability/tracing.py src/inv_man_intake/observability/__init__.py src/inv_man_intake/v1_smoke.py tests/observability/test_langsmith_fleet.py tests/test_v1_acceptance_smoke.py`.
+  - `git diff --check`.
+- Next action: commit, push, open a non-draft PR with `agent:codex`, `agents:keepalive`, and `autofix`; then keepalive owns any CI fixups or review-comment work.
+
 ## 2026-05-11T03:18:00Z - opener lane issue #27 feedback report materialization
 
 - Automation: `pd-workloop-resume` (codex opener lane).


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:438 -->
> **Source:** Issue #438

Closes #438

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Inv-Man-Intake has valuable operational data across package intake, document processing, extraction, redaction, validation, scoring, and review queues. The repo plan calls for production-capable package intake, provenance, human review escalation, retry behavior, cross-stage trace propagation, and observability from the start. Current LangSmith work needs to become consistent enough for package-level debugging and dashboard optimization.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [stranske/Workflows#2150](https://github.com/stranske/Workflows/issues/2150)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [x] Audit the production/manual entry points that run package intake and extraction.
- [x] Ensure a LangSmith sink/context is enabled when `LANGSMITH_API_KEY` is available.
- [x] Propagate correlation IDs through package, document, extraction, validation, scoring, and review stages.
- [ ] Add shared metadata for package/run ID, provider, model, latency, status, trace ID/URL, and error category.
- [ ] Add domain metadata for package/document identifiers, document type, redaction status, extraction count, validation status, confidence/escalation state, retry count, score count, and review queue outcome where available.
- [x] Include trace references in summary logs or artifacts that operators already inspect.
- [x] Emit dashboard-compatible `langsmith-fleet/v1` NDJSON records with shared fields plus Inv-Man-Intake domain metadata.
- [x] Add fixtures or tests for successful extraction, validation failure, escalation, and no-secret fallback.
- [ ] Update docs/runbooks that explain how to inspect package-level traces and dashboard artifacts.

#### Acceptance criteria
- [ ] Production and manual intake/extraction runs enable LangSmith tracing when configured.
- [x] Missing `LANGSMITH_API_KEY` causes a clean no-op without changing pipeline behavior.
- [ ] Trace metadata includes package, document, redaction, extraction-count, validation, provider/model, trace ID/URL, and error fields.
- [ ] Cross-stage correlation IDs make package-level debugging possible.
- [ ] Dashboard records validate against the Workflows fleet contract from stranske/Workflows#2150.
- [ ] Dashboard artifacts avoid raw documents and sensitive extracted values; hashes or artifact references are used where needed.
- [ ] Tests cover trace metadata creation, dashboard record emission, escalation/error cases, and no-secret fallback.

<!-- auto-status-summary:end -->