### PR TITLE
Add contribution directional baselines

### DIFF
--- a/docs/reports/baseline-coverage.md
+++ b/docs/reports/baseline-coverage.md
@@ -4,6 +4,26 @@
 - touched by directionals: 8
 - uncovered: 0
 
+## Priority metrics
+- base_score
+- final_score
+- contribution.performance_consistency
+- contribution.risk_adjusted_returns
+- contribution.operational_quality
+- contribution.transparency
+- contribution.team_experience
+- red_flag_applied
+
+## Touched keys
+- base_score
+- contribution.operational_quality
+- contribution.performance_consistency
+- contribution.risk_adjusted_returns
+- contribution.team_experience
+- contribution.transparency
+- final_score
+- red_flag_applied
+
 ## Priority gaps
 - none
 

--- a/docs/reports/baseline-coverage.md
+++ b/docs/reports/baseline-coverage.md
@@ -1,12 +1,14 @@
 # Inv-Man-Intake baseline coverage manifest
 
-- Input parameters: **8**
-- Exercised by a scenario: **4** (50.0%)
-- Observed read at runtime: **0**
+- total metric keys: 8
+- touched by directionals: 8
+- uncovered: 0
 
-## Priority parameters
+## Priority gaps
+- none
 
-- [x] `base_score`
-- [x] `final_score`
-- [x] `contribution.risk_adjusted_returns`
-- [x] `red_flag_applied`
+## Unknown directional keys
+- none
+
+## Uncovered keys
+- none

--- a/src/baseline_kit/__init__.py
+++ b/src/baseline_kit/__init__.py
@@ -77,6 +77,18 @@ class CoverageManifest:
         lines.append(f"- touched by directionals: {len(self.touched_keys)}")
         lines.append(f"- uncovered: {len(self.uncovered_keys)}")
         lines.append("")
+        lines.append("## Priority metrics")
+        if self.priority_params:
+            lines.extend(f"- {key}" for key in self.priority_params)
+        else:
+            lines.append("- none")
+        lines.append("")
+        lines.append("## Touched keys")
+        if self.touched_keys:
+            lines.extend(f"- {key}" for key in sorted(self.touched_keys))
+        else:
+            lines.append("- none")
+        lines.append("")
         lines.append("## Priority gaps")
         if self.priority_gaps:
             lines.extend(f"- {key}" for key in self.priority_gaps)

--- a/tests/baseline/catalog.yaml
+++ b/tests/baseline/catalog.yaml
@@ -59,6 +59,30 @@ scenarios:
     patch:
       - {op: set_component, name: risk_adjusted_returns, value: 0.85}
 
+  # Lift only the performance-consistency sleeve -> that contribution rises
+  # under the equity_market_neutral weight of 0.30.
+  - id: raise_performance_consistency
+    patch:
+      - {op: set_component, name: performance_consistency, value: 0.80}
+
+  # Lift only the operational-quality sleeve -> that contribution rises under
+  # the equity_market_neutral weight of 0.15.
+  - id: raise_operational_quality
+    patch:
+      - {op: set_component, name: operational_quality, value: 0.90}
+
+  # Lift only the transparency sleeve -> that contribution rises under the
+  # equity_market_neutral weight of 0.15.
+  - id: raise_transparency
+    patch:
+      - {op: set_component, name: transparency, value: 0.70}
+
+  # Lift only the team-experience sleeve -> that contribution rises under the
+  # equity_market_neutral weight of 0.15.
+  - id: raise_team_experience
+    patch:
+      - {op: set_component, name: team_experience, value: 0.85}
+
   # Same component profile, re-weighted as a trend_following manager. trend
   # weights risk_adjusted_returns highest (0.33 vs equity's 0.25), so the RAR
   # contribution rises relative to the equity base.
@@ -130,6 +154,35 @@ directionals:
     metric: contribution.risk_adjusted_returns
     direction: increase
     enforce: true
+  # Raising performance_consistency from 0.60 to 0.80 raises its contribution
+  # under equity_market_neutral weight=0.30.
+  - id: raise_performance_consistency_contribution
+    scenario: raise_performance_consistency
+    control: base
+    metric: contribution.performance_consistency
+    direction: increase
+    enforce: true
+  # Raising operational_quality from 0.70 to 0.90 raises its contribution.
+  - id: raise_operational_quality_contribution
+    scenario: raise_operational_quality
+    control: base
+    metric: contribution.operational_quality
+    direction: increase
+    enforce: true
+  # Raising transparency from 0.50 to 0.70 raises its contribution.
+  - id: raise_transparency_contribution
+    scenario: raise_transparency
+    control: base
+    metric: contribution.transparency
+    direction: increase
+    enforce: true
+  # Raising team_experience from 0.65 to 0.85 raises its contribution.
+  - id: raise_team_experience_contribution
+    scenario: raise_team_experience
+    control: base
+    metric: contribution.team_experience
+    direction: increase
+    enforce: true
   # Re-weighting the same manager as trend_following (which weights RAR highest)
   # raises the risk_adjusted_returns contribution vs the equity base.
   - id: trend_reweight_raises_rar_contribution
@@ -167,5 +220,9 @@ directionals:
 priority_metrics:
   - base_score
   - final_score
+  - contribution.performance_consistency
   - contribution.risk_adjusted_returns
+  - contribution.operational_quality
+  - contribution.transparency
+  - contribution.team_experience
   - red_flag_applied

--- a/tests/baseline/test_coverage_manifest.py
+++ b/tests/baseline/test_coverage_manifest.py
@@ -53,8 +53,8 @@ def test_catalog_contract_shape():
     priority_metrics = list(catalog.get("priority_metrics", []))
 
     assert "base" in catalog
-    assert len(scenarios) == 9
-    assert len(directionals) == 8
+    assert len(scenarios) == 13
+    assert len(directionals) == 12
     assert priority_metrics
 
 

--- a/tests/baseline/test_coverage_manifest.py
+++ b/tests/baseline/test_coverage_manifest.py
@@ -77,3 +77,7 @@ def test_emit_coverage_report(tmp_path: Path):
     report_path.write_text(markdown)
     assert report_path.exists()
     assert not m.priority_gaps
+    assert "- contribution.performance_consistency" in markdown
+    assert "- contribution.operational_quality" in markdown
+    assert "- contribution.transparency" in markdown
+    assert "- contribution.team_experience" in markdown

--- a/tests/baseline/test_golden/test_scoring_golden_raise_operational_quality_.yml
+++ b/tests/baseline/test_golden/test_scoring_golden_raise_operational_quality_.yml
@@ -1,0 +1,8 @@
+base_score: 0.625
+contribution.operational_quality: 0.135
+contribution.performance_consistency: 0.18
+contribution.risk_adjusted_returns: 0.1375
+contribution.team_experience: 0.0975
+contribution.transparency: 0.075
+final_score: 0.625
+red_flag_applied: 0

--- a/tests/baseline/test_golden/test_scoring_golden_raise_performance_consistency_.yml
+++ b/tests/baseline/test_golden/test_scoring_golden_raise_performance_consistency_.yml
@@ -1,0 +1,8 @@
+base_score: 0.655
+contribution.operational_quality: 0.105
+contribution.performance_consistency: 0.24
+contribution.risk_adjusted_returns: 0.1375
+contribution.team_experience: 0.0975
+contribution.transparency: 0.075
+final_score: 0.655
+red_flag_applied: 0

--- a/tests/baseline/test_golden/test_scoring_golden_raise_team_experience_.yml
+++ b/tests/baseline/test_golden/test_scoring_golden_raise_team_experience_.yml
@@ -1,0 +1,8 @@
+base_score: 0.625
+contribution.operational_quality: 0.105
+contribution.performance_consistency: 0.18
+contribution.risk_adjusted_returns: 0.1375
+contribution.team_experience: 0.1275
+contribution.transparency: 0.075
+final_score: 0.625
+red_flag_applied: 0

--- a/tests/baseline/test_golden/test_scoring_golden_raise_transparency_.yml
+++ b/tests/baseline/test_golden/test_scoring_golden_raise_transparency_.yml
@@ -1,0 +1,8 @@
+base_score: 0.625
+contribution.operational_quality: 0.105
+contribution.performance_consistency: 0.18
+contribution.risk_adjusted_returns: 0.1375
+contribution.team_experience: 0.0975
+contribution.transparency: 0.105
+final_score: 0.625
+red_flag_applied: 0

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,3 +1,14 @@
+## 2026-06-10T23:10Z - opener (codex) issue #547 directional baseline PR
+
+- Lane: opener / new_issue. Materialized approved weekly-review queue item as issue **#547** (`Add directional baseline checks for 4 non-RAR scoring contribution metric keys`) and implemented branch `codex/issue-547-directional-baselines`.
+- Worktree: `/Users/teacher/.codex/automations/pd-workloop-resume/worktrees/inv-man-547-directional`.
+- Implementation: added four isolated `set_component` baseline scenarios and enforced directional checks for `contribution.performance_consistency`, `contribution.operational_quality`, `contribution.transparency`, and `contribution.team_experience`; expanded priority coverage to all produced flat metric keys; regenerated `docs/reports/baseline-coverage.md`.
+- Validation: `pytest tests/baseline/test_directional.py --no-cov` (12 passed); focused new checks with `-k "raise_performance_consistency_contribution or raise_operational_quality_contribution or raise_transparency_contribution or raise_team_experience_contribution"` (4 passed); `pytest tests/baseline/test_coverage_manifest.py::test_catalog_contract_shape --no-cov` (passed); `BASELINE_REFRESH_REPORT=1 pytest tests/baseline/test_coverage_manifest.py::test_emit_coverage_report --no-cov` (passed); final `pytest tests/baseline/test_directional.py tests/baseline/test_coverage_manifest.py --no-cov` (16 passed).
+- Deliberate-break gate: temporarily changed `raise_performance_consistency_contribution` to `direction: decrease`; quoted pytest node id failed with `Economically wrong direction -- ... variant=0.24 decrease control=0.18 -> False`; restored `increase` and reran green.
+- Extra disposition: stale approved TPP queue item was materialized as `Travel-Plan-Permission#1182`, then closed as duplicate/completed because the same work already merged via `Travel-Plan-Permission#1179` / PR `#1180` at `2026-06-10T18:23:16Z` (`b9be2d7` on main).
+- PR state: PR **#548** is open/non-draft, closes #547, head `4b2a8b6`, labels [agent:codex, agents:keepalive, autofix, repo-review-approved, priority:normal]. Direct PR status immediately after open showed Gate/Agents Gate Followups/CI/guard jobs queued or in progress; cap-health lagged with `needs-dispatch-evidence`, but direct checks showed active async worker evidence.
+- Next action: keepalive/Gate owns PR #548.
+
 ## 2026-06-03T16:08:45Z - opener (codex) issue #518 -> PR #519
 
 - Lane: opener / new_issue. Materialized approved weekly-review queue item as issue **#518** (`Wire load_threshold_config() from config/extraction_thresholds.yaml into the headless ingest production path`) and opened ready-for-review PR **#519**.


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:547 -->
> **Source:** Issue #547

Closes #547

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
`docs/INV_MAN_INTAKE_PLAN_V1.md` (Workstream 6) requires "implement explainable score breakdown," and `docs/contracts/scoring_explainability.md` formalizes each component's `contribution: weight * score` as a required output field. But `tests/baseline/catalog.yaml` (lines 104–161) guards only 4 of the 8 flat metric keys declared in `tests/baseline/adapter.py:67–72`. The four uncovered keys — `contribution.performance_consistency`, `contribution.operational_quality`, `contribution.transparency`, and `contribution.team_experience` — have no directional check. An edit to `config/scoring_weights/equity_market_neutral.toml` could silently shift any of these contributions while the full test suite stays green. `docs/reports/baseline-coverage.md` records this gap: 4/8 keys exercised (50%). **Latent fragility, not a current break.**

#### Tasks
- [ ] In `tests/baseline/catalog.yaml`, add scenario `raise_performance_consistency` (`patch: [{op: set_component, name: performance_consistency, value: 0.80}]`) and directional check `raise_performance_consistency_contribution` (metric `contribution.performance_consistency`, direction `increase`, `enforce: true`; comment: "raises 0.60→0.80 under equity_market_neutral weight=0.30").
- [ ] Add scenario `raise_operational_quality` (`patch: [{op: set_component, name: operational_quality, value: 0.90}]`) and directional check `raise_operational_quality_contribution` (metric `contribution.operational_quality`, direction `increase`, `enforce: true`).
- [ ] Add scenario `raise_transparency` (`patch: [{op: set_component, name: transparency, value: 0.70}]`) and directional check `raise_transparency_contribution` (metric `contribution.transparency`, direction `increase`, `enforce: true`).
- [ ] Add scenario `raise_team_experience` (`patch: [{op: set_component, name: team_experience, value: 0.85}]`) and directional check `raise_team_experience_contribution` (metric `contribution.team_experience`, direction `increase`, `enforce: true`).
- [ ] In `tests/baseline/test_coverage_manifest.py:57`, change `assert len(directionals) == 8` to `assert len(directionals) == 12`.
- [ ] Regenerate `docs/reports/baseline-coverage.md`: `BASELINE_REFRESH_REPORT=1 pytest tests/baseline/test_coverage_manifest.py::test_emit_coverage_report --no-cov`, commit the result.
- [ ] Perform the deliberate-break verification (see Acceptance Criteria) and revert before requesting review.

#### Acceptance criteria
- [ ] `pytest tests/baseline/test_directional.py --no-cov` passes all 12 checks; `pytest tests/baseline/test_directional.py -k "raise_performance_consistency_contribution or raise_operational_quality_contribution or raise_transparency_contribution or raise_team_experience_contribution" --no-cov` reports 4 passed.
- [ ] `pytest tests/baseline/test_coverage_manifest.py::test_catalog_contract_shape --no-cov` passes with the expected count updated to 12.
- [ ] Regenerated `docs/reports/baseline-coverage.md` reports ≥7/8 metric keys and lists all 4 new `contribution.*` keys.
- [ ] **Deliberate-break gate:** Temporarily set `raise_performance_consistency_contribution` to `direction: decrease` in `catalog.yaml`. `pytest tests/baseline/test_directional.py::test_directional[raise_performance_consistency_contribution] --no-cov` **must FAIL** with "Economically wrong direction". Revert; confirm green.

<!-- auto-status-summary:end -->