### PR TITLE
Use TOML scoring weights in smoke paths

### DIFF
--- a/app/streamlit_app.py
+++ b/app/streamlit_app.py
@@ -16,6 +16,7 @@ from inv_man_intake.observability import InMemoryTraceSink  # noqa: E402
 from inv_man_intake.readiness.fixture_batches import DEFAULT_BATCH_PACKAGES  # noqa: E402
 from inv_man_intake.scoring.contracts import ScoreComponent, ScoreSubmission  # noqa: E402
 from inv_man_intake.scoring.engine import compute_score  # noqa: E402
+from inv_man_intake.scoring.weights import weights_by_asset_class_for  # noqa: E402
 
 FIXTURE_ROOT = Path(__file__).resolve().parents[1] / "tests" / "fixtures" / "intake"
 FIXTURE_OPTIONS = tuple(
@@ -138,7 +139,8 @@ def _browser_safe_demo_fixture(fixture_name: str) -> DemoResult:
             manager_id="fund_summit_arc_special_situations",
             asset_class="credit",
             components=components,
-        )
+        ),
+        weights_by_asset_class=weights_by_asset_class_for("credit"),
     )
     return DemoResult(
         fixture_name=fixture_name,

--- a/src/inv_man_intake/scoring/__init__.py
+++ b/src/inv_man_intake/scoring/__init__.py
@@ -35,6 +35,7 @@ from inv_man_intake.scoring.weights import (
     get_weight_set,
     load_weight_registry,
     normalize_asset_class,
+    weights_by_asset_class_for,
 )
 
 __all__ = [
@@ -64,4 +65,5 @@ __all__ = [
     "load_weight_registry",
     "normalize_asset_class",
     "rank_by_asset_class",
+    "weights_by_asset_class_for",
 ]

--- a/src/inv_man_intake/scoring/weights.py
+++ b/src/inv_man_intake/scoring/weights.py
@@ -108,6 +108,15 @@ def get_weight_set(asset_class: str, config_dir: Path | None = None) -> ScoringW
         raise ValueError(unknown_asset_class_message(asset_class)) from exc
 
 
+def weights_by_asset_class_for(
+    asset_class: str, config_dir: Path | None = None
+) -> dict[str, dict[str, float]]:
+    """Return registry-loaded weights in the shape expected by ``compute_score``."""
+
+    weight_set = get_weight_set(asset_class, config_dir=config_dir)
+    return {weight_set.asset_class: dict(weight_set.weights)}
+
+
 def normalize_asset_class(asset_class: str) -> str:
     """Return the canonical v1 launch asset-class key for a label or alias."""
 

--- a/src/inv_man_intake/v1_smoke.py
+++ b/src/inv_man_intake/v1_smoke.py
@@ -51,12 +51,13 @@ from inv_man_intake.performance.metrics import compute_metrics
 from inv_man_intake.performance.normalize import normalize_payload
 from inv_man_intake.queue.assignment import create_analyst_first_assignment
 from inv_man_intake.scoring.contracts import ScoreComponent, ScoreSubmission
-from inv_man_intake.scoring.engine import compute_score, default_weights_by_asset_class
+from inv_man_intake.scoring.engine import compute_score
 from inv_man_intake.scoring.explainability import (
     ScoreComponentInput,
     build_explainability_payload,
     format_explainability_payload,
 )
+from inv_man_intake.scoring.weights import get_weight_set, weights_by_asset_class_for
 from inv_man_intake.storage.document_store import InMemoryDocumentStore
 
 
@@ -301,7 +302,8 @@ def _run_pipeline_core(
                 manager_id=record.fund_id,
                 asset_class="credit",
                 components=components,
-            )
+            ),
+            weights_by_asset_class=weights_by_asset_class_for("credit"),
         )
         explainability = build_explainability_payload(
             components=_explainability_inputs(score.asset_class, components),
@@ -579,7 +581,7 @@ def _explainability_inputs(
     asset_class: str,
     components: tuple[ScoreComponent, ...],
 ) -> tuple[ScoreComponentInput, ...]:
-    weights = default_weights_by_asset_class()[asset_class]
+    weights = get_weight_set(asset_class).weights
     rationale_by_component = {
         "performance_consistency": "Normalized monthly track record is complete.",
         "risk_adjusted_returns": "Prioritized metrics include Sharpe and correlation evidence.",

--- a/tests/app/test_streamlit_app_smoke.py
+++ b/tests/app/test_streamlit_app_smoke.py
@@ -141,6 +141,33 @@ def test_app_uses_browser_safe_score_when_pyodide_lacks_sqlite(
     assert recorder.metrics == [("Final score", "0.7809")]
 
 
+def test_app_browser_safe_score_uses_registry_weights(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _sqlite_missing_pipeline(**_: object) -> object:
+        raise ModuleNotFoundError("No module named 'sqlite3'", name="sqlite3")
+
+    monkeypatch.setattr("app.streamlit_app.run_v1_smoke_pipeline", _sqlite_missing_pipeline)
+    monkeypatch.setattr(
+        "app.streamlit_app.weights_by_asset_class_for",
+        lambda asset_class: {
+            "credit_long_short": {
+                "performance_consistency": 1.00,
+                "risk_adjusted_returns": 0.00,
+                "operational_quality": 0.00,
+                "transparency": 0.00,
+                "team_experience": 0.00,
+            }
+        },
+    )
+
+    result = render_app(_StreamlitRecorder())
+
+    assert result.final_score == pytest.approx(0.80)
+    assert result.components[0] == {
+        "component": "performance_consistency",
+        "contribution": pytest.approx(0.80),
+    }
+
+
 def test_live_verification_evidence_is_recorded() -> None:
     evidence = Path("app/live-verification.md")
     screenshot = Path("app/live-verification-screenshot.svg")

--- a/tests/scoring/test_weights_config.py
+++ b/tests/scoring/test_weights_config.py
@@ -6,6 +6,8 @@ from pathlib import Path
 
 import pytest
 
+from inv_man_intake.scoring.contracts import ScoreComponent, ScoreSubmission
+from inv_man_intake.scoring.engine import compute_score, default_weights_by_asset_class
 from inv_man_intake.scoring.weights import (
     ASSET_CLASS_ALIASES,
     COMPONENT_NAMES,
@@ -13,6 +15,7 @@ from inv_man_intake.scoring.weights import (
     get_weight_set,
     load_weight_registry,
     normalize_asset_class,
+    weights_by_asset_class_for,
 )
 
 EXPECTED_V1_LAUNCH_ASSET_CLASSES = (
@@ -72,6 +75,51 @@ def test_load_weight_registry_returns_all_launch_asset_classes() -> None:
         assert weight_set.version == "v1"
         assert set(weight_set.weights) == set(COMPONENT_NAMES)
         assert sum(weight_set.weights.values()) == pytest.approx(1.0)
+
+
+def test_default_weight_fallback_matches_toml_registry() -> None:
+    registry = load_weight_registry()
+
+    assert default_weights_by_asset_class() == {
+        asset_class: dict(weight_set.weights) for asset_class, weight_set in registry.items()
+    }
+
+
+def test_weight_registry_adapter_changes_compute_score_when_toml_changes(tmp_path: Path) -> None:
+    config_dir = tmp_path / "scoring_weights"
+    for asset_class in LAUNCH_ASSET_CLASSES:
+        weights_block = _valid_weights_block()
+        if asset_class == "credit_long_short":
+            weights_block = "\n".join(
+                [
+                    "performance_consistency = 1.00",
+                    "risk_adjusted_returns = 0.00",
+                    "operational_quality = 0.00",
+                    "transparency = 0.00",
+                    "team_experience = 0.00",
+                ]
+            )
+        _write_weight_file(config_dir, asset_class=asset_class, weights_block=weights_block)
+
+    result = compute_score(
+        ScoreSubmission(
+            manager_id="mgr_001",
+            asset_class="credit",
+            components=(
+                ScoreComponent("performance_consistency", 0.80),
+                ScoreComponent("risk_adjusted_returns", 0.60),
+                ScoreComponent("operational_quality", 0.90),
+                ScoreComponent("transparency", 0.70),
+                ScoreComponent("team_experience", 0.50),
+            ),
+        ),
+        weights_by_asset_class=weights_by_asset_class_for("credit", config_dir=config_dir),
+    )
+
+    assert result.asset_class == "credit_long_short"
+    assert result.final_score == pytest.approx(0.80)
+    assert result.contributions["performance_consistency"] == pytest.approx(0.80)
+    assert result.contributions["risk_adjusted_returns"] == pytest.approx(0.00)
 
 
 def test_launch_asset_class_catalog_matches_v1_approved_classes() -> None:

--- a/tests/test_v1_acceptance_smoke.py
+++ b/tests/test_v1_acceptance_smoke.py
@@ -10,6 +10,7 @@ import pytest
 from inv_man_intake.intake.integration import register_intake_bundle_file
 from inv_man_intake.intake.service import IngestionService
 from inv_man_intake.observability import InMemoryTraceSink
+from inv_man_intake.scoring import weights as scoring_weights
 from inv_man_intake.scoring.contracts import ScoreSubmission
 from inv_man_intake.scoring.engine import compute_score
 from inv_man_intake.v1_smoke import (
@@ -151,6 +152,55 @@ def test_v1_acceptance_smoke_exercises_intake_to_scoring_path(v1_smoke_artifacts
     assert all("summit" not in str(item).lower() for item in fleet_records)
 
 
+def test_v1_smoke_pipeline_score_uses_toml_weight_registry(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_dir = tmp_path / "scoring_weights"
+    for asset_class in scoring_weights.LAUNCH_ASSET_CLASSES:
+        weights_block = "\n".join(
+            [
+                "performance_consistency = 0.20",
+                "risk_adjusted_returns = 0.20",
+                "operational_quality = 0.20",
+                "transparency = 0.20",
+                "team_experience = 0.20",
+            ]
+        )
+        if asset_class == "credit_long_short":
+            weights_block = "\n".join(
+                [
+                    "performance_consistency = 1.00",
+                    "risk_adjusted_returns = 0.00",
+                    "operational_quality = 0.00",
+                    "transparency = 0.00",
+                    "team_experience = 0.00",
+                ]
+            )
+        _write_weight_file(config_dir, asset_class=asset_class, weights_block=weights_block)
+
+    monkeypatch.setattr(scoring_weights, "DEFAULT_CONFIG_DIR", config_dir)
+    scoring_weights._load_weight_registry_cached.cache_clear()
+    try:
+        artifacts = run_v1_smoke_pipeline(
+            fixture_root=_FIXTURE_ROOT,
+            package_id=_SMOKE_PACKAGE_ID,
+            expected_document_ids=_EXPECTED_DOCUMENT_IDS,
+        )
+    finally:
+        scoring_weights._load_weight_registry_cached.cache_clear()
+
+    assert artifacts.score.asset_class == "credit_long_short"
+    assert artifacts.score.final_score == pytest.approx(0.80)
+    assert artifacts.score.contributions["performance_consistency"] == pytest.approx(0.80)
+    assert artifacts.score.contributions["risk_adjusted_returns"] == pytest.approx(0.00)
+    performance_component = next(
+        item
+        for item in artifacts.formatted_explainability["components"]
+        if item["component"] == "performance_consistency"
+    )
+    assert performance_component["weight"] == pytest.approx(1.00)
+
+
 def test_v1_acceptance_smoke_fails_when_intake_registration_is_bypassed() -> None:
     service = IngestionService()
     with pytest.raises(KeyError, match="unknown package_id=pkg_pdf_mixed_001"):
@@ -257,6 +307,23 @@ def test_v1_smoke_pipeline_without_langsmith_key_uses_local_trace_context(monkey
 
     assert "langsmith_enabled" not in artifacts.trace_context.tags
     assert "langsmith_project" not in artifacts.trace_context.tags
+
+
+def _write_weight_file(directory: Path, *, asset_class: str, weights_block: str) -> None:
+    directory.mkdir(parents=True, exist_ok=True)
+    (directory / f"{asset_class}.toml").write_text(
+        "\n".join(
+            [
+                f'asset_class = "{asset_class}"',
+                'version = "v1"',
+                "",
+                "[weights]",
+                weights_block,
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
 
 
 def _start_event(sink: InMemoryTraceSink, name: str):


### PR DESCRIPTION
Closes #592

## Summary
- add a registry adapter that returns TOML scoring weights in the shape compute_score already accepts
- wire the v1 smoke pipeline and Streamlit browser-safe scoring fallback to use TOML-backed credit weights
- add regression coverage for fallback/TOML parity, injected TOML score changes, v1 smoke scoring, and Streamlit fallback scoring

## Validation
- ruff check app/streamlit_app.py src/inv_man_intake/scoring/__init__.py src/inv_man_intake/scoring/weights.py src/inv_man_intake/v1_smoke.py tests/app/test_streamlit_app_smoke.py tests/scoring/test_weights_config.py tests/test_v1_acceptance_smoke.py
- pytest tests/scoring/test_weights_config.py tests/scoring/test_engine.py tests/test_v1_acceptance_smoke.py tests/app/test_streamlit_app_smoke.py -q --no-cov
- deliberate-break: removed the v1 smoke weights_by_asset_class argument and confirmed test_v1_smoke_pipeline_score_uses_toml_weight_registry fails before restoring

## Notes
- a partial pytest run without --no-cov passed all selected tests but failed the repo-wide coverage threshold because it was intentionally scoped


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Scoring system now supports configurable asset class weights via TOML configuration files, allowing customization of scoring component contributions.

* **Improvements**
  * Enhanced weight management APIs for more flexible scoring configuration access.
  * Browser environment now properly loads and applies configured weights.

* **Tests**
  * Added comprehensive test coverage for weight configuration loading and scoring accuracy with custom weights.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->