### PR TITLE
chore: sync workflow templates

### DIFF
--- a/scripts/sync_test_dependencies.py
+++ b/scripts/sync_test_dependencies.py
@@ -184,8 +184,23 @@ def _detect_local_project_modules() -> set[str]:
 
     tests_dir = Path("tests")
     if tests_dir.is_dir():
+        tests_is_package = (tests_dir / "__init__.py").exists()
+        tests_on_pythonpath = _tests_dir_on_pythonpath()
         for item in tests_dir.iterdir():
             if item.name.startswith(".") or item.name == "__pycache__":
+                continue
+            if tests_is_package:
+                if item.name == "conftest.py":
+                    detected.add("conftest")
+                elif tests_on_pythonpath and item.is_dir() and (item / "__init__.py").exists():
+                    detected.add(item.name)
+                elif (
+                    tests_on_pythonpath
+                    and item.suffix == ".py"
+                    and not item.name.startswith("test_")
+                    and item.name != "__init__.py"
+                ):
+                    detected.add(item.stem)
                 continue
             if item.is_dir() and (item / "__init__.py").exists():
                 detected.add(item.name)
@@ -196,6 +211,31 @@ def _detect_local_project_modules() -> set[str]:
                     detected.add(item.stem)
 
     return detected
+
+
+def _tests_dir_on_pythonpath() -> bool:
+    if not PYPROJECT_FILE.exists():
+        return False
+    try:
+        with PYPROJECT_FILE.open("rb") as fh:
+            data = tomllib.load(fh)
+    except (OSError, tomllib.TOMLDecodeError):
+        return False
+
+    pytest_options = (
+        data.get("tool", {}).get("pytest", {}).get("ini_options", {})
+        if isinstance(data, dict)
+        else {}
+    )
+    pythonpath = pytest_options.get("pythonpath", [])
+    if isinstance(pythonpath, str):
+        entries = pythonpath.split()
+    elif isinstance(pythonpath, list):
+        entries = [str(entry) for entry in pythonpath]
+    else:
+        entries = []
+
+    return any(entry.strip().rstrip("/").removeprefix("./") == "tests" for entry in entries)
 
 
 def _read_local_modules() -> set[str]:


### PR DESCRIPTION
## Sync Summary

### Files Updated
- sync_test_dependencies.py: Syncs test dependency pins - required by reusable CI workflow

### Files Skipped
- pr-00-gate.yml: File exists and sync_mode is create_only
- ci.yml: File exists and sync_mode is create_only
- dependabot.yml: File exists and sync_mode is create_only
- llm_slots.json: None

---

### Review Checklist
- [ ] CI passes with updated workflows
- [ ] No repo-specific customizations were overwritten

**Source:** stranske/Workflows
**Source SHA:** `d0a03fccf2d7417ee2f6dd1179b0ad9cf42a39c1`
**Template hash:** `d22940a86187`
**Sync branch:** `sync/workflows-d22940a86187`
**Consumer repo:** `stranske/Inv-Man-Intake`
**Manifest:** `.github/sync-manifest.yml`

<!-- workflows-consumer-sync:v1 {"schema":"workflows-consumer-sync-pr/v1","consumer_repo":"stranske/Inv-Man-Intake","source_repository":"stranske/Workflows","source_sha":"d0a03fccf2d7417ee2f6dd1179b0ad9cf42a39c1","template_hash":"d22940a86187","sync_branch":"sync/workflows-d22940a86187","manifest":".github/sync-manifest.yml","lifecycle_state":"opened","run_id":"26855924407","run_attempt":"1","changes_count":1} -->