### PR TITLE
Add headless inv-man-ingest entry point that writes run.json + artifacts (#473)

### DIFF
--- a/.github/workflows/pr-00-gate.yml
+++ b/.github/workflows/pr-00-gate.yml
@@ -49,7 +49,7 @@ jobs:
       classification_rationale: ${{ steps.classify.outputs.classification-rationale || 'path classifier unavailable' }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Classify changed paths
         id: classify
@@ -90,7 +90,7 @@ jobs:
       description: ${{ steps.summarize.outputs.description }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           sparse-checkout: |
             .github/scripts
@@ -151,7 +151,7 @@ jobs:
 
       - name: Report Gate commit status
         if: ${{ always() }}
-        uses: actions/github-script@v9.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         env:
           STATE: ${{ steps.summarize.outputs.state || 'pending' }}
           DESCRIPTION: ${{ steps.summarize.outputs.description || 'Gate status pending' }}

--- a/docs/runbooks/headless_ingest.md
+++ b/docs/runbooks/headless_ingest.md
@@ -1,0 +1,49 @@
+# Headless ingest runbook (`inv-man-ingest`)
+
+The `inv-man-ingest` console script runs the full deterministic
+intake → extraction → thresholds → performance → queue → scoring path for a
+single intake bundle and writes one replayable `run.json` plus three named
+artifact files to an operator-supplied output directory. It is the production,
+orchestrator-callable counterpart to the `run_v1_smoke_pipeline` test helper;
+both delegate to the single core `inv_man_intake.v1_smoke._run_pipeline_core`,
+exposed for headless use as `inv_man_intake.run.run_pipeline`.
+
+## Invocation
+
+```bash
+# Console script (installed via [project.scripts]):
+inv-man-ingest tests/fixtures/intake/pdf_primary_mixed_bundle.json --out ./.run-out
+
+# Equivalent module form:
+python -m inv_man_intake.cli.ingest tests/fixtures/intake/pdf_primary_mixed_bundle.json --out ./.run-out
+```
+
+- `bundle` (positional): path to the intake bundle JSON file.
+- `--out` (required): output directory. Created if missing.
+
+Exit codes: `0` on success, `2` if the bundle file does not exist, `1` if the
+bundle is structurally invalid or registration is rejected.
+
+## Output directory layout
+
+All four files are written directly into the supplied `--out` directory:
+
+| File | Contents |
+| --- | --- |
+| `run.json` | Top-level replayable run record: `run_id`, `inputs`, per-field `fields`, `confidence_state`, `escalation_state`, `final_score`, `explainability`, `warnings`, `latency_ms`, `provenance` (per-field evidence pointers), `trace_refs`, `artifact_refs`. |
+| `metadata.json` | Package / firm / fund IDs plus per-document metadata (file name, hash, fund, received-at, source channel). |
+| `threshold-summary.json` | The `confidence.document.*` summary fields plus the threshold decision (coverage ratio, auto-pass, escalation reason, auto-accept fields). |
+| `explainability.json` | The deterministic `format_explainability_payload` output (per-component weights, contributions, rationale). |
+
+## Data-zone constraint (privacy / LLM boundary)
+
+The deterministic core (intake, `PdfPrimaryExtractionProvider`, thresholds,
+scoring) performs **zero network/LLM egress**, so it may be run on real
+proprietary packages locally. `run.json` is a *full* per-run artifact that can
+carry extracted field values, so it is written **only** to the operator-supplied
+`--out` directory and is **never** emitted to the fleet telemetry NDJSON sink
+(which enforces its own `SENSITIVE_FIELD_TOKENS` denylist and
+`redacted_metadata_only` status). Do not redirect `--out` into a fleet/telemetry
+upload path. Any future LLM-backed extraction provider must be gated behind an
+authorized no-train endpoint with redaction, or disabled for the proprietary
+zone — out of scope for this entry point.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,9 @@ dev = [
 Homepage = "https://github.com/stranske/Inv-Man-Intake"
 Repository = "https://github.com/stranske/Inv-Man-Intake"
 
+[project.scripts]
+inv-man-ingest = "inv_man_intake.cli.ingest:main"
+
 [tool.setuptools.package-data]
 inv_man_intake = ["data/migrations/sql/*.sql"]
 

--- a/src/inv_man_intake/cli/__init__.py
+++ b/src/inv_man_intake/cli/__init__.py
@@ -1,0 +1,1 @@
+"""Command-line entry points for the inv_man_intake package."""

--- a/src/inv_man_intake/cli/ingest.py
+++ b/src/inv_man_intake/cli/ingest.py
@@ -1,0 +1,73 @@
+"""Headless ``inv-man-ingest`` console entry point.
+
+Runs the deterministic intake-to-scoring pipeline for one intake bundle and
+writes ``run.json`` plus the named artifact files to an output directory.
+
+Invocation forms (both supported):
+
+    inv-man-ingest <bundle.json> --out <output_dir>
+    python -m inv_man_intake.cli.ingest <bundle.json> --out <output_dir>
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+
+from inv_man_intake.run import RunResult, run_pipeline
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="inv-man-ingest",
+        description=(
+            "Run the deterministic intake-to-scoring pipeline headlessly and write "
+            "run.json plus named artifacts to an output directory (zero data egress)."
+        ),
+    )
+    parser.add_argument("bundle", help="Path to the intake bundle JSON file.")
+    parser.add_argument(
+        "--out",
+        required=True,
+        help="Output directory for run.json and the named artifact files.",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the ingest pipeline. Returns 0 on success, non-zero on failure."""
+
+    parser = _build_parser()
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    bundle_path = Path(args.bundle)
+    output_dir = Path(args.out)
+
+    if not bundle_path.is_file():
+        print(f"error: intake bundle not found: {bundle_path}", file=sys.stderr)
+        return 2
+
+    try:
+        result = run_pipeline(bundle_path, output_dir=output_dir)
+    except (ValueError, KeyError, json.JSONDecodeError, OSError) as exc:
+        print(f"error: intake run failed: {exc}", file=sys.stderr)
+        return 1
+
+    _print_summary(result=result, output_dir=output_dir)
+    return 0
+
+
+def _print_summary(*, result: RunResult, output_dir: Path) -> None:
+    print(f"run_id: {result.run_id}")
+    print(f"final_score: {result.final_score}")
+    print(f"escalation: {result.escalation_state.get('reason')}")
+    print(f"output_dir: {output_dir}")
+    for ref in result.artifact_refs:
+        print(f"artifact: {output_dir / ref}")
+
+
+if __name__ == "__main__":  # pragma: no cover - module CLI shim
+    raise SystemExit(main())

--- a/src/inv_man_intake/observability/entrypoints.py
+++ b/src/inv_man_intake/observability/entrypoints.py
@@ -53,6 +53,15 @@ def audit_intake_extraction_entrypoints() -> tuple[PipelineEntrypoint, ...]:
                 "run_v1_smoke_pipeline -> ExtractionOrchestrator.run",
                 "python -m inv_man_intake.readiness.throughput",
             ),
+            (
+                "ingest_cli",
+                "inv_man_intake.cli.ingest",
+                "main",
+                "production",
+                "run_pipeline -> register_intake_bundle_file",
+                "run_pipeline -> ExtractionOrchestrator.run",
+                "python -m inv_man_intake.cli.ingest <bundle> --out <output_dir>",
+            ),
         )
     )
 

--- a/src/inv_man_intake/run.py
+++ b/src/inv_man_intake/run.py
@@ -1,0 +1,254 @@
+"""Headless intake run entry point: ``package -> run.json + named artifacts``.
+
+This module exposes :func:`run_pipeline`, the reusable core that executes the
+deterministic intake -> extraction -> thresholds -> performance -> queue ->
+scoring path for an arbitrary intake bundle and writes a single replayable
+``run.json`` plus the three already-named artifact files
+(``metadata.json``, ``threshold-summary.json``, ``explainability.json``) into
+an operator-supplied output directory.
+
+The orchestration itself lives in :func:`inv_man_intake.v1_smoke._run_pipeline_core`,
+which the acceptance smoke (``run_v1_smoke_pipeline``) also delegates to, so the
+operator CLI and the smoke test share one code path.
+
+Privacy / data-zone note: the deterministic core (intake,
+``PdfPrimaryExtractionProvider``, thresholds, scoring) has zero data egress and
+may run on real proprietary packages locally. ``run.json`` is a full per-run
+artifact carrying field values, so it is written only to the operator-supplied
+``output_dir`` and is never emitted to the fleet telemetry NDJSON sink, which
+enforces its own redaction denylist.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, cast
+
+from inv_man_intake.extraction.confidence import ThresholdDecision
+from inv_man_intake.intake.integration import IntakeRegistrationResult
+from inv_man_intake.intake.models import IngestRecord
+from inv_man_intake.observability.tracing import TraceContext
+from inv_man_intake.scoring.contracts import ScoreResult
+from inv_man_intake.v1_smoke import V1SmokeArtifacts, _pipeline_latency_ms, _run_pipeline_core
+
+_ROOT_SPAN_NAME = "v1_acceptance.intake_register"
+
+ARTIFACT_RUN = "run.json"
+ARTIFACT_METADATA = "metadata.json"
+ARTIFACT_THRESHOLD = "threshold-summary.json"
+ARTIFACT_EXPLAINABILITY = "explainability.json"
+
+
+@dataclass(frozen=True)
+class RunResult:
+    """Replayable per-run record produced by :func:`run_pipeline`.
+
+    Every field is concretely typed (no bare ``object``) and JSON-serializable.
+    :meth:`to_json` returns a plain ``dict`` whose deterministic on-disk form is
+    produced with ``json.dumps(..., sort_keys=True)``.
+    """
+
+    run_id: str
+    inputs: dict[str, Any]
+    fields: list[dict[str, Any]]
+    confidence_state: dict[str, Any]
+    escalation_state: dict[str, Any]
+    final_score: float
+    explainability: dict[str, Any]
+    warnings: list[str]
+    latency_ms: int | None
+    provenance: dict[str, Any]
+    trace_refs: list[str]
+    artifact_refs: list[str]
+
+    def to_json(self) -> dict[str, Any]:
+        """Return the run record as a JSON-serializable dictionary."""
+
+        return {
+            "run_id": self.run_id,
+            "inputs": self.inputs,
+            "fields": self.fields,
+            "confidence_state": self.confidence_state,
+            "escalation_state": self.escalation_state,
+            "final_score": self.final_score,
+            "explainability": self.explainability,
+            "warnings": self.warnings,
+            "latency_ms": self.latency_ms,
+            "provenance": self.provenance,
+            "trace_refs": self.trace_refs,
+            "artifact_refs": self.artifact_refs,
+        }
+
+
+def run_pipeline(bundle_path: Path, *, output_dir: Path) -> RunResult:
+    """Run the intake pipeline for ``bundle_path`` and write artifacts to ``output_dir``.
+
+    Returns the :class:`RunResult`. Writes ``run.json`` plus the three named
+    artifact files into ``output_dir`` (created if missing). Raises
+    :class:`ValueError` for a structurally invalid or rejected bundle.
+    """
+
+    bundle = json.loads(bundle_path.read_text(encoding="utf-8"))
+    if not isinstance(bundle, dict):
+        raise ValueError("intake bundle root must be a JSON object")
+    package_id = bundle.get("package_id")
+    if not isinstance(package_id, str) or not package_id.strip():
+        raise ValueError("intake bundle must declare a non-empty string package_id")
+
+    artifacts = _run_pipeline_core(
+        fixture_root=bundle_path.parent,
+        intake_bundle_file=bundle_path.name,
+        package_id=package_id,
+    )
+    result = _build_run_result(artifacts)
+    _write_run_artifacts(result=result, artifacts=artifacts, output_dir=output_dir)
+    return result
+
+
+def _build_run_result(artifacts: V1SmokeArtifacts) -> RunResult:
+    record = cast(IngestRecord, artifacts.record)
+    score = cast(ScoreResult, artifacts.score)
+    decision = cast(ThresholdDecision, artifacts.threshold_decision)
+    trace_context = cast(TraceContext, artifacts.trace_context)
+    registration = cast(IntakeRegistrationResult, artifacts.registration)
+    extraction = artifacts.extraction_with_thresholds
+
+    fields = [
+        {
+            "key": field.key,
+            "value": field.value,
+            "confidence": field.confidence,
+            "source_doc_id": field.source_doc_id,
+            "source_page": field.source_page,
+        }
+        for field in extraction.fields
+    ]
+    evidence = {
+        field.key: {
+            "source_doc_id": field.source_doc_id,
+            "source_page": field.source_page,
+        }
+        for field in extraction.fields
+    }
+
+    return RunResult(
+        run_id=trace_context.run_id or trace_context.trace_id,
+        inputs={
+            "package_id": record.package_id,
+            "firm_id": record.firm_id,
+            "fund_id": record.fund_id,
+            "file_count": record.file_count,
+            "status": record.status,
+            "document_ids": list(record.document_ids),
+        },
+        fields=fields,
+        confidence_state={
+            "key_field_coverage_ratio": decision.key_field_coverage_ratio,
+            "auto_pass_document": decision.auto_pass_document,
+            "auto_accept_fields": list(decision.auto_accept_fields),
+        },
+        escalation_state={
+            "escalate": decision.escalate,
+            "reason": decision.escalation_reason or "none",
+            "auto_pass_document": decision.auto_pass_document,
+        },
+        final_score=score.final_score,
+        explainability=dict(artifacts.formatted_explainability),
+        warnings=_collect_warnings(registration=registration, decision=decision),
+        latency_ms=_pipeline_latency_ms(sink=artifacts.sink, root_span_name=_ROOT_SPAN_NAME),
+        provenance={
+            "tool": "inv-man-ingest",
+            "provider": extraction.provider_name,
+            "evidence": evidence,
+        },
+        trace_refs=[f"trace:{trace_context.trace_id}"],
+        artifact_refs=[
+            ARTIFACT_RUN,
+            ARTIFACT_METADATA,
+            ARTIFACT_THRESHOLD,
+            ARTIFACT_EXPLAINABILITY,
+        ],
+    )
+
+
+def _collect_warnings(
+    *,
+    registration: IntakeRegistrationResult,
+    decision: ThresholdDecision,
+) -> list[str]:
+    warnings = [f"intake:{issue.code}" for issue in registration.warnings]
+    if decision.escalate and decision.escalation_reason:
+        warnings.append(f"threshold:{decision.escalation_reason}")
+    return sorted(warnings)
+
+
+def _build_metadata(artifacts: V1SmokeArtifacts) -> dict[str, Any]:
+    record = cast(IngestRecord, artifacts.record)
+    repository = artifacts.core_repository
+    documents: list[dict[str, Any]] = []
+    for document_id in record.document_ids:
+        document = repository.get_document(document_id)
+        if document is None:
+            documents.append({"document_id": document_id})
+            continue
+        documents.append(
+            {
+                "document_id": document_id,
+                "file_name": document.file_name,
+                "file_hash": document.file_hash,
+                "fund_id": document.fund_id,
+                "received_at": document.received_at,
+                "source_channel": document.source_channel,
+            }
+        )
+    return {
+        "package_id": record.package_id,
+        "firm_id": record.firm_id,
+        "fund_id": record.fund_id,
+        "file_count": record.file_count,
+        "status": record.status,
+        "created_at": record.created_at,
+        "updated_at": record.updated_at,
+        "documents": documents,
+    }
+
+
+def _build_threshold_summary(artifacts: V1SmokeArtifacts) -> dict[str, Any]:
+    decision = cast(ThresholdDecision, artifacts.threshold_decision)
+    extraction = artifacts.extraction_with_thresholds
+    document_fields = {
+        field.key: field.value
+        for field in extraction.fields
+        if field.key.startswith("confidence.document.")
+    }
+    return {
+        "document": document_fields,
+        "key_field_coverage_ratio": decision.key_field_coverage_ratio,
+        "auto_pass_document": decision.auto_pass_document,
+        "escalate": decision.escalate,
+        "escalation_reason": decision.escalation_reason or "none",
+        "auto_accept_fields": list(decision.auto_accept_fields),
+    }
+
+
+def _write_run_artifacts(
+    *,
+    result: RunResult,
+    artifacts: V1SmokeArtifacts,
+    output_dir: Path,
+) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    _write_json(output_dir / ARTIFACT_RUN, result.to_json())
+    _write_json(output_dir / ARTIFACT_METADATA, _build_metadata(artifacts))
+    _write_json(output_dir / ARTIFACT_THRESHOLD, _build_threshold_summary(artifacts))
+    _write_json(output_dir / ARTIFACT_EXPLAINABILITY, dict(artifacts.formatted_explainability))
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, sort_keys=True, indent=2) + "\n",
+        encoding="utf-8",
+    )

--- a/src/inv_man_intake/run.py
+++ b/src/inv_man_intake/run.py
@@ -86,8 +86,12 @@ def run_pipeline(bundle_path: Path, *, output_dir: Path) -> RunResult:
     """Run the intake pipeline for ``bundle_path`` and write artifacts to ``output_dir``.
 
     Returns the :class:`RunResult`. Writes ``run.json`` plus the three named
-    artifact files into ``output_dir`` (created if missing). Raises
-    :class:`ValueError` for a structurally invalid or rejected bundle.
+    artifact files into ``output_dir`` (created if missing).
+
+    Raises:
+        ValueError: The bundle is malformed, declares no usable ``package_id``,
+            or is rejected by intake validation.
+        OSError: The bundle or output artifact paths cannot be read or written.
     """
 
     bundle = json.loads(bundle_path.read_text(encoding="utf-8"))

--- a/src/inv_man_intake/v1_smoke.py
+++ b/src/inv_man_intake/v1_smoke.py
@@ -117,6 +117,38 @@ def run_v1_smoke_pipeline(
     package_id: str,
     expected_document_ids: tuple[str, ...],
 ) -> V1SmokeArtifacts:
+    """Run the smoke pipeline with strict package/document-id assertions.
+
+    Thin wrapper that delegates to :func:`_run_pipeline_core`, the single
+    orchestration code path also used by the headless ``run_pipeline`` entry
+    point in :mod:`inv_man_intake.run`. Keeping one core means the operator
+    CLI and the acceptance smoke exercise identical pipeline behavior.
+    """
+
+    return _run_pipeline_core(
+        fixture_root=fixture_root,
+        intake_bundle_file=intake_bundle_file,
+        package_id=package_id,
+        expected_document_ids=expected_document_ids,
+    )
+
+
+def _run_pipeline_core(
+    *,
+    fixture_root: Path,
+    intake_bundle_file: str = "pdf_primary_mixed_bundle.json",
+    package_id: str,
+    expected_document_ids: tuple[str, ...] | None = None,
+) -> V1SmokeArtifacts:
+    """Execute the deterministic intake-to-scoring pipeline once.
+
+    When ``expected_document_ids`` is provided (the smoke path), the registered
+    package state is asserted exactly. When it is ``None`` (the headless
+    ``run_pipeline`` path), registration is validated softly: a rejected bundle
+    raises :class:`ValueError` instead of asserting, so the CLI can surface a
+    clean non-zero exit rather than an ``AssertionError`` traceback.
+    """
+
     sink = InMemoryTraceSink()
     tracer = _entrypoint_tracer(sink=sink)
     correlation_id = ensure_correlation_id()
@@ -143,11 +175,17 @@ def run_v1_smoke_pipeline(
             document_store=document_store,
         )
 
-    record = _assert_registered_package_state(
-        service=service,
-        package_id=package_id,
-        expected_document_ids=expected_document_ids,
-    )
+    if expected_document_ids is None:
+        if not registration.accepted:
+            rejected = ", ".join(issue.code for issue in registration.errors) or "unknown"
+            raise ValueError(f"intake bundle registration rejected: {rejected}")
+        record = service.get_record(package_id)
+    else:
+        record = _assert_registered_package_state(
+            service=service,
+            package_id=package_id,
+            expected_document_ids=expected_document_ids,
+        )
     intake_start = _start_event(sink, "v1_acceptance.intake_register")
     extracted_context = extract_trace_context(inject_trace_context(trace_context))
     assert extracted_context is not None

--- a/tests/cli/test_ingest_entrypoint.py
+++ b/tests/cli/test_ingest_entrypoint.py
@@ -1,0 +1,63 @@
+"""Acceptance test for the headless ``inv-man-ingest`` entry point (#473)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from inv_man_intake.cli.ingest import main
+
+_BUNDLE = "tests/fixtures/intake/pdf_primary_mixed_bundle.json"
+_ARTIFACT_FILES = (
+    "run.json",
+    "metadata.json",
+    "threshold-summary.json",
+    "explainability.json",
+)
+_KEY_FIELDS = (
+    "strategy.asset_class",
+    "terms.management_fee",
+    "performance.net_return_1y",
+    "operations.aum",
+    "team.key_person_risk",
+)
+
+
+def test_ingest_entrypoint_writes_run_and_named_artifacts(tmp_path: Path) -> None:
+    exit_code = main([_BUNDLE, "--out", str(tmp_path)])
+
+    assert exit_code == 0
+    for name in _ARTIFACT_FILES:
+        assert (tmp_path / name).is_file(), f"missing artifact on disk: {name}"
+
+
+def test_ingest_run_json_carries_score_escalation_and_evidence(tmp_path: Path) -> None:
+    assert main([_BUNDLE, "--out", str(tmp_path)]) == 0
+
+    run_payload = json.loads((tmp_path / "run.json").read_text(encoding="utf-8"))
+
+    assert run_payload["final_score"] == pytest.approx(0.7809)
+    assert run_payload["escalation_state"]["reason"] == "low_key_field_coverage"
+
+    evidence = run_payload["provenance"]["evidence"]
+    for key in _KEY_FIELDS:
+        assert key in evidence, f"missing evidence pointer for key field {key}"
+        pointer = evidence[key]
+        assert pointer["source_doc_id"]
+        assert pointer["source_page"] is not None
+
+
+def test_ingest_entrypoint_returns_nonzero_for_missing_bundle(tmp_path: Path) -> None:
+    exit_code = main([str(tmp_path / "missing.json"), "--out", str(tmp_path / "out")])
+
+    assert exit_code != 0
+
+
+def test_ingest_entrypoint_returns_nonzero_for_rejected_bundle(tmp_path: Path) -> None:
+    exit_code = main(
+        ["tests/fixtures/intake/malformed_missing_metadata.json", "--out", str(tmp_path)]
+    )
+
+    assert exit_code == 1

--- a/tests/observability/test_entrypoints_audit.py
+++ b/tests/observability/test_entrypoints_audit.py
@@ -13,16 +13,25 @@ def test_audit_lists_manual_and_production_entrypoints() -> None:
     assert [entrypoint.name for entrypoint in entrypoints] == [
         "v1_smoke_pipeline",
         "throughput_readiness_batch",
+        "ingest_cli",
     ]
     assert {entrypoint.mode for entrypoint in entrypoints} == {"manual", "production"}
 
 
 def test_audited_entrypoints_resolve_to_callables() -> None:
-    for entrypoint in audit_intake_extraction_entrypoints():
+    entrypoints = audit_intake_extraction_entrypoints()
+    for entrypoint in entrypoints:
         module = import_module(entrypoint.module)
         target = getattr(module, entrypoint.function)
         assert callable(target)
         assert entrypoint.verification == "verified"
+
+    production_ingest = [
+        entrypoint
+        for entrypoint in entrypoints
+        if entrypoint.name == "ingest_cli" and entrypoint.mode == "production"
+    ]
+    assert len(production_ingest) == 1
 
 
 def test_audit_requires_intake_and_extraction_surfaces() -> None:


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:473 -->
> **Source:** Issue #473

Closes #473

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
**Why.** The agent-readiness blueprint requires a tool to be invokable headless and to return one replayable run object plus named artifacts. Today the full intake→extraction→thresholds→performance→queue→scoring path exists **only** inside `run_v1_smoke_pipeline(...)`, a test-support helper that returns `V1SmokeArtifacts` — a dataclass whose fields are typed `object` and is never serialized (`src/inv_man_intake/v1_smoke.py:85-107`, returned at `:308`). The repo's own entry-point audit classifies the only intake path as `mode="manual"` with invocation `python -c 'from inv_man_intake.v1_smoke import run_v1_smoke_pipeline'` (`src/inv_man_intake/observability/entrypoints.py:38-46`), and the readiness CLI runs a hard-coded fixture batch, not an arbitrary package (`src/inv_man_intake/readiness/throughput.py:16-36`, `:84-95`). `pyproject.toml` has no `[project.scripts]`. The missing behavior: no `package → run.json + artifacts/` invocation that an orchestrator or sibling tool in the backplane can call.

**Scope.** Add a new module `src/inv_man_intake/cli/ingest.py` (new `src/inv_man_intake/cli/__init__.py`) plus a `src/inv_man_intake/run.py` that: accepts an intake bundle path + an output directory, runs the existing pipeline stages via a refactored reusable core, and writes (a) one top-level `run.json` (who/what/why: run_id, validated input echo, per-field outputs, confidence/escalation, evidence pointers, final score, explainability, warnings, latency_ms, provenance, trace_refs) and (b) the three already-named artifact files under a per-run directory. Reuse `build_summary_from_pipeline` / `build_fleet_records` (`src/inv_man_intake/observability/langsmith_fleet.py:147,217`) and `format_explainability_payload` (`src/inv_man_intake/scoring/explainability.py:74`).

**Non-Goals.** New extraction providers or real PDF/PPTX parsing beyond `PdfPrimaryExtractionProvider`; a web/HTTP/API server; any public-SaaS deployment surface; changing scoring math, thresholds (`ThresholdConfig` values in `v1_smoke.py:178-184`), or weight configs. **A scaffold that prints JSON to stdout but does not write `run.json` + all three artifact files to disk does NOT satisfy this issue**; nor does leaving `run_v1_smoke_pipeline` as the only caller of the new core.

**Tasks.**

#### Tasks
- [ ] Extract the orchestration body of `run_v1_smoke_pipeline` (`src/inv_man_intake/v1_smoke.py:110-330`) into a reusable `run_pipeline(bundle_path: Path, *, output_dir: Path) -> RunResult` in `src/inv_man_intake/run.py`, and make `run_v1_smoke_pipeline` delegate to it so there is a single code path.
- [ ] Define a frozen `RunResult` dataclass in `src/inv_man_intake/run.py` with concretely-typed (not `object`) fields and a `to_json() -> dict[str, Any]` producing deterministic `json.dumps(..., sort_keys=True)` output; required keys: `run_id`, `inputs`, `fields`, `confidence_state`, `escalation_state`, `final_score`, `explainability`, `warnings`, `latency_ms`, `provenance`, `trace_refs`, `artifact_refs`.
- [ ] Replace the literal artifact pointer strings (`src/inv_man_intake/v1_smoke.py:274-278`) with real writes: serialize `metadata.json` (package/firm/fund IDs + document metadata from `record`), `threshold-summary.json` (the `confidence.document.*` fields from `attach_threshold_summary`, `src/inv_man_intake/extraction/confidence.py:140-176`), and `explainability.json` (`format_explainability_payload(...)` output). Model the writes on `write_fleet_records` (`langsmith_fleet.py:261-276`): `path.parent.mkdir(parents=True, exist_ok=True)` + UTF-8.
- [ ] Add `src/inv_man_intake/cli/ingest.py` with an `argparse` parser (`bundle` positional, `--out` required, mirroring the style of `readiness/throughput.py:173-184`) and a `main(argv) -> int` returning non-zero when validation fails.
- [ ] Register a `inv-man-ingest` console script under a new `[project.scripts]` table in `pyproject.toml`, and add the new entry point to `audit_intake_extraction_entrypoints()` (`src/inv_man_intake/observability/entrypoints.py:37-56`) with `mode="production"`.
- [ ] Add a runbook section under `docs/runbooks/` documenting headless invocation, the output directory layout, and the data-zone constraint (below).

#### Acceptance criteria
- [ ] New failing-first test `tests/cli/test_ingest_entrypoint.py` invokes `main(["tests/fixtures/intake/pdf_primary_mixed_bundle.json", "--out", str(tmp_path)])`, asserts exit code 0, and asserts the run dir contains `run.json`, `metadata.json`, `threshold-summary.json`, and `explainability.json` on disk.
- [ ] The same test asserts `run.json` parses, carries `final_score == pytest.approx(0.7809)` (the golden value pinned in `tests/test_v1_acceptance_smoke.py:109`), `escalation_state` reflecting `low_key_field_coverage`, and ≥1 evidence pointer (`source_doc_id` + `source_page`) for each of the five key fields in `_assert_extraction_contains_provenance` (`tests/test_v1_acceptance_smoke.py:283-289`).
- [ ] `tests/observability/test_entrypoints_audit.py::test_audited_entrypoints_resolve_to_callables` (which iterates `audit_intake_extraction_entrypoints()` and asserts `verification == "verified"`) passes with the new production entry point present; extend it to assert one entry has `mode="production"` and `name="ingest_cli"`.
- [ ] Running `inv-man-ingest tests/fixtures/intake/pdf_primary_mixed_bundle.json --out ./.run-out` from a clean checkout exits 0 and produces the four files. *(documented live-verification gate; record the command + `ls` of the output dir in the PR)*

<!-- auto-status-summary:end -->