### PR TITLE
Issue #472: Label throughput readiness as synthetic lower bound

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,10 @@ ruff check src/ tests/
 mypy
 ```
 
+The throughput readiness command reports a synthetic lower-bound fixture timing. It verifies
+that the local smoke path still produces measurable stage timings, but it excludes real
+extraction and IO cost and must not be treated as proof of live same-business-day capacity.
+
 LangSmith runtime setup and dashboard artifact fields are documented in
 [`docs/runbooks/langsmith_tracing.md`](docs/runbooks/langsmith_tracing.md).
 

--- a/docs/INV_MAN_INTAKE_PLAN_V1.md
+++ b/docs/INV_MAN_INTAKE_PLAN_V1.md
@@ -283,4 +283,8 @@ python -m inv_man_intake.readiness.throughput --output reports/readiness/through
 ```
 
 The readiness report records package count, per-stage timing, score count, escalation count,
-and bottleneck warnings against the 10 to 15 packages/week and same-business-day targets.
+`synthetic_lower_bound`, and bottleneck warnings against the 10 to 15 packages/week and
+same-business-day targets. The default fixture batch is explicitly labeled as a synthetic
+lower bound because it excludes real extraction and IO cost; it is a smoke-path capacity
+caveat, not proof of live same-business-day throughput. A realistic capacity figure requires
+a real-cost batch after the real-bytes intake path and production extractor are available.

--- a/docs/runbooks/throughput_readiness.md
+++ b/docs/runbooks/throughput_readiness.md
@@ -6,7 +6,7 @@ The same-business-day readiness check runs the deterministic v1 fixture package 
 python -m inv_man_intake.readiness.throughput --output reports/readiness/throughput_readiness.json
 ```
 
-The command exits `0` only when every required stage produces measurable output and the projected same-day fixture capacity is consistent with the v1 target of 10 to 15 manager packages per week. It exits non-zero when a stage is unavailable, timing evidence is missing, scoring produces no verifiable score, or the fixture batch exceeds the same-business-day target.
+The fixture runtime is a synthetic lower bound. It excludes real document extraction and IO cost, so it is useful for detecting smoke-path regressions but is not proof of live same-business-day throughput. The command exits `0` only when every required fixture stage produces measurable output and the projected fixture capacity is consistent with the v1 target of 10 to 15 manager packages per week. It exits non-zero when a stage is unavailable, timing evidence is missing, scoring produces no verifiable score, or the fixture batch exceeds the same-business-day target.
 
 The report fields map to the v1 targets:
 
@@ -15,6 +15,9 @@ The report fields map to the v1 targets:
 - `score_count`: count of verifiable scoring outputs produced by the batch.
 - `escalation_count`: count of deterministic escalation paths exercised by the fixture batch.
 - `projected_packages_per_business_day`: same-day capacity estimate from the observed fixture runtime.
-- `bottleneck_warnings`: concrete reasons the check is not ready for live testing.
+- `synthetic_lower_bound`: always `true` for the default fixture batch, indicating that real extraction and IO cost are excluded.
+- `bottleneck_warnings`: concrete caveats or reasons the check is not ready for live testing. The synthetic-lower-bound caveat is non-failing; missing stages, no scores, zero elapsed time, and capacity misses remain failing conditions.
 
 The default output path is ignored by git. Treat it as an operator artifact, not source material.
+
+To obtain a realistic live capacity figure, run a real-cost batch after the real-bytes intake path and production extractor are available. That follow-up should time the same stage boundaries against real package bytes instead of the deterministic fixture-only smoke path.

--- a/src/inv_man_intake/readiness/throughput.py
+++ b/src/inv_man_intake/readiness/throughput.py
@@ -39,6 +39,9 @@ MIN_PACKAGES_PER_WEEK = 10
 TARGET_PACKAGES_PER_WEEK = 15
 BUSINESS_DAYS_PER_WEEK = 5
 SAME_BUSINESS_DAY_SECONDS = 8 * 60 * 60
+SYNTHETIC_LOWER_BOUND_WARNING = (
+    "synthetic lower bound: fixture timing excludes real extraction and IO cost"
+)
 STAGE_EVENT_NAMES = {
     "intake": ("v1_acceptance.intake_register",),
     "extraction_thresholds": (
@@ -72,6 +75,7 @@ class ReadinessReport:
     same_business_day_target_seconds: int
     observed_total_seconds: float
     projected_packages_per_business_day: float
+    synthetic_lower_bound: bool
     stage_timings: list[StageTiming]
     bottleneck_warnings: list[str]
     report_path: str
@@ -153,7 +157,7 @@ def build_readiness_report(
         observed_total_seconds=observed_total_seconds,
         projected_packages_per_business_day=projected_packages_per_business_day,
     )
-    status = "pass" if not bottleneck_warnings else "fail"
+    status = "pass" if not _blocking_warnings(bottleneck_warnings) else "fail"
     return ReadinessReport(
         status=status,
         package_count=package_count,
@@ -164,6 +168,7 @@ def build_readiness_report(
         same_business_day_target_seconds=SAME_BUSINESS_DAY_SECONDS,
         observed_total_seconds=observed_total_seconds,
         projected_packages_per_business_day=projected_packages_per_business_day,
+        synthetic_lower_bound=True,
         stage_timings=stage_timings,
         bottleneck_warnings=bottleneck_warnings,
         report_path=str(output_path),
@@ -247,7 +252,7 @@ def _bottleneck_warnings(
     observed_total_seconds: float,
     projected_packages_per_business_day: float,
 ) -> list[str]:
-    warnings = []
+    warnings = [SYNTHETIC_LOWER_BOUND_WARNING]
     if missing_stages:
         warnings.append(f"missing timing evidence for stages: {', '.join(missing_stages)}")
     if score_count < 1:
@@ -260,6 +265,10 @@ def _bottleneck_warnings(
     if projected_packages_per_week < MIN_PACKAGES_PER_WEEK:
         warnings.append("projected weekly capacity is below 10 packages/week target")
     return warnings
+
+
+def _blocking_warnings(warnings: list[str]) -> list[str]:
+    return [warning for warning in warnings if warning != SYNTHETIC_LOWER_BOUND_WARNING]
 
 
 if __name__ == "__main__":

--- a/tests/readiness/test_throughput_readiness.py
+++ b/tests/readiness/test_throughput_readiness.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from inv_man_intake.observability import TraceEvent
 from inv_man_intake.readiness.throughput import (
     STAGE_EVENT_NAMES,
+    SYNTHETIC_LOWER_BOUND_WARNING,
     _bottleneck_warnings,
     _duration_for_events,
     build_readiness_report,
@@ -31,6 +32,8 @@ def test_throughput_readiness_writes_report_with_required_fields(tmp_path: Path)
     assert payload["target_packages_per_week"] == "10-15"
     assert payload["same_business_day_target_seconds"] == 28800
     assert payload["projected_packages_per_business_day"] >= 10
+    assert payload["synthetic_lower_bound"] is True
+    assert SYNTHETIC_LOWER_BOUND_WARNING in payload["bottleneck_warnings"]
 
 
 def test_throughput_readiness_fails_when_stage_output_is_missing(tmp_path: Path) -> None:
@@ -45,6 +48,19 @@ def test_throughput_readiness_fails_when_stage_output_is_missing(tmp_path: Path)
     assert report.status == "fail"
     assert "scoring stage produced no verifiable scores" in report.bottleneck_warnings
     assert any("missing timing evidence" in warning for warning in report.bottleneck_warnings)
+    assert SYNTHETIC_LOWER_BOUND_WARNING in report.bottleneck_warnings
+
+
+def test_fixture_run_is_marked_synthetic_lower_bound(tmp_path: Path) -> None:
+    output_path = tmp_path / "throughput_readiness.json"
+
+    report = run_readiness_check(output_path=output_path)
+    payload = json.loads(output_path.read_text(encoding="utf-8"))
+
+    assert report.synthetic_lower_bound is True
+    assert payload["synthetic_lower_bound"] is True
+    assert SYNTHETIC_LOWER_BOUND_WARNING in report.bottleneck_warnings
+    assert SYNTHETIC_LOWER_BOUND_WARNING in payload["bottleneck_warnings"]
 
 
 def test_duration_for_events_sums_completed_spans_by_name() -> None:


### PR DESCRIPTION
Closes #472

## Summary
- add `synthetic_lower_bound` to the throughput readiness report and persist the caveat in `bottleneck_warnings`
- keep CLI success semantics for fixture-only smoke readiness while failing on real blocking warnings
- update README, plan, and runbook wording so fixture timing is not presented as live throughput proof

## Validation
- `python -m pytest tests/readiness/test_throughput_readiness.py -q --no-cov`
- `python -m ruff check src/inv_man_intake/readiness/throughput.py tests/readiness/test_throughput_readiness.py`
- `python -m ruff format --check src/inv_man_intake/readiness/throughput.py tests/readiness/test_throughput_readiness.py`