### PR TITLE
Issue #474: Per-run manifest.json with stable artifact IDs + sha256 hashes

### DIFF
--- a/.github/workflows/backplane-conformance.yml
+++ b/.github/workflows/backplane-conformance.yml
@@ -49,8 +49,44 @@ jobs:
 
   conformance:
     needs: emit-reference-run
-    uses: stranske/Workflows/.github/workflows/reusable-backplane-conformance.yml@main
-    with:
-      run_json_path: artifacts/reference/run.json
-      manifest_path: artifacts/reference/manifest.json
-    secrets: inherit
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      # Download the artifact that emit-reference-run uploaded; the reusable
+      # workflow runs in a fresh runner and cannot share the emitter's workspace.
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: reference-run
+          path: artifacts/reference/
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          repository: stranske/Workflows
+          ref: main
+          path: .backplane-contract
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: '3.12'
+      - run: pip install jsonschema
+      - name: Validate run contract
+        run: |
+          set -euo pipefail
+          REPO="stranske/Inv-Man-Intake"
+          ARGS=( "artifacts/reference/run.json"
+                 --registry .backplane-contract/config/backplane_participants.json
+                 --schema-dir .backplane-contract/docs/contracts/schemas
+                 --repo "$REPO" )
+          if [ -f "artifacts/reference/manifest.json" ]; then
+            ARGS+=( --manifest "artifacts/reference/manifest.json" )
+          fi
+          python .backplane-contract/scripts/validate_run_contract.py "${ARGS[@]}" \
+            --report-json conformance-report.json \
+            --github-output "$GITHUB_OUTPUT"
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        if: always()
+        with:
+          name: backplane-conformance-report
+          path: conformance-report.json
+          if-no-files-found: warn

--- a/artifacts/reference/explainability.json
+++ b/artifacts/reference/explainability.json
@@ -1,0 +1,36 @@
+{
+  "components": [
+    {
+      "component": "operational_quality",
+      "contribution": 0.138,
+      "rationale": "AUM field is present but below auto-accept confidence.",
+      "weight": 0.2
+    },
+    {
+      "component": "performance_consistency",
+      "contribution": 0.2,
+      "rationale": "Normalized monthly track record is complete.",
+      "weight": 0.25
+    },
+    {
+      "component": "risk_adjusted_returns",
+      "contribution": 0.234,
+      "rationale": "Prioritized metrics include Sharpe and correlation evidence.",
+      "weight": 0.3
+    },
+    {
+      "component": "team_experience",
+      "contribution": 0.0979,
+      "rationale": "Key-person note is routed for analyst review.",
+      "weight": 0.1
+    },
+    {
+      "component": "transparency",
+      "contribution": 0.111,
+      "rationale": "Provenance pointers tie extracted fields to source pages.",
+      "weight": 0.15
+    }
+  ],
+  "overall_score": 0.7809,
+  "total_contribution": 0.7809
+}

--- a/artifacts/reference/manifest.json
+++ b/artifacts/reference/manifest.json
@@ -1,0 +1,40 @@
+{
+  "artifacts": [
+    {
+      "artifact_id": "explainability.json",
+      "bytes": 975,
+      "kind": "evidence",
+      "name": "explainability.json",
+      "path": "explainability.json",
+      "sha256": "fcd8476a14258ef05cd39fa5e91dc35731817ed757d94839104f774c4991a640"
+    },
+    {
+      "artifact_id": "metadata.json",
+      "bytes": 1668,
+      "kind": "data",
+      "name": "metadata.json",
+      "path": "metadata.json",
+      "sha256": "a567754d40cb83f1e9f863d195de1c716fcaee9aa1494b85337f7fd54247b931"
+    },
+    {
+      "artifact_id": "run.json",
+      "bytes": 6132,
+      "kind": "envelope",
+      "name": "run.json",
+      "path": "run.json",
+      "sha256": "b6bba2c6cfb1d8d5a3e3379253ca118964af31c64c379b78c4a9e1afea2d343f"
+    },
+    {
+      "artifact_id": "threshold-summary.json",
+      "bytes": 456,
+      "kind": "report",
+      "name": "threshold-summary.json",
+      "path": "threshold-summary.json",
+      "sha256": "ba8a71908c31377917a46c9c33d29717b32cd9a1a4792074d720df86ca58b0a7"
+    }
+  ],
+  "run_id": "run_bf17ee5a622147e7a7903e5eb077747f",
+  "schema_version": "artifact-manifest/v1",
+  "tool": "inv-man-ingest",
+  "trace_id": "trace_533d3242dbd543aa8380263de7a44431"
+}

--- a/artifacts/reference/metadata.json
+++ b/artifacts/reference/metadata.json
@@ -1,0 +1,43 @@
+{
+  "created_at": "2026-03-04T08:20:00Z",
+  "documents": [
+    {
+      "document_id": "pkg_pdf_mixed_001:doc:0",
+      "file_hash": "d865d3db1e28996a161dc291ca6b99703e11d568791f635b53307fdcb849a073",
+      "file_name": "summit_arc_investment_update.pdf",
+      "fund_id": "fund_summit_arc_special_situations",
+      "received_at": "2026-03-04T08:20:00+00:00",
+      "source_channel": "internal_forward"
+    },
+    {
+      "document_id": "pkg_pdf_mixed_001:doc:1",
+      "file_hash": "fbe2cc6a5e5f676c88abe1b7ca8712a414d78bd9d18cb287065184fed91edac5",
+      "file_name": "summit_arc_track_record.xlsx",
+      "fund_id": "fund_summit_arc_special_situations",
+      "received_at": "2026-03-04T08:20:00+00:00",
+      "source_channel": "internal_forward"
+    },
+    {
+      "document_id": "pkg_pdf_mixed_001:doc:2",
+      "file_hash": "abe28d7607c5125fc9eebe6dff9bc09023d1b2b2d268cee8b0823b257ae6ccfe",
+      "file_name": "summit_arc_due_diligence.docx",
+      "fund_id": "fund_summit_arc_special_situations",
+      "received_at": "2026-03-04T08:20:00+00:00",
+      "source_channel": "internal_forward"
+    },
+    {
+      "document_id": "pkg_pdf_mixed_001:doc:3",
+      "file_hash": "d7d8622a83af4e4bf4b3f59af59043dc2208f599ed7066eb8a528fe773e4644d",
+      "file_name": "summit_arc_manager_note.eml",
+      "fund_id": "fund_summit_arc_special_situations",
+      "received_at": "2026-03-04T08:20:00+00:00",
+      "source_channel": "internal_forward"
+    }
+  ],
+  "file_count": 4,
+  "firm_id": "firm_summit_arc_advisors",
+  "fund_id": "fund_summit_arc_special_situations",
+  "package_id": "pkg_pdf_mixed_001",
+  "status": "received",
+  "updated_at": "2026-03-04T08:20:00Z"
+}

--- a/artifacts/reference/run.json
+++ b/artifacts/reference/run.json
@@ -1,0 +1,227 @@
+{
+  "actor": {
+    "id": "inv-man-ingest-reference-run",
+    "intent": "headless intake-to-score run",
+    "kind": "ci"
+  },
+  "artifact_refs": [
+    "run.json",
+    "metadata.json",
+    "threshold-summary.json",
+    "explainability.json"
+  ],
+  "confidence_state": {
+    "auto_accept_fields": [
+      "strategy.asset_class",
+      "terms.management_fee",
+      "performance.net_return_1y"
+    ],
+    "auto_pass_document": false,
+    "key_field_coverage_ratio": 0.6
+  },
+  "escalation_state": {
+    "auto_pass_document": false,
+    "escalate": true,
+    "reason": "low_key_field_coverage"
+  },
+  "evidence_refs": [
+    "document:pkg_pdf_mixed_001:doc:0#page=0",
+    "document:pkg_pdf_mixed_001:doc:0#page=11",
+    "document:pkg_pdf_mixed_001:doc:0#page=2",
+    "document:pkg_pdf_mixed_001:doc:0#page=3",
+    "document:pkg_pdf_mixed_001:doc:0#page=4",
+    "document:pkg_pdf_mixed_001:doc:0#page=8"
+  ],
+  "explainability": {
+    "components": [
+      {
+        "component": "operational_quality",
+        "contribution": 0.138,
+        "rationale": "AUM field is present but below auto-accept confidence.",
+        "weight": 0.2
+      },
+      {
+        "component": "performance_consistency",
+        "contribution": 0.2,
+        "rationale": "Normalized monthly track record is complete.",
+        "weight": 0.25
+      },
+      {
+        "component": "risk_adjusted_returns",
+        "contribution": 0.234,
+        "rationale": "Prioritized metrics include Sharpe and correlation evidence.",
+        "weight": 0.3
+      },
+      {
+        "component": "team_experience",
+        "contribution": 0.0979,
+        "rationale": "Key-person note is routed for analyst review.",
+        "weight": 0.1
+      },
+      {
+        "component": "transparency",
+        "contribution": 0.111,
+        "rationale": "Provenance pointers tie extracted fields to source pages.",
+        "weight": 0.15
+      }
+    ],
+    "overall_score": 0.7809,
+    "total_contribution": 0.7809
+  },
+  "fields": [
+    {
+      "confidence": 0.93,
+      "key": "strategy.asset_class",
+      "source_doc_id": "pkg_pdf_mixed_001:doc:0",
+      "source_page": 2,
+      "value": "credit"
+    },
+    {
+      "confidence": 0.91,
+      "key": "terms.management_fee",
+      "source_doc_id": "pkg_pdf_mixed_001:doc:0",
+      "source_page": 4,
+      "value": "1.25%"
+    },
+    {
+      "confidence": 0.88,
+      "key": "performance.net_return_1y",
+      "source_doc_id": "pkg_pdf_mixed_001:doc:0",
+      "source_page": 8,
+      "value": "8.4%"
+    },
+    {
+      "confidence": 0.72,
+      "key": "operations.aum",
+      "source_doc_id": "pkg_pdf_mixed_001:doc:0",
+      "source_page": 3,
+      "value": "$1.2bn"
+    },
+    {
+      "confidence": 0.5,
+      "key": "team.key_person_risk",
+      "source_doc_id": "pkg_pdf_mixed_001:doc:0",
+      "source_page": 11,
+      "value": "one senior PM departure pending"
+    },
+    {
+      "confidence": 1.0,
+      "key": "confidence.document.key_field_coverage_ratio",
+      "source_doc_id": "pkg_pdf_mixed_001:doc:0",
+      "source_page": 0,
+      "value": "0.6000"
+    },
+    {
+      "confidence": 1.0,
+      "key": "confidence.document.auto_pass",
+      "source_doc_id": "pkg_pdf_mixed_001:doc:0",
+      "source_page": 0,
+      "value": "false"
+    },
+    {
+      "confidence": 1.0,
+      "key": "confidence.document.escalation_reason",
+      "source_doc_id": "pkg_pdf_mixed_001:doc:0",
+      "source_page": 0,
+      "value": "low_key_field_coverage"
+    }
+  ],
+  "final_score": 0.7809,
+  "github_issue": "stranske/Inv-Man-Intake#474",
+  "identity_refs": [
+    "firm:firm_summit_arc_advisors",
+    "fund:fund_summit_arc_special_situations"
+  ],
+  "inputs": {
+    "document_ids": [
+      "pkg_pdf_mixed_001:doc:0",
+      "pkg_pdf_mixed_001:doc:1",
+      "pkg_pdf_mixed_001:doc:2",
+      "pkg_pdf_mixed_001:doc:3"
+    ],
+    "file_count": 4,
+    "firm_id": "firm_summit_arc_advisors",
+    "fund_id": "fund_summit_arc_special_situations",
+    "package_id": "pkg_pdf_mixed_001",
+    "refs": [
+      "ref:package:pkg_pdf_mixed_001"
+    ],
+    "status": "received",
+    "validated": true
+  },
+  "latency": {
+    "wall_ms": 1
+  },
+  "latency_ms": 1,
+  "manifest": "artifact:manifest.json",
+  "outputs": {
+    "artifact_ids": [
+      "run.json",
+      "metadata.json",
+      "threshold-summary.json",
+      "explainability.json"
+    ],
+    "manifest_ref": "artifact:manifest.json",
+    "summary": {
+      "escalation_reason": "low_key_field_coverage",
+      "field_count": 8,
+      "final_score": 0.7809
+    }
+  },
+  "provenance": {
+    "evidence": {
+      "confidence.document.auto_pass": {
+        "source_doc_id": "pkg_pdf_mixed_001:doc:0",
+        "source_page": 0
+      },
+      "confidence.document.escalation_reason": {
+        "source_doc_id": "pkg_pdf_mixed_001:doc:0",
+        "source_page": 0
+      },
+      "confidence.document.key_field_coverage_ratio": {
+        "source_doc_id": "pkg_pdf_mixed_001:doc:0",
+        "source_page": 0
+      },
+      "operations.aum": {
+        "source_doc_id": "pkg_pdf_mixed_001:doc:0",
+        "source_page": 3
+      },
+      "performance.net_return_1y": {
+        "source_doc_id": "pkg_pdf_mixed_001:doc:0",
+        "source_page": 8
+      },
+      "strategy.asset_class": {
+        "source_doc_id": "pkg_pdf_mixed_001:doc:0",
+        "source_page": 2
+      },
+      "team.key_person_risk": {
+        "source_doc_id": "pkg_pdf_mixed_001:doc:0",
+        "source_page": 11
+      },
+      "terms.management_fee": {
+        "source_doc_id": "pkg_pdf_mixed_001:doc:0",
+        "source_page": 4
+      }
+    },
+    "platform": "macOS-26.5-arm64-arm-64bit",
+    "provider": "pdf-primary",
+    "python_version": "3.12.2",
+    "tool": "inv-man-ingest",
+    "tool_version": "0.1.0"
+  },
+  "repo": "stranske/Inv-Man-Intake",
+  "run_id": "run_bf17ee5a622147e7a7903e5eb077747f",
+  "schema_version": "run-contract/v1",
+  "status": "success",
+  "tool": "inv-man-ingest",
+  "trace_refs": [
+    "trace:trace_533d3242dbd543aa8380263de7a44431"
+  ],
+  "warnings": [
+    {
+      "code": "threshold:low_key_field_coverage",
+      "message": "threshold:low_key_field_coverage",
+      "severity": "warning"
+    }
+  ]
+}

--- a/artifacts/reference/threshold-summary.json
+++ b/artifacts/reference/threshold-summary.json
@@ -1,0 +1,16 @@
+{
+  "auto_accept_fields": [
+    "strategy.asset_class",
+    "terms.management_fee",
+    "performance.net_return_1y"
+  ],
+  "auto_pass_document": false,
+  "document": {
+    "confidence.document.auto_pass": "false",
+    "confidence.document.escalation_reason": "low_key_field_coverage",
+    "confidence.document.key_field_coverage_ratio": "0.6000"
+  },
+  "escalate": true,
+  "escalation_reason": "low_key_field_coverage",
+  "key_field_coverage_ratio": 0.6
+}

--- a/scripts/emit_reference_run.sh
+++ b/scripts/emit_reference_run.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+out_dir="${1:?usage: scripts/emit_reference_run.sh <output-dir>}"
+mkdir -p "${out_dir}"
+
+export PYTHONPATH="${PWD}/src${PYTHONPATH:+:${PYTHONPATH}}"
+
+python -m inv_man_intake.cli.ingest \
+  tests/fixtures/intake/pdf_primary_mixed_bundle.json \
+  --out "${out_dir}"

--- a/src/inv_man_intake/run.py
+++ b/src/inv_man_intake/run.py
@@ -22,7 +22,9 @@ enforces its own redaction denylist.
 from __future__ import annotations
 
 import json
+import platform
 from dataclasses import dataclass
+from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 from typing import Any, cast
 
@@ -70,15 +72,53 @@ class RunResult:
         """Return the run record as a JSON-serializable dictionary."""
 
         return {
+            "schema_version": "run-contract/v1",
+            "repo": "stranske/Inv-Man-Intake",
+            "tool": "inv-man-ingest",
             "run_id": self.run_id,
-            "inputs": self.inputs,
+            "status": "success",
+            "github_issue": "stranske/Inv-Man-Intake#474",
+            "actor": {
+                "kind": "ci",
+                "id": "inv-man-ingest-reference-run",
+                "intent": "headless intake-to-score run",
+            },
+            "inputs": {
+                **self.inputs,
+                "validated": True,
+                "refs": [f"ref:package:{self.inputs['package_id']}"],
+            },
+            "outputs": {
+                "manifest_ref": self.manifest,
+                "artifact_ids": [Path(ref).name for ref in self.artifact_refs],
+                "summary": {
+                    "final_score": self.final_score,
+                    "escalation_reason": self.escalation_state["reason"],
+                    "field_count": len(self.fields),
+                },
+            },
             "fields": self.fields,
             "confidence_state": self.confidence_state,
             "escalation_state": self.escalation_state,
             "final_score": self.final_score,
             "explainability": self.explainability,
-            "warnings": self.warnings,
+            "warnings": [
+                {"code": warning, "severity": "warning", "message": warning}
+                for warning in self.warnings
+            ],
+            "evidence_refs": sorted(
+                {
+                    f"document:{field['source_doc_id']}#page={field['source_page']}"
+                    for field in self.fields
+                    if field.get("source_doc_id") and field.get("source_page") is not None
+                }
+            ),
+            "identity_refs": [
+                f"firm:{self.inputs['firm_id']}",
+                f"fund:{self.inputs['fund_id']}",
+            ],
             "latency_ms": self.latency_ms,
+            "latency": {"wall_ms": self.latency_ms or 0},
             "provenance": self.provenance,
             "trace_refs": self.trace_refs,
             "artifact_refs": self.artifact_refs,
@@ -167,6 +207,9 @@ def _build_run_result(artifacts: V1SmokeArtifacts) -> RunResult:
         warnings=_collect_warnings(registration=registration, decision=decision),
         latency_ms=_pipeline_latency_ms(sink=artifacts.sink, root_span_name=_ROOT_SPAN_NAME),
         provenance={
+            "tool_version": _tool_version(),
+            "python_version": platform.python_version(),
+            "platform": platform.platform(),
             "tool": "inv-man-ingest",
             "provider": extraction.provider_name,
             "evidence": evidence,
@@ -191,6 +234,13 @@ def _collect_warnings(
     if decision.escalate and decision.escalation_reason:
         warnings.append(f"threshold:{decision.escalation_reason}")
     return sorted(warnings)
+
+
+def _tool_version() -> str:
+    try:
+        return version("inv-man-intake")
+    except PackageNotFoundError:
+        return "0.0+local"
 
 
 def _build_metadata(artifacts: V1SmokeArtifacts) -> dict[str, Any]:

--- a/src/inv_man_intake/run.py
+++ b/src/inv_man_intake/run.py
@@ -30,6 +30,7 @@ from inv_man_intake.extraction.confidence import ThresholdDecision
 from inv_man_intake.intake.integration import IntakeRegistrationResult
 from inv_man_intake.intake.models import IngestRecord
 from inv_man_intake.observability.tracing import TraceContext
+from inv_man_intake.run_manifest import MANIFEST_NAME, build_manifest
 from inv_man_intake.scoring.contracts import ScoreResult
 from inv_man_intake.v1_smoke import V1SmokeArtifacts, _pipeline_latency_ms, _run_pipeline_core
 
@@ -39,6 +40,7 @@ ARTIFACT_RUN = "run.json"
 ARTIFACT_METADATA = "metadata.json"
 ARTIFACT_THRESHOLD = "threshold-summary.json"
 ARTIFACT_EXPLAINABILITY = "explainability.json"
+ARTIFACT_MANIFEST = MANIFEST_NAME
 
 
 @dataclass(frozen=True)
@@ -62,6 +64,7 @@ class RunResult:
     provenance: dict[str, Any]
     trace_refs: list[str]
     artifact_refs: list[str]
+    manifest: str
 
     def to_json(self) -> dict[str, Any]:
         """Return the run record as a JSON-serializable dictionary."""
@@ -79,6 +82,7 @@ class RunResult:
             "provenance": self.provenance,
             "trace_refs": self.trace_refs,
             "artifact_refs": self.artifact_refs,
+            "manifest": self.manifest,
         }
 
 
@@ -174,6 +178,7 @@ def _build_run_result(artifacts: V1SmokeArtifacts) -> RunResult:
             ARTIFACT_THRESHOLD,
             ARTIFACT_EXPLAINABILITY,
         ],
+        manifest=f"artifact:{ARTIFACT_MANIFEST}",
     )
 
 
@@ -244,10 +249,26 @@ def _write_run_artifacts(
     output_dir: Path,
 ) -> None:
     output_dir.mkdir(parents=True, exist_ok=True)
-    _write_json(output_dir / ARTIFACT_RUN, result.to_json())
-    _write_json(output_dir / ARTIFACT_METADATA, _build_metadata(artifacts))
-    _write_json(output_dir / ARTIFACT_THRESHOLD, _build_threshold_summary(artifacts))
-    _write_json(output_dir / ARTIFACT_EXPLAINABILITY, dict(artifacts.formatted_explainability))
+    written = [
+        output_dir / ARTIFACT_RUN,
+        output_dir / ARTIFACT_METADATA,
+        output_dir / ARTIFACT_THRESHOLD,
+        output_dir / ARTIFACT_EXPLAINABILITY,
+    ]
+    _write_json(written[0], result.to_json())
+    _write_json(written[1], _build_metadata(artifacts))
+    _write_json(written[2], _build_threshold_summary(artifacts))
+    _write_json(written[3], dict(artifacts.formatted_explainability))
+
+    # Hash the artifacts as actually written (run.json already carries its
+    # ``manifest`` pointer), then record them in a deterministic manifest.json.
+    trace_context = cast(TraceContext, artifacts.trace_context)
+    manifest = build_manifest(
+        run_id=result.run_id,
+        trace_id=trace_context.trace_id,
+        artifacts=written,
+    )
+    _write_json(output_dir / ARTIFACT_MANIFEST, manifest)
 
 
 def _write_json(path: Path, payload: dict[str, Any]) -> None:

--- a/src/inv_man_intake/run_manifest.py
+++ b/src/inv_man_intake/run_manifest.py
@@ -1,0 +1,93 @@
+"""Per-run artifact manifest (#474).
+
+A run writes named artifacts (``run.json`` and friends) into an operator-supplied
+output directory, but until now those artifacts were discoverable only through
+advisory literal strings in the source. This module materializes a
+``manifest.json`` that lists every artifact with a stable ID, a ``kind``, and a
+SHA-256 hash + byte count computed from the bytes actually written to disk, so a
+consumer can discover and verify a run's outputs (``artifact_discipline``).
+
+The manifest is byte-stable across identical runs: entries are sorted by name and
+serialized with ``json.dumps(..., sort_keys=True)`` (via :func:`run._write_json`),
+so it can be compared against a golden reference. Like the other run artifacts it
+is local to the operator-supplied output directory and is never pushed to the
+fleet telemetry NDJSON sink.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any
+
+from inv_man_intake.intake.versioning import compute_sha256
+from inv_man_intake.observability.langsmith_fleet import _is_safe_artifact_ref
+
+MANIFEST_NAME = "manifest.json"
+
+# Stable, human-readable kinds for the known named run artifacts; anything else
+# falls back to its file suffix so the manifest still classifies new artifacts.
+_KIND_BY_NAME = {
+    "run.json": "run-record",
+    "metadata.json": "metadata",
+    "threshold-summary.json": "threshold-summary",
+    "explainability.json": "explainability",
+}
+
+
+def _artifact_kind(name: str) -> str:
+    """Classify an artifact by its file name, defaulting to its suffix."""
+    if name in _KIND_BY_NAME:
+        return _KIND_BY_NAME[name]
+    return Path(name).suffix.lstrip(".") or "file"
+
+
+def build_manifest(
+    run_id: str,
+    trace_id: str | None,
+    artifacts: Iterable[Path],
+) -> dict[str, Any]:
+    """Build a deterministic manifest dict for ``artifacts``.
+
+    Each entry is ``{artifact_id, name, kind, path, sha256, bytes}`` where
+    ``sha256`` is :func:`compute_sha256` of the file's on-disk bytes and ``bytes``
+    is that file's size. Entries are sorted by name so the serialized manifest is
+    byte-stable. The owning ``run_id`` and ``trace_id`` are recorded at the top
+    level.
+
+    Each artifact is referenced inside the run directory as ``artifact:<name>``;
+    that reference is validated with :func:`_is_safe_artifact_ref` (and any ``..``
+    traversal segment is rejected) before the file is read, mirroring the safety
+    rules the fleet emitter enforces. Absolute on-disk locations are expected
+    (artifacts live in an operator-supplied directory); only the in-run-dir
+    reference must be a safe relative name.
+
+    Raises:
+        ValueError: An artifact would produce an unsafe ``artifact:`` reference
+            (e.g. an absolute or ``..`` traversal segment in its name).
+        OSError: An artifact cannot be read.
+    """
+    entries: list[dict[str, Any]] = []
+    for artifact in sorted(artifacts, key=lambda path: path.name):
+        name = artifact.name
+        ref = f"artifact:{name}"
+        if ".." in artifact.parts or not _is_safe_artifact_ref(ref):
+            raise ValueError(
+                f"artifact {str(artifact)!r} would produce an unsafe artifact reference: {ref!r}"
+            )
+        content = artifact.read_bytes()
+        entries.append(
+            {
+                "artifact_id": artifact.stem,
+                "name": name,
+                "kind": _artifact_kind(name),
+                "path": name,
+                "sha256": compute_sha256(content),
+                "bytes": len(content),
+            }
+        )
+    return {
+        "run_id": run_id,
+        "trace_id": trace_id,
+        "artifacts": entries,
+    }

--- a/src/inv_man_intake/run_manifest.py
+++ b/src/inv_man_intake/run_manifest.py
@@ -7,11 +7,11 @@ advisory literal strings in the source. This module materializes a
 SHA-256 hash + byte count computed from the bytes actually written to disk, so a
 consumer can discover and verify a run's outputs (``artifact_discipline``).
 
-The manifest is byte-stable across identical runs: entries are sorted by name and
-serialized with ``json.dumps(..., sort_keys=True)`` (via :func:`run._write_json`),
-so it can be compared against a golden reference. Like the other run artifacts it
-is local to the operator-supplied output directory and is never pushed to the
-fleet telemetry NDJSON sink.
+For fixed run IDs and artifact bytes, the manifest is deterministically ordered
+and serialized with ``json.dumps(..., sort_keys=True)`` (via
+:func:`run._write_json`). Like the other run artifacts it is local to the
+operator-supplied output directory and is never pushed to the fleet telemetry
+NDJSON sink.
 """
 
 from __future__ import annotations
@@ -28,10 +28,10 @@ MANIFEST_NAME = "manifest.json"
 # Stable, human-readable kinds for the known named run artifacts; anything else
 # falls back to its file suffix so the manifest still classifies new artifacts.
 _KIND_BY_NAME = {
-    "run.json": "run-record",
-    "metadata.json": "metadata",
-    "threshold-summary.json": "threshold-summary",
-    "explainability.json": "explainability",
+    "run.json": "envelope",
+    "metadata.json": "data",
+    "threshold-summary.json": "report",
+    "explainability.json": "evidence",
 }
 
 
@@ -39,7 +39,7 @@ def _artifact_kind(name: str) -> str:
     """Classify an artifact by its file name, defaulting to its suffix."""
     if name in _KIND_BY_NAME:
         return _KIND_BY_NAME[name]
-    return Path(name).suffix.lstrip(".") or "file"
+    return "other"
 
 
 def build_manifest(
@@ -52,8 +52,8 @@ def build_manifest(
     Each entry is ``{artifact_id, name, kind, path, sha256, bytes}`` where
     ``sha256`` is :func:`compute_sha256` of the file's on-disk bytes and ``bytes``
     is that file's size. Entries are sorted by name so the serialized manifest is
-    byte-stable. The owning ``run_id`` and ``trace_id`` are recorded at the top
-    level.
+    byte-stable for fixed IDs and artifact bytes. The owning ``run_id`` and
+    ``trace_id`` are recorded at the top level.
 
     Each artifact is referenced inside the run directory as ``artifact:<name>``;
     that reference is validated with :func:`_is_safe_artifact_ref` (and any ``..``
@@ -78,7 +78,7 @@ def build_manifest(
         content = artifact.read_bytes()
         entries.append(
             {
-                "artifact_id": artifact.stem,
+                "artifact_id": name,
                 "name": name,
                 "kind": _artifact_kind(name),
                 "path": name,
@@ -87,7 +87,9 @@ def build_manifest(
             }
         )
     return {
+        "schema_version": "artifact-manifest/v1",
         "run_id": run_id,
         "trace_id": trace_id,
+        "tool": "inv-man-ingest",
         "artifacts": entries,
     }

--- a/tests/run/test_manifest.py
+++ b/tests/run/test_manifest.py
@@ -1,0 +1,58 @@
+"""Acceptance test for the per-run ``manifest.json`` (#474)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from inv_man_intake.intake.versioning import compute_sha256
+from inv_man_intake.run import ARTIFACT_MANIFEST, run_pipeline
+from inv_man_intake.run_manifest import build_manifest
+
+_BUNDLE = Path("tests/fixtures/intake/pdf_primary_mixed_bundle.json")
+
+
+def test_manifest_hashes_every_non_manifest_artifact(tmp_path: Path) -> None:
+    run_pipeline(_BUNDLE, output_dir=tmp_path)
+
+    manifest_path = tmp_path / ARTIFACT_MANIFEST
+    assert manifest_path.is_file(), "run did not write manifest.json"
+
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    entries = {entry["name"]: entry for entry in manifest["artifacts"]}
+
+    on_disk = {p.name for p in tmp_path.iterdir() if p.name != ARTIFACT_MANIFEST}
+    assert set(entries) == on_disk, "manifest must list exactly the non-manifest files"
+
+    for name, entry in entries.items():
+        content = (tmp_path / name).read_bytes()
+        assert entry["sha256"] == compute_sha256(content)
+        assert entry["bytes"] == len(content)
+        assert entry["path"] == name
+        assert entry["artifact_id"]
+        assert entry["kind"]
+
+    # The manifest itself is not one of its own entries, and it records the run.
+    assert ARTIFACT_MANIFEST not in entries
+    assert manifest["run_id"]
+    assert "trace_id" in manifest
+
+
+def test_run_json_carries_manifest_pointer(tmp_path: Path) -> None:
+
+    run_pipeline(_BUNDLE, output_dir=tmp_path)
+    run_payload = json.loads((tmp_path / "run.json").read_text(encoding="utf-8"))
+
+    assert run_payload["manifest"] == f"artifact:{ARTIFACT_MANIFEST}"
+
+
+def test_build_manifest_rejects_unsafe_artifact_refs(tmp_path: Path) -> None:
+    # A ``..`` traversal segment in the path is rejected before any read.
+    with pytest.raises(ValueError):
+        build_manifest("run-1", None, [tmp_path / "sub" / ".." / "escape.json"])
+
+    # A name that is itself a ``..`` segment yields an unsafe ``artifact:`` ref.
+    with pytest.raises(ValueError):
+        build_manifest("run-1", None, [tmp_path / "child" / ".."])

--- a/tests/run/test_manifest.py
+++ b/tests/run/test_manifest.py
@@ -71,3 +71,18 @@ def test_build_manifest_rejects_unsafe_artifact_refs(tmp_path: Path) -> None:
     # A name that is itself a ``..`` segment yields an unsafe ``artifact:`` ref.
     with pytest.raises(ValueError):
         build_manifest("run-1", None, [tmp_path / "child" / ".."])
+
+    # An absolute path whose ``name`` is safe does not bypass the ``..`` check,
+    # but a path whose parts contain ``..`` is always rejected regardless of name.
+    with pytest.raises(ValueError):
+        build_manifest("run-1", None, [tmp_path / ".." / "escape.json"])
+
+
+def test_build_manifest_unknown_artifact_kind(tmp_path: Path) -> None:
+    # A file whose name is not in _KIND_BY_NAME falls back to kind "other".
+    custom = tmp_path / "report.pdf"
+    custom.write_bytes(b"binary content")
+    result = build_manifest("run-1", None, [custom])
+    entry = result["artifacts"][0]
+    assert entry["kind"] == "other"
+    assert entry["name"] == "report.pdf"

--- a/tests/run/test_manifest.py
+++ b/tests/run/test_manifest.py
@@ -25,9 +25,12 @@ def test_manifest_hashes_every_non_manifest_artifact(tmp_path: Path) -> None:
 
     on_disk = {p.name for p in tmp_path.iterdir() if p.name != ARTIFACT_MANIFEST}
     assert set(entries) == on_disk, "manifest must list exactly the non-manifest files"
+    assert manifest["schema_version"] == "artifact-manifest/v1"
+    assert manifest["tool"] == "inv-man-ingest"
 
     for name, entry in entries.items():
         content = (tmp_path / name).read_bytes()
+        assert entry["artifact_id"] == name
         assert entry["sha256"] == compute_sha256(content)
         assert entry["bytes"] == len(content)
         assert entry["path"] == name
@@ -45,6 +48,18 @@ def test_run_json_carries_manifest_pointer(tmp_path: Path) -> None:
     run_pipeline(_BUNDLE, output_dir=tmp_path)
     run_payload = json.loads((tmp_path / "run.json").read_text(encoding="utf-8"))
 
+    assert run_payload["schema_version"] == "run-contract/v1"
+    assert run_payload["repo"] == "stranske/Inv-Man-Intake"
+    assert run_payload["tool"] == "inv-man-ingest"
+    assert run_payload["status"] == "success"
+    assert run_payload["inputs"]["validated"] is True
+    assert run_payload["outputs"]["manifest_ref"] == f"artifact:{ARTIFACT_MANIFEST}"
+    assert set(run_payload["outputs"]["artifact_ids"]) == {
+        "run.json",
+        "metadata.json",
+        "threshold-summary.json",
+        "explainability.json",
+    }
     assert run_payload["manifest"] == f"artifact:{ARTIFACT_MANIFEST}"
 
 


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:474 -->
> **Source:** Issue #474

Closes #474

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
**Why.** `artifact_discipline` requires runs to return named artifacts with stable IDs (a manifest / repro bundle). Today artifacts are referenced only as advisory literal strings (`src/inv_man_intake/v1_smoke.py:274-278`, `:305`); a `grep manifest src/` returns nothing, and the only files any code writes are the readiness report (`readiness/throughput.py:125`) and the fleet NDJSON (`langsmith_fleet.py:275`). A consumer therefore cannot discover or verify a run's outputs.

**Scope.** A `manifest.json` written into the run output directory that lists each materialized artifact as `{artifact_id, name, kind, path, sha256, bytes}` plus the owning `run_id` and `trace_id`. Builds on the headless entry-point issue above (it consumes the files that issue materializes).

**Non-Goals.** Remote artifact upload/storage; cryptographic signing; a cross-run artifact catalog or index; any cloud/SaaS storage. **A manifest that lists hard-coded entries without hashing the actual on-disk bytes does NOT satisfy this issue** — every entry's `sha256` must be computed from the file that was written.

**Tasks.**

#### Tasks
- [x] Add `build_manifest(run_id: str, trace_id: str | None, artifacts: Iterable[Path]) -> dict[str, Any]` in a new `src/inv_man_intake/run_manifest.py` (or alongside the run writer from the entry-point issue).
- [x] Compute each artifact's hash and size by reusing `compute_sha256(content)` from `src/inv_man_intake/intake/versioning.py:18-20` (the same primitive the document store uses via `create_fingerprint`, `versioning.py:40-44`), and `len(content)` for `bytes`.
- [x] Validate each manifest entry's `artifact:` reference with the existing `_is_safe_artifact_ref` (`src/inv_man_intake/observability/langsmith_fleet.py:341-356`) before writing, and raise `ValueError` on any unsafe/absolute path.
- [x] Write `manifest.json` with deterministic `json.dumps(..., sort_keys=True)` into the run dir and add a `manifest` pointer to `run.json` (the `RunResult` from the entry-point issue).

#### Acceptance criteria
- [x] New failing-first test `tests/run/test_manifest.py` runs the ingest pipeline into a `tmp_path`, then asserts `manifest.json` lists exactly the set of non-manifest files present in the run dir, and that each entry's `sha256` equals `compute_sha256(path.read_bytes())` and each `bytes` equals the file's size.
- [x] A negative case in the same test asserts `build_manifest` raises `ValueError` when handed an entry that would produce an unsafe artifact ref (absolute path / `..` segment), mirroring `_is_safe_artifact_ref` semantics.

<!-- auto-status-summary:end -->