### PR TITLE
Issue #477: Add CI golden reference runs for threshold decision branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,9 @@ jobs:
       - name: Install project with dev dependencies
         run: pip install -e ".[dev]"
 
+      - name: Run golden reference runs gate
+        run: pytest -q tests/test_golden_reference_runs.py --no-cov
+
       - name: Validate observability setup syntax
         env:
           LANGSMITH_API_KEY: lsv2_pt_ci_smoke_key

--- a/docs/runbooks/intake_fixture_catalog.md
+++ b/docs/runbooks/intake_fixture_catalog.md
@@ -14,6 +14,23 @@ This catalog maps the issue #19 intake fixture corpus to expected registration o
 | `tests/fixtures/intake/malformed_unsupported_type.json` | `malformed_unsupported_file_type_and_missing_primary` | Rejected (`accepted=false`, `status=None`, `package_id=pkg_unsupported_type_001`) | `unsupported_file_type` (`files[0].file_name`), `missing_primary_document` (`files`) |
 | `tests/fixtures/intake/malformed_corrupted_file.json` | `malformed_invalid_json_bundle` | Rejected (`accepted=false`, `status=None`, `package_id=None`) | `invalid_json_bundle` (bundle path) |
 
+## Golden reference-run scenarios
+
+These bundles are **not** intake-registration bundles. They are synthetic field
+sets fed through the deterministic extraction-threshold decision core
+(`evaluate_thresholds`) to pin the threshold decision branches via committed
+goldens in `tests/fixtures/golden/`. See `tests/test_golden_reference_runs.py`
+and `src/inv_man_intake/reference_runs.py`.
+
+| Fixture | Scenario | Expected decision branch |
+| --- | --- | --- |
+| `tests/fixtures/intake/reference_auto_pass_bundle.json` | `auto_pass` | `auto_pass_document=true`, `escalate=false` |
+| `tests/fixtures/intake/reference_missing_mandatory_bundle.json` | `missing_mandatory` | `escalate=true`, `escalation_reason=missing_mandatory_field:operations.aum` |
+| `tests/fixtures/intake/reference_confidence_below_threshold_bundle.json` | `confidence_below_threshold` | `escalate=true`, `escalation_reason=confidence_below_threshold:operations.aum` |
+
+Regenerate the goldens after an intentional decision-contract change with
+`python -m inv_man_intake.reference_runs --regenerate`.
+
 ## Notes
 
 - `tests/intake/test_ingest_integration.py` is the canonical integration test entrypoint for the registration outcomes listed above.

--- a/src/inv_man_intake/reference_runs.py
+++ b/src/inv_man_intake/reference_runs.py
@@ -1,0 +1,225 @@
+"""Golden reference runs for the deterministic extraction-threshold decision core.
+
+The acceptance smoke (:mod:`inv_man_intake.v1_smoke`) and the throughput
+readiness check both exercise a *single* escalate-shaped package
+(``pkg_pdf_mixed_001`` / ``pkg_pptx_mixed_001``), so the decision branches in
+:func:`inv_man_intake.extraction.confidence.evaluate_thresholds` that a triage
+tool must never silently regress -- ``auto_pass_document`` vs
+``missing_mandatory_field:*`` vs ``confidence_below_threshold:*`` -- have no
+named, drift-detecting golden coverage.
+
+This module builds **golden reference runs** for those branches. Each scenario
+is a synthetic field bundle (``tests/fixtures/intake/reference_*_bundle.json``)
+fed through the real ``evaluate_thresholds`` + ``attach_threshold_summary``
+decision core. The deterministic, redaction-safe subset of the result (the
+threshold decision plus per-field ``key``/``confidence``/``source_page``, with
+field *values* stripped) is serialized with ``json.dumps(..., sort_keys=True)``
+-- the same stable-writer pattern used by ``run.py`` and ``langsmith_fleet`` --
+and compared byte-for-byte against a committed golden in
+``tests/fixtures/golden/``.
+
+Privacy / data-zone note: this path is the local deterministic core with zero
+LLM/network involvement. The bundles are synthetic fixtures (no real proprietary
+values) and the serialized golden subset strips field values regardless, so
+nothing sensitive is committed.
+
+Regenerate the committed goldens after an intentional decision-contract change::
+
+    python -m inv_man_intake.reference_runs --regenerate
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+from inv_man_intake.extraction.confidence import (
+    ThresholdConfig,
+    attach_threshold_summary,
+    evaluate_thresholds,
+)
+from inv_man_intake.extraction.providers.base import (
+    ExtractedDocumentResult,
+    ExtractedField,
+)
+
+REFERENCE_SCHEMA_VERSION = "reference-run/v1"
+REFERENCE_PROVIDER_NAME = "reference-synthetic"
+
+FIXTURE_ROOT = Path("tests/fixtures/intake")
+GOLDEN_ROOT = Path("tests/fixtures/golden")
+
+# Scenario bundle file -> committed golden file. The three entries cover the
+# distinct decision branches of ``evaluate_thresholds`` that are not already
+# pinned by the single escalate-shaped acceptance smoke fixture.
+REFERENCE_SCENARIOS: tuple[tuple[str, str], ...] = (
+    ("reference_auto_pass_bundle.json", "reference_auto_pass_run.json"),
+    ("reference_missing_mandatory_bundle.json", "reference_missing_mandatory_run.json"),
+    (
+        "reference_confidence_below_threshold_bundle.json",
+        "reference_confidence_below_threshold_run.json",
+    ),
+)
+
+
+def load_bundle(path: Path) -> dict[str, Any]:
+    """Load and shallowly validate a synthetic reference scenario bundle."""
+
+    bundle = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(bundle, dict):
+        raise ValueError(f"reference bundle root must be a JSON object: {path}")
+    for required in ("scenario_id", "package_id", "source_doc_id", "key_fields", "fields"):
+        if required not in bundle:
+            raise ValueError(f"reference bundle {path} missing required key: {required}")
+    if "threshold_config" not in bundle:
+        raise ValueError(f"reference bundle {path} missing threshold_config")
+    return bundle
+
+
+def _threshold_config(bundle: dict[str, Any]) -> ThresholdConfig:
+    raw = bundle["threshold_config"]
+    return ThresholdConfig(
+        field_auto_accept_min=float(raw["field_auto_accept_min"]),
+        key_field_confidence_min=float(raw["key_field_confidence_min"]),
+        document_key_field_coverage_min=float(raw["document_key_field_coverage_min"]),
+        mandatory_field_min=float(raw["mandatory_field_min"]),
+        mandatory_fields=tuple(raw["mandatory_fields"]),
+    )
+
+
+def _extracted_result(bundle: dict[str, Any]) -> ExtractedDocumentResult:
+    source_doc_id = str(bundle["source_doc_id"])
+    fields = tuple(
+        ExtractedField(
+            key=str(field["key"]),
+            value=str(field["value"]),
+            confidence=float(field["confidence"]),
+            source_doc_id=source_doc_id,
+            source_page=int(field["source_page"]),
+        )
+        for field in bundle["fields"]
+    )
+    return ExtractedDocumentResult(
+        source_doc_id=source_doc_id,
+        fields=fields,
+        provider_name=REFERENCE_PROVIDER_NAME,
+    )
+
+
+def build_reference_run(bundle: dict[str, Any]) -> dict[str, Any]:
+    """Run a synthetic scenario through the real threshold-decision core.
+
+    Returns the deterministic, redaction-safe golden subset: the threshold
+    decision plus the per-field ``key``/``confidence``/``source_page`` inputs
+    (field *values* stripped) and the decision-derived threshold-summary fields.
+    """
+
+    config = _threshold_config(bundle)
+    result = _extracted_result(bundle)
+    key_fields = tuple(str(key) for key in bundle["key_fields"])
+
+    decision = evaluate_thresholds(result=result, key_fields=key_fields, config=config)
+    with_summary = attach_threshold_summary(result=result, decision=decision)
+
+    input_keys = {field.key for field in result.fields}
+    summary_fields = [
+        {"key": field.key, "value": field.value}
+        for field in with_summary.fields
+        if field.key not in input_keys
+    ]
+
+    return {
+        "schema_version": REFERENCE_SCHEMA_VERSION,
+        "scenario_id": str(bundle["scenario_id"]),
+        "package_id": str(bundle["package_id"]),
+        "source_doc_id": result.source_doc_id,
+        "provider_name": result.provider_name,
+        "key_fields": sorted(key_fields),
+        "decision": {
+            "auto_pass_document": decision.auto_pass_document,
+            "escalate": decision.escalate,
+            "escalation_reason": decision.escalation_reason or "none",
+            "key_field_coverage_ratio": round(decision.key_field_coverage_ratio, 4),
+            "auto_accept_fields": sorted(decision.auto_accept_fields),
+        },
+        # Redaction-safe per-field subset: deterministic decision inputs only,
+        # field values deliberately stripped. Sorted for stable goldens.
+        "fields": [
+            {
+                "key": field.key,
+                "confidence": field.confidence,
+                "source_page": field.source_page,
+            }
+            for field in sorted(result.fields, key=lambda item: item.key)
+        ],
+        "threshold_summary_fields": sorted(summary_fields, key=lambda item: item["key"]),
+    }
+
+
+def serialize_reference_run(payload: dict[str, Any]) -> str:
+    """Serialize a reference run to its stable on-disk form (sorted keys)."""
+
+    return json.dumps(payload, sort_keys=True, indent=2) + "\n"
+
+
+def iter_reference_runs(*, fixture_root: Path = FIXTURE_ROOT) -> list[tuple[str, dict[str, Any]]]:
+    """Build every committed reference scenario; returns ``(golden_name, payload)``."""
+
+    runs: list[tuple[str, dict[str, Any]]] = []
+    for bundle_name, golden_name in REFERENCE_SCENARIOS:
+        bundle = load_bundle(fixture_root / bundle_name)
+        runs.append((golden_name, build_reference_run(bundle)))
+    return runs
+
+
+def regenerate_goldens(
+    *, fixture_root: Path = FIXTURE_ROOT, golden_root: Path = GOLDEN_ROOT
+) -> list[Path]:
+    """Write the committed goldens for every scenario; returns written paths."""
+
+    golden_root.mkdir(parents=True, exist_ok=True)
+    written: list[Path] = []
+    for golden_name, payload in iter_reference_runs(fixture_root=fixture_root):
+        path = golden_root / golden_name
+        path.write_text(serialize_reference_run(payload), encoding="utf-8")
+        written.append(path)
+    return written
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--regenerate",
+        action="store_true",
+        help="Overwrite the committed goldens in tests/fixtures/golden/.",
+    )
+    parser.add_argument(
+        "--fixture-root",
+        type=Path,
+        default=FIXTURE_ROOT,
+        help=f"Scenario bundle directory. Default: {FIXTURE_ROOT}",
+    )
+    parser.add_argument(
+        "--golden-root",
+        type=Path,
+        default=GOLDEN_ROOT,
+        help=f"Committed golden directory. Default: {GOLDEN_ROOT}",
+    )
+    args = parser.parse_args(argv)
+
+    if args.regenerate:
+        written = regenerate_goldens(fixture_root=args.fixture_root, golden_root=args.golden_root)
+        for path in written:
+            print(f"wrote {path}")
+        return 0
+
+    for golden_name, payload in iter_reference_runs(fixture_root=args.fixture_root):
+        print(f"# {golden_name}")
+        print(serialize_reference_run(payload), end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/golden/reference_auto_pass_run.json
+++ b/tests/fixtures/golden/reference_auto_pass_run.json
@@ -1,0 +1,66 @@
+{
+  "decision": {
+    "auto_accept_fields": [
+      "performance.net_return_1y",
+      "strategy.asset_class",
+      "terms.management_fee"
+    ],
+    "auto_pass_document": true,
+    "escalate": false,
+    "escalation_reason": "none",
+    "key_field_coverage_ratio": 1.0
+  },
+  "fields": [
+    {
+      "confidence": 0.82,
+      "key": "operations.aum",
+      "source_page": 4
+    },
+    {
+      "confidence": 0.86,
+      "key": "performance.net_return_1y",
+      "source_page": 3
+    },
+    {
+      "confidence": 0.93,
+      "key": "strategy.asset_class",
+      "source_page": 1
+    },
+    {
+      "confidence": 0.79,
+      "key": "team.key_person_risk",
+      "source_page": 5
+    },
+    {
+      "confidence": 0.88,
+      "key": "terms.management_fee",
+      "source_page": 2
+    }
+  ],
+  "key_fields": [
+    "operations.aum",
+    "performance.net_return_1y",
+    "strategy.asset_class",
+    "team.key_person_risk",
+    "terms.management_fee"
+  ],
+  "package_id": "pkg_ref_auto_pass_001",
+  "provider_name": "reference-synthetic",
+  "scenario_id": "auto_pass",
+  "schema_version": "reference-run/v1",
+  "source_doc_id": "pkg_ref_auto_pass_001:doc:0",
+  "threshold_summary_fields": [
+    {
+      "key": "confidence.document.auto_pass",
+      "value": "true"
+    },
+    {
+      "key": "confidence.document.escalation_reason",
+      "value": "none"
+    },
+    {
+      "key": "confidence.document.key_field_coverage_ratio",
+      "value": "1.0000"
+    }
+  ]
+}

--- a/tests/fixtures/golden/reference_confidence_below_threshold_run.json
+++ b/tests/fixtures/golden/reference_confidence_below_threshold_run.json
@@ -1,0 +1,64 @@
+{
+  "decision": {
+    "auto_accept_fields": [
+      "strategy.asset_class"
+    ],
+    "auto_pass_document": false,
+    "escalate": true,
+    "escalation_reason": "confidence_below_threshold:operations.aum",
+    "key_field_coverage_ratio": 0.8
+  },
+  "fields": [
+    {
+      "confidence": 0.45,
+      "key": "operations.aum",
+      "source_page": 4
+    },
+    {
+      "confidence": 0.82,
+      "key": "performance.net_return_1y",
+      "source_page": 3
+    },
+    {
+      "confidence": 0.9,
+      "key": "strategy.asset_class",
+      "source_page": 1
+    },
+    {
+      "confidence": 0.78,
+      "key": "team.key_person_risk",
+      "source_page": 5
+    },
+    {
+      "confidence": 0.84,
+      "key": "terms.management_fee",
+      "source_page": 2
+    }
+  ],
+  "key_fields": [
+    "operations.aum",
+    "performance.net_return_1y",
+    "strategy.asset_class",
+    "team.key_person_risk",
+    "terms.management_fee"
+  ],
+  "package_id": "pkg_ref_below_threshold_001",
+  "provider_name": "reference-synthetic",
+  "scenario_id": "confidence_below_threshold",
+  "schema_version": "reference-run/v1",
+  "source_doc_id": "pkg_ref_below_threshold_001:doc:0",
+  "threshold_summary_fields": [
+    {
+      "key": "confidence.document.auto_pass",
+      "value": "false"
+    },
+    {
+      "key": "confidence.document.escalation_reason",
+      "value": "confidence_below_threshold:operations.aum"
+    },
+    {
+      "key": "confidence.document.key_field_coverage_ratio",
+      "value": "0.8000"
+    }
+  ]
+}

--- a/tests/fixtures/golden/reference_missing_mandatory_run.json
+++ b/tests/fixtures/golden/reference_missing_mandatory_run.json
@@ -1,0 +1,59 @@
+{
+  "decision": {
+    "auto_accept_fields": [
+      "strategy.asset_class"
+    ],
+    "auto_pass_document": false,
+    "escalate": true,
+    "escalation_reason": "missing_mandatory_field:operations.aum",
+    "key_field_coverage_ratio": 0.8
+  },
+  "fields": [
+    {
+      "confidence": 0.82,
+      "key": "performance.net_return_1y",
+      "source_page": 3
+    },
+    {
+      "confidence": 0.9,
+      "key": "strategy.asset_class",
+      "source_page": 1
+    },
+    {
+      "confidence": 0.78,
+      "key": "team.key_person_risk",
+      "source_page": 5
+    },
+    {
+      "confidence": 0.84,
+      "key": "terms.management_fee",
+      "source_page": 2
+    }
+  ],
+  "key_fields": [
+    "operations.aum",
+    "performance.net_return_1y",
+    "strategy.asset_class",
+    "team.key_person_risk",
+    "terms.management_fee"
+  ],
+  "package_id": "pkg_ref_missing_mandatory_001",
+  "provider_name": "reference-synthetic",
+  "scenario_id": "missing_mandatory",
+  "schema_version": "reference-run/v1",
+  "source_doc_id": "pkg_ref_missing_mandatory_001:doc:0",
+  "threshold_summary_fields": [
+    {
+      "key": "confidence.document.auto_pass",
+      "value": "false"
+    },
+    {
+      "key": "confidence.document.escalation_reason",
+      "value": "missing_mandatory_field:operations.aum"
+    },
+    {
+      "key": "confidence.document.key_field_coverage_ratio",
+      "value": "0.8000"
+    }
+  ]
+}

--- a/tests/fixtures/intake/reference_auto_pass_bundle.json
+++ b/tests/fixtures/intake/reference_auto_pass_bundle.json
@@ -1,0 +1,28 @@
+{
+  "scenario_id": "auto_pass",
+  "package_id": "pkg_ref_auto_pass_001",
+  "source_doc_id": "pkg_ref_auto_pass_001:doc:0",
+  "key_fields": [
+    "strategy.asset_class",
+    "terms.management_fee",
+    "performance.net_return_1y",
+    "operations.aum",
+    "team.key_person_risk"
+  ],
+  "threshold_config": {
+    "field_auto_accept_min": 0.85,
+    "key_field_confidence_min": 0.75,
+    "document_key_field_coverage_min": 0.8,
+    "mandatory_field_min": 0.6,
+    "mandatory_fields": [
+      "operations.aum"
+    ]
+  },
+  "fields": [
+    {"key": "strategy.asset_class", "value": "synthetic-asset-class", "confidence": 0.93, "source_page": 1},
+    {"key": "terms.management_fee", "value": "synthetic-fee", "confidence": 0.88, "source_page": 2},
+    {"key": "performance.net_return_1y", "value": "synthetic-return", "confidence": 0.86, "source_page": 3},
+    {"key": "operations.aum", "value": "synthetic-aum", "confidence": 0.82, "source_page": 4},
+    {"key": "team.key_person_risk", "value": "synthetic-team", "confidence": 0.79, "source_page": 5}
+  ]
+}

--- a/tests/fixtures/intake/reference_confidence_below_threshold_bundle.json
+++ b/tests/fixtures/intake/reference_confidence_below_threshold_bundle.json
@@ -1,0 +1,28 @@
+{
+  "scenario_id": "confidence_below_threshold",
+  "package_id": "pkg_ref_below_threshold_001",
+  "source_doc_id": "pkg_ref_below_threshold_001:doc:0",
+  "key_fields": [
+    "strategy.asset_class",
+    "terms.management_fee",
+    "performance.net_return_1y",
+    "operations.aum",
+    "team.key_person_risk"
+  ],
+  "threshold_config": {
+    "field_auto_accept_min": 0.85,
+    "key_field_confidence_min": 0.75,
+    "document_key_field_coverage_min": 0.8,
+    "mandatory_field_min": 0.6,
+    "mandatory_fields": [
+      "operations.aum"
+    ]
+  },
+  "fields": [
+    {"key": "strategy.asset_class", "value": "synthetic-asset-class", "confidence": 0.90, "source_page": 1},
+    {"key": "terms.management_fee", "value": "synthetic-fee", "confidence": 0.84, "source_page": 2},
+    {"key": "performance.net_return_1y", "value": "synthetic-return", "confidence": 0.82, "source_page": 3},
+    {"key": "operations.aum", "value": "synthetic-aum", "confidence": 0.45, "source_page": 4},
+    {"key": "team.key_person_risk", "value": "synthetic-team", "confidence": 0.78, "source_page": 5}
+  ]
+}

--- a/tests/fixtures/intake/reference_missing_mandatory_bundle.json
+++ b/tests/fixtures/intake/reference_missing_mandatory_bundle.json
@@ -1,0 +1,27 @@
+{
+  "scenario_id": "missing_mandatory",
+  "package_id": "pkg_ref_missing_mandatory_001",
+  "source_doc_id": "pkg_ref_missing_mandatory_001:doc:0",
+  "key_fields": [
+    "strategy.asset_class",
+    "terms.management_fee",
+    "performance.net_return_1y",
+    "operations.aum",
+    "team.key_person_risk"
+  ],
+  "threshold_config": {
+    "field_auto_accept_min": 0.85,
+    "key_field_confidence_min": 0.75,
+    "document_key_field_coverage_min": 0.8,
+    "mandatory_field_min": 0.6,
+    "mandatory_fields": [
+      "operations.aum"
+    ]
+  },
+  "fields": [
+    {"key": "strategy.asset_class", "value": "synthetic-asset-class", "confidence": 0.90, "source_page": 1},
+    {"key": "terms.management_fee", "value": "synthetic-fee", "confidence": 0.84, "source_page": 2},
+    {"key": "performance.net_return_1y", "value": "synthetic-return", "confidence": 0.82, "source_page": 3},
+    {"key": "team.key_person_risk", "value": "synthetic-team", "confidence": 0.78, "source_page": 5}
+  ]
+}

--- a/tests/test_golden_reference_runs.py
+++ b/tests/test_golden_reference_runs.py
@@ -1,0 +1,110 @@
+"""Golden reference-run gate for the extraction-threshold decision branches.
+
+Each scenario bundle under ``tests/fixtures/intake/reference_*_bundle.json`` is
+run through the real ``evaluate_thresholds`` decision core and its deterministic
+golden subset is compared byte-for-byte against the committed golden in
+``tests/fixtures/golden/``. This catches silent regressions in the auto-pass /
+missing-mandatory / confidence-below-threshold branches that the single
+escalate-shaped acceptance smoke fixture does not cover.
+
+Regenerate the committed goldens after an intentional decision-contract change::
+
+    python -m inv_man_intake.reference_runs --regenerate
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from inv_man_intake.reference_runs import (
+    GOLDEN_ROOT,
+    REFERENCE_SCENARIOS,
+    build_reference_run,
+    iter_reference_runs,
+    load_bundle,
+    main,
+    regenerate_goldens,
+    serialize_reference_run,
+)
+
+_FIXTURE_ROOT = Path("tests/fixtures/intake")
+
+
+@pytest.mark.parametrize(("bundle_name", "golden_name"), REFERENCE_SCENARIOS)
+def test_reference_run_matches_committed_golden(bundle_name: str, golden_name: str) -> None:
+    bundle = load_bundle(_FIXTURE_ROOT / bundle_name)
+    produced = serialize_reference_run(build_reference_run(bundle))
+    committed = (GOLDEN_ROOT / golden_name).read_text(encoding="utf-8")
+    assert produced == committed, (
+        f"{golden_name} diverged from the committed golden; "
+        "regenerate intentionally with `python -m inv_man_intake.reference_runs --regenerate`"
+    )
+
+
+def test_reference_run_gate_fails_when_a_golden_is_mutated(tmp_path: Path) -> None:
+    """The gate must fail when any deterministic field drifts from the golden."""
+
+    bundle_name, golden_name = REFERENCE_SCENARIOS[0]
+    produced = build_reference_run(load_bundle(_FIXTURE_ROOT / bundle_name))
+
+    mutated = json.loads((GOLDEN_ROOT / golden_name).read_text(encoding="utf-8"))
+    mutated["decision"]["auto_pass_document"] = not mutated["decision"]["auto_pass_document"]
+    mutated_path = tmp_path / golden_name
+    mutated_path.write_text(serialize_reference_run(mutated), encoding="utf-8")
+
+    assert serialize_reference_run(produced) != mutated_path.read_text(encoding="utf-8")
+
+
+def test_auto_pass_scenario_takes_the_auto_pass_branch() -> None:
+    payload = build_reference_run(load_bundle(_FIXTURE_ROOT / "reference_auto_pass_bundle.json"))
+    assert payload["decision"]["auto_pass_document"] is True
+    assert payload["decision"]["escalate"] is False
+    assert payload["decision"]["escalation_reason"] == "none"
+
+
+def test_missing_mandatory_scenario_takes_the_missing_field_branch() -> None:
+    payload = build_reference_run(
+        load_bundle(_FIXTURE_ROOT / "reference_missing_mandatory_bundle.json")
+    )
+    assert payload["decision"]["auto_pass_document"] is False
+    assert payload["decision"]["escalate"] is True
+    assert payload["decision"]["escalation_reason"] == "missing_mandatory_field:operations.aum"
+
+
+def test_below_threshold_scenario_takes_the_confidence_branch() -> None:
+    payload = build_reference_run(
+        load_bundle(_FIXTURE_ROOT / "reference_confidence_below_threshold_bundle.json")
+    )
+    assert payload["decision"]["auto_pass_document"] is False
+    assert payload["decision"]["escalate"] is True
+    assert payload["decision"]["escalation_reason"] == "confidence_below_threshold:operations.aum"
+
+
+def test_regenerate_is_idempotent_against_committed_goldens(tmp_path: Path) -> None:
+    """`--regenerate` into a temp dir must reproduce the committed goldens exactly."""
+
+    written = regenerate_goldens(fixture_root=_FIXTURE_ROOT, golden_root=tmp_path)
+    assert {path.name for path in written} == {golden for _, golden in REFERENCE_SCENARIOS}
+    for path in written:
+        assert path.read_text(encoding="utf-8") == (GOLDEN_ROOT / path.name).read_text(
+            encoding="utf-8"
+        )
+
+
+def test_cli_default_prints_every_scenario(capsys: pytest.CaptureFixture[str]) -> None:
+    exit_code = main(["--fixture-root", str(_FIXTURE_ROOT)])
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    for _, golden_name in REFERENCE_SCENARIOS:
+        assert golden_name in out
+    # Sanity: the printed payloads cover all three decision branches.
+    assert "missing_mandatory_field:operations.aum" in out
+    assert "confidence_below_threshold:operations.aum" in out
+
+
+def test_iter_reference_runs_covers_all_scenarios() -> None:
+    runs = iter_reference_runs(fixture_root=_FIXTURE_ROOT)
+    assert {golden for golden, _ in runs} == {golden for _, golden in REFERENCE_SCENARIOS}


### PR DESCRIPTION
Closes #477

## What

Adds named, drift-detecting **golden reference runs** for the extraction-threshold decision branches that a triage tool must never silently regress. The existing acceptance smoke (`pkg_pdf_mixed_001`) and throughput readiness check only exercise the single escalate-shaped (`low_key_field_coverage`) package, leaving these branches unpinned:

- **auto-pass** — `auto_pass_document=true`, `escalate=false`
- **missing-mandatory hard-fail** — `escalation_reason=missing_mandatory_field:operations.aum`
- **confidence-below-threshold** — `escalation_reason=confidence_below_threshold:operations.aum`

## How

- `src/inv_man_intake/reference_runs.py` — feeds synthetic field bundles through the **real** `evaluate_thresholds` + `attach_threshold_summary` decision core and serializes a deterministic, redaction-safe subset (threshold decision + per-field `key`/`confidence`/`source_page`, field **values stripped**) using the established `json.dumps(..., sort_keys=True)` stable-writer pattern. `python -m inv_man_intake.reference_runs --regenerate` rewrites the goldens.
- `tests/fixtures/intake/reference_*_bundle.json` — three synthetic scenarios (no real values).
- `tests/fixtures/golden/reference_*_run.json` — committed goldens.
- `tests/test_golden_reference_runs.py` — byte-for-byte golden gate; **proves it fails when a golden is mutated**; pins each decision branch; idempotent-regen consistency check.
- `.github/workflows/ci.yml` — runs `pytest -q tests/test_golden_reference_runs.py --no-cov` as a **required, build-failing** step in the `observability-smoke` job.
- `docs/runbooks/intake_fixture_catalog.md` — documents the reference scenarios.

## Acceptance criteria

- [x] `tests/test_golden_reference_runs.py` fails if the serialized run JSON diverges from the committed golden on any deterministic field, for both auto-pass and missing-mandatory hard-fail (+ a third below-threshold branch). Failing-first confirmed locally by mutating a committed golden (gate → exit 1).
- [x] New CI step appears in `.github/workflows/ci.yml` as a required, build-failing step.

## Scoping notes

- The headless `run_pipeline` extraction is driven by **real fixture bytes** for one escalate-shaped package, so per-branch golden runs target the genuinely package-varying deterministic output (the **threshold decision contract**) rather than the constant hardcoded `final_score`. This uses the real decision core, stronger than the issue's `run_readiness_check`-JSON fallback.
- `ExtractedField.method` (issue #476) is not yet on `main`, so the golden subset uses `key`/`source_page`/`confidence`.

## Validation

- `pytest -q tests/test_golden_reference_runs.py --no-cov` → 10 passed
- Full suite: 588 passed, coverage 91.38% (≥80% gate)
- `ruff check`, `black --check`, `mypy` on changed files → clean

Synthetic/fixture data only; deterministic local core, zero LLM/network involvement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)