### PR TITLE
Issue #518: wire production threshold config

### DIFF
--- a/docs/contracts/extraction_thresholds.md
+++ b/docs/contracts/extraction_thresholds.md
@@ -5,6 +5,7 @@ Issue: #22
 ## Config Source
 
 Thresholds are loaded from [`config/extraction_thresholds.yaml`](../../config/extraction_thresholds.yaml) using `load_threshold_config` in `src/inv_man_intake/extraction/confidence.py`.
+Production headless runs (`run_pipeline()` and `inv-man-ingest`) load this YAML by default; `inv-man-ingest --threshold-config PATH` can point a run at an alternate policy file.
 The loader intentionally supports a strict subset:
 - scalar numeric keys must be plain `key: value` entries
 - `mandatory_fields` must use block-list syntax (`mandatory_fields:` followed by `- field.key` lines)

--- a/src/inv_man_intake/cli/ingest.py
+++ b/src/inv_man_intake/cli/ingest.py
@@ -34,6 +34,12 @@ def _build_parser() -> argparse.ArgumentParser:
         required=True,
         help="Output directory for run.json and the named artifact files.",
     )
+    parser.add_argument(
+        "--threshold-config",
+        default=None,
+        metavar="PATH",
+        help="Threshold YAML config path (default: repo-bundled config/extraction_thresholds.yaml).",
+    )
     return parser
 
 
@@ -45,13 +51,18 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     bundle_path = Path(args.bundle)
     output_dir = Path(args.out)
+    threshold_config_path = Path(args.threshold_config) if args.threshold_config else None
 
     if not bundle_path.is_file():
         print(f"error: intake bundle not found: {bundle_path}", file=sys.stderr)
         return 2
 
     try:
-        result = run_pipeline(bundle_path, output_dir=output_dir)
+        result = run_pipeline(
+            bundle_path,
+            output_dir=output_dir,
+            threshold_config_path=threshold_config_path,
+        )
     except (ValueError, KeyError, json.JSONDecodeError, OSError) as exc:
         print(f"error: intake run failed: {exc}", file=sys.stderr)
         return 1

--- a/src/inv_man_intake/run.py
+++ b/src/inv_man_intake/run.py
@@ -44,7 +44,9 @@ ARTIFACT_METADATA = "metadata.json"
 ARTIFACT_THRESHOLD = "threshold-summary.json"
 ARTIFACT_EXPLAINABILITY = "explainability.json"
 ARTIFACT_MANIFEST = MANIFEST_NAME
-DEFAULT_THRESHOLD_CONFIG_PATH = Path(__file__).resolve().parents[2] / "config" / "extraction_thresholds.yaml"
+DEFAULT_THRESHOLD_CONFIG_PATH = (
+    Path(__file__).resolve().parents[2] / "config" / "extraction_thresholds.yaml"
+)
 
 
 @dataclass(frozen=True)

--- a/src/inv_man_intake/run.py
+++ b/src/inv_man_intake/run.py
@@ -28,7 +28,7 @@ from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 from typing import Any, cast
 
-from inv_man_intake.extraction.confidence import ThresholdDecision
+from inv_man_intake.extraction.confidence import ThresholdDecision, load_threshold_config
 from inv_man_intake.extraction.providers.base import SnippetMetadata, SourceLocation
 from inv_man_intake.intake.integration import IntakeRegistrationResult
 from inv_man_intake.intake.models import IngestRecord
@@ -44,6 +44,7 @@ ARTIFACT_METADATA = "metadata.json"
 ARTIFACT_THRESHOLD = "threshold-summary.json"
 ARTIFACT_EXPLAINABILITY = "explainability.json"
 ARTIFACT_MANIFEST = MANIFEST_NAME
+DEFAULT_THRESHOLD_CONFIG_PATH = Path(__file__).resolve().parents[2] / "config" / "extraction_thresholds.yaml"
 
 
 @dataclass(frozen=True)
@@ -127,7 +128,12 @@ class RunResult:
         }
 
 
-def run_pipeline(bundle_path: Path, *, output_dir: Path) -> RunResult:
+def run_pipeline(
+    bundle_path: Path,
+    *,
+    output_dir: Path,
+    threshold_config_path: Path | None = None,
+) -> RunResult:
     """Run the intake pipeline for ``bundle_path`` and write artifacts to ``output_dir``.
 
     Returns the :class:`RunResult`. Writes ``run.json`` plus the three named
@@ -146,10 +152,12 @@ def run_pipeline(bundle_path: Path, *, output_dir: Path) -> RunResult:
     if not isinstance(package_id, str) or not package_id.strip():
         raise ValueError("intake bundle must declare a non-empty string package_id")
 
+    threshold_config = load_threshold_config(threshold_config_path or DEFAULT_THRESHOLD_CONFIG_PATH)
     artifacts = _run_pipeline_core(
         fixture_root=bundle_path.parent,
         intake_bundle_file=bundle_path.name,
         package_id=package_id,
+        threshold_config=threshold_config,
     )
     result = _build_run_result(artifacts)
     _write_run_artifacts(result=result, artifacts=artifacts, output_dir=output_dir)

--- a/src/inv_man_intake/v1_smoke.py
+++ b/src/inv_man_intake/v1_smoke.py
@@ -139,6 +139,7 @@ def _run_pipeline_core(
     intake_bundle_file: str = "pdf_primary_mixed_bundle.json",
     package_id: str,
     expected_document_ids: tuple[str, ...] | None = None,
+    threshold_config: ThresholdConfig | None = None,
 ) -> V1SmokeArtifacts:
     """Execute the deterministic intake-to-scoring pipeline once.
 
@@ -218,7 +219,7 @@ def _run_pipeline_core(
         context=extraction_context,
         metadata={"package_id": record.package_id},
     ):
-        threshold_config = ThresholdConfig(
+        effective_threshold_config = threshold_config or ThresholdConfig(
             field_auto_accept_min=0.85,
             key_field_confidence_min=0.75,
             document_key_field_coverage_min=0.80,
@@ -234,7 +235,7 @@ def _run_pipeline_core(
                 "operations.aum",
                 "team.key_person_risk",
             ),
-            config=threshold_config,
+            config=effective_threshold_config,
         )
         extraction_with_thresholds = attach_threshold_summary(
             result=extraction_result,

--- a/tests/run/test_pipeline_threshold_config.py
+++ b/tests/run/test_pipeline_threshold_config.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
+import inv_man_intake.run as run_module
 from inv_man_intake.extraction.confidence import load_threshold_config
 from inv_man_intake.run import DEFAULT_THRESHOLD_CONFIG_PATH, run_pipeline
 
@@ -16,14 +19,7 @@ _MANDATORY_FIELDS = {
 }
 
 
-def test_yaml_mandatory_fields_match_v1_contract() -> None:
-    config = load_threshold_config(DEFAULT_THRESHOLD_CONFIG_PATH)
-
-    assert set(config.mandatory_fields) == _MANDATORY_FIELDS
-
-
-def test_run_pipeline_uses_yaml_mandatory_fields(tmp_path: Path) -> None:
-    config_path = tmp_path / "strict-thresholds.yaml"
+def _write_strict_threshold_config(config_path: Path) -> None:
     config_path.write_text(
         "\n".join(
             [
@@ -40,6 +36,37 @@ def test_run_pipeline_uses_yaml_mandatory_fields(tmp_path: Path) -> None:
         ),
         encoding="utf-8",
     )
+
+
+def test_yaml_mandatory_fields_match_v1_contract() -> None:
+    config = load_threshold_config(DEFAULT_THRESHOLD_CONFIG_PATH)
+
+    assert set(config.mandatory_fields) == _MANDATORY_FIELDS
+
+
+def test_run_pipeline_uses_default_yaml_mandatory_fields(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_path = tmp_path / "strict-thresholds.yaml"
+    _write_strict_threshold_config(config_path)
+    monkeypatch.setattr(run_module, "DEFAULT_THRESHOLD_CONFIG_PATH", config_path)
+
+    output_dir = tmp_path / "out"
+    run_pipeline(_BUNDLE, output_dir=output_dir)
+
+    summary = json.loads((output_dir / "threshold-summary.json").read_text(encoding="utf-8"))
+
+    assert summary["escalate"] is True
+    assert summary["escalation_reason"] == "confidence_below_threshold:operations.aum"
+    assert (
+        summary["document"]["confidence.document.escalation_reason"]
+        == "confidence_below_threshold:operations.aum"
+    )
+
+
+def test_run_pipeline_uses_yaml_mandatory_fields(tmp_path: Path) -> None:
+    config_path = tmp_path / "strict-thresholds.yaml"
+    _write_strict_threshold_config(config_path)
 
     output_dir = tmp_path / "out"
     run_pipeline(_BUNDLE, output_dir=output_dir, threshold_config_path=config_path)

--- a/tests/run/test_pipeline_threshold_config.py
+++ b/tests/run/test_pipeline_threshold_config.py
@@ -1,0 +1,54 @@
+"""Tests for production threshold-config wiring (#518)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from inv_man_intake.extraction.confidence import load_threshold_config
+from inv_man_intake.run import DEFAULT_THRESHOLD_CONFIG_PATH, run_pipeline
+
+_BUNDLE = Path("tests/fixtures/intake/pdf_primary_mixed_bundle.json")
+_MANDATORY_FIELDS = {
+    "terms.management_fee",
+    "performance.net_return_1y",
+    "operations.aum",
+}
+
+
+def test_yaml_mandatory_fields_match_v1_contract() -> None:
+    config = load_threshold_config(DEFAULT_THRESHOLD_CONFIG_PATH)
+
+    assert set(config.mandatory_fields) == _MANDATORY_FIELDS
+
+
+def test_run_pipeline_uses_yaml_mandatory_fields(tmp_path: Path) -> None:
+    config_path = tmp_path / "strict-thresholds.yaml"
+    config_path.write_text(
+        "\n".join(
+            [
+                "field_auto_accept_min: 0.85",
+                "key_field_confidence_min: 0.75",
+                "document_key_field_coverage_min: 0.80",
+                "mandatory_field_min: 0.80",
+                "mandatory_fields:",
+                "  - terms.management_fee",
+                "  - performance.net_return_1y",
+                "  - operations.aum",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    output_dir = tmp_path / "out"
+    run_pipeline(_BUNDLE, output_dir=output_dir, threshold_config_path=config_path)
+
+    summary = json.loads((output_dir / "threshold-summary.json").read_text(encoding="utf-8"))
+
+    assert summary["escalate"] is True
+    assert summary["escalation_reason"] == "confidence_below_threshold:operations.aum"
+    assert (
+        summary["document"]["confidence.document.escalation_reason"]
+        == "confidence_below_threshold:operations.aum"
+    )

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,3 +1,14 @@
+## 2026-06-03T16:08:45Z - opener (codex) issue #518 -> PR #519
+
+- Lane: opener / new_issue. Materialized approved weekly-review queue item as issue **#518** (`Wire load_threshold_config() from config/extraction_thresholds.yaml into the headless ingest production path`) and opened ready-for-review PR **#519**.
+- Branch/worktree: `codex/issue-518-threshold-config` at `/Users/teacher/.codex/automations/pd-workloop-resume/worktrees/inv-man-518-threshold-config`.
+- Implementation: `run_pipeline()` now loads the repo-bundled `config/extraction_thresholds.yaml` by default, threads the resulting threshold config into `_run_pipeline_core()`, and `inv-man-ingest` accepts `--threshold-config PATH`. The smoke core keeps its existing one-field fallback when no config is supplied. `docs/contracts/extraction_thresholds.md` now states that production headless runs load the YAML by default.
+- Regression coverage: added `tests/run/test_pipeline_threshold_config.py` to assert the committed YAML mandatory-field set and to prove a custom YAML config changes the generated `threshold-summary.json` escalation reason to `confidence_below_threshold:operations.aum`.
+- Deliberate-break gate: temporarily removed the `threshold_config=threshold_config` pass-through in `run_pipeline()`; `python -m pytest tests/run/test_pipeline_threshold_config.py::test_run_pipeline_uses_yaml_mandatory_fields -q --no-cov` failed on `low_key_field_coverage` versus `confidence_below_threshold:operations.aum`; restored and reran green.
+- Validation: `python -m pytest tests/run/test_pipeline_threshold_config.py tests/run/test_manifest.py tests/cli/test_ingest_entrypoint.py tests/extraction/test_thresholds.py -q --no-cov` -> 16 passed; `python -m pytest tests/v1/ tests/run/ -q --no-cov` -> 22 passed; focused `ruff`, focused `mypy`, and `git diff --check` passed.
+- PR state: PR **#519** open/non-draft, closes #518, labels [agent:codex, agents:keepalive, autofix]. `codex`/`codex-automation` labels are not present in this repo label list; `agent:retry` exists but was not required for initial creation. Cap-health after PR creation sees #519 as draining with active Gate/Gate Followups/Autofix evidence.
+- Next action: keepalive/Gate owns PR #519.
+
 ## 2026-06-02T04:12:00Z - opener (codex) PR #500 typecheck recovery
 
 - Selected recovery lane: `stranske/Inv-Man-Intake` PR `#500` (`codex/issue-498-browser-artifact`), source issue `#498`.

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,7 +1,7 @@
 ## 2026-06-03T16:08:45Z - opener (codex) issue #518 -> PR #519
 
 - Lane: opener / new_issue. Materialized approved weekly-review queue item as issue **#518** (`Wire load_threshold_config() from config/extraction_thresholds.yaml into the headless ingest production path`) and opened ready-for-review PR **#519**.
-- Branch/worktree: `codex/issue-518-threshold-config` at `/Users/teacher/.codex/automations/pd-workloop-resume/worktrees/inv-man-518-threshold-config`.
+- Branch/worktree: `codex/issue-518-threshold-config` in the automation worktree for issue #518.
 - Implementation: `run_pipeline()` now loads the repo-bundled `config/extraction_thresholds.yaml` by default, threads the resulting threshold config into `_run_pipeline_core()`, and `inv-man-ingest` accepts `--threshold-config PATH`. The smoke core keeps its existing one-field fallback when no config is supplied. `docs/contracts/extraction_thresholds.md` now states that production headless runs load the YAML by default.
 - Regression coverage: added `tests/run/test_pipeline_threshold_config.py` to assert the committed YAML mandatory-field set and to prove a custom YAML config changes the generated `threshold-summary.json` escalation reason to `confidence_below_threshold:operations.aum`.
 - Deliberate-break gate: temporarily removed the `threshold_config=threshold_config` pass-through in `run_pipeline()`; `python -m pytest tests/run/test_pipeline_threshold_config.py::test_run_pipeline_uses_yaml_mandatory_fields -q --no-cov` failed on `low_key_field_coverage` versus `confidence_below_threshold:operations.aum`; restored and reran green.


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:518 -->
> **Source:** Issue #518

Closes #518

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
`docs/contracts/extraction_thresholds.md:7` declares: "Thresholds are loaded from `config/extraction_thresholds.yaml` using `load_threshold_config`." The committed YAML at `config/extraction_thresholds.yaml:6-9` names three mandatory fields: `terms.management_fee`, `performance.net_return_1y`, `operations.aum`. Production runs ignore this: `src/inv_man_intake/run.py:149` calls `_run_pipeline_core`, which at `src/inv_man_intake/v1_smoke.py:221-227` hardcodes `ThresholdConfig(mandatory_fields=("operations.aum",))`, discarding the other two. `load_threshold_config()` (`src/inv_man_intake/extraction/confidence.py:33`) is defined and tested but never called from any production file. A fund document missing `terms.management_fee` passes extraction gating today when the contract requires escalation; editing the YAML has zero effect.

#### Tasks
- [ ] In `src/inv_man_intake/run.py`, add `from inv_man_intake.extraction.confidence import load_threshold_config` and update `run_pipeline()` (line 130) to accept `threshold_config_path: Path | None = None`; call `load_threshold_config(threshold_config_path or Path(__file__).resolve().parents[4] / "config" / "extraction_thresholds.yaml")` and pass the config to `_run_pipeline_core`.
- [ ] In `src/inv_man_intake/v1_smoke.py`, add `threshold_config: ThresholdConfig | None = None` to `_run_pipeline_core`; at lines 221-227 use it when not `None`, else retain the hardcoded `ThresholdConfig(mandatory_fields=("operations.aum",))` as fallback.
- [ ] In `src/inv_man_intake/cli/ingest.py:_build_parser()` (line 23), add `parser.add_argument("--threshold-config", default=None, metavar="PATH", help="Threshold YAML config path (default: repo-bundled config/extraction_thresholds.yaml).")` and update `main()` to pass `threshold_config_path=Path(args.threshold_config) if args.threshold_config else None`.
- [ ] Create `tests/run/test_pipeline_threshold_config.py` with `test_run_pipeline_uses_yaml_mandatory_fields(tmp_path)`: call `run_pipeline(Path("tests/fixtures/intake/pdf_primary_mixed_bundle.json"), output_dir=tmp_path)`, call `load_threshold_config(Path("config/extraction_thresholds.yaml"))`, assert `set(config.mandatory_fields) == {"terms.management_fee", "performance.net_return_1y", "operations.aum"}`, and read `threshold-summary.json` to assert `escalation_reason` reflects three-field enforcement.
- [ ] In the same file, add `test_yaml_mandatory_fields_match_v1_contract`: `load_threshold_config(Path("config/extraction_thresholds.yaml"))` and assert `set(config.mandatory_fields) == {"terms.management_fee", "performance.net_return_1y", "operations.aum"}`.
- [ ] Update `docs/contracts/extraction_thresholds.md` under "Config Source" to note that `run_pipeline()` and `inv-man-ingest` load from the YAML by default.

#### Acceptance criteria
- [ ] `pytest tests/run/test_pipeline_threshold_config.py::test_run_pipeline_uses_yaml_mandatory_fields -q` passes, confirming three-field YAML policy is active in production runs.
- [ ] `pytest tests/run/test_pipeline_threshold_config.py::test_yaml_mandatory_fields_match_v1_contract -q` passes, asserting `mandatory_fields == {"terms.management_fee", "performance.net_return_1y", "operations.aum"}`.
- [ ] **Deliberate-break gate:** temporarily revert `src/inv_man_intake/run.py` to pass no `threshold_config` to `_run_pipeline_core`; `test_run_pipeline_uses_yaml_mandatory_fields` must FAIL. Restore; it must pass. Capture both outputs in the PR.
- [ ] `rg "load_threshold_config" src/inv_man_intake/run.py` returns at least one match.
- [ ] `pytest tests/v1/ tests/run/ -q` passes in full.

<!-- auto-status-summary:end -->