### PR TITLE
Fix red flag application bookkeeping

### DIFF
--- a/src/inv_man_intake/scoring/engine.py
+++ b/src/inv_man_intake/scoring/engine.py
@@ -138,14 +138,14 @@ def compute_score(
         decision = red_flag_hook.apply(submission, base_score=base_score)
         if decision.blocked:
             final_score = 0.0
-            red_flag_applied = final_score != base_score
+            red_flag_applied = True
             red_flag_reason = decision.reason or "blocked"
         elif decision.capped_score is not None:
             if decision.capped_score < 0 or decision.capped_score > 1:
                 raise ValueError("red flag capped_score must be between 0 and 1")
             final_score = min(base_score, round(decision.capped_score, 6))
-            red_flag_applied = final_score != base_score
-            red_flag_reason = decision.reason
+            red_flag_applied = final_score < base_score
+            red_flag_reason = decision.reason if red_flag_applied else None
 
     return ScoreResult(
         manager_id=submission.manager_id,

--- a/tests/baseline/invariants.py
+++ b/tests/baseline/invariants.py
@@ -19,7 +19,8 @@ placeholders:
   * red-flag monotonicity:    final_score <= base_score always (a cap takes the
                               MIN with base; a block sends it to 0; no override
                               can raise it).
-  * red-flag flag agrees:     red_flag_applied == 1 iff final_score < base_score.
+  * red-flag flag agrees:     red_flag_applied == 1 when a block applies, or
+                              when a cap lowers final_score below base_score.
 
 The result type and assertion helper are shared
 (``baseline_kit.InvariantResult`` / ``assert_invariants``).
@@ -100,12 +101,21 @@ def check_scenario(scenario: dict[str, Any], base: dict[str, Any]) -> list[Invar
         f"final_score={final_score} base_score={base_score}",
     )
 
-    # A red flag is "applied" iff it actually changes the total downward.
+    # A block decision applies even when the score was already at zero; a cap
+    # applies only when it moves the final score downward.
+    red_flag = spec.get("red_flag")
     moved = final_score < base_score - _EPS
+    expected_applied = bool(
+        red_flag
+        and (
+            red_flag.get("kind") == "block"
+            or (red_flag.get("kind") == "cap" and moved)
+        )
+    )
     add(
         "red_flag_applied_matches_engine_semantics",
-        red_flag_applied == (1 if moved else 0),
-        f"red_flag_applied={red_flag_applied} expected={moved} "
+        red_flag_applied == (1 if expected_applied else 0),
+        f"red_flag_applied={red_flag_applied} expected={expected_applied} "
         f"(base={base_score} final={final_score})",
     )
 

--- a/tests/baseline/test_invariants.py
+++ b/tests/baseline/test_invariants.py
@@ -39,7 +39,7 @@ def test_blocked_floor_score_matches_engine_red_flag_semantics():
 
     assert metrics["base_score"] == 0.0
     assert metrics["final_score"] == 0.0
-    assert metrics["red_flag_applied"] == 0
+    assert metrics["red_flag_applied"] == 1
     assert (metrics["final_score"] < metrics["base_score"]) is False
     assert_invariants(
         invariants.check_scenario(floor_blocked, _BASE),

--- a/tests/scoring/test_engine.py
+++ b/tests/scoring/test_engine.py
@@ -72,6 +72,46 @@ def test_red_flag_hook_can_fully_block_score() -> None:
     assert result.red_flag_reason == "compliance-block"
 
 
+def test_red_flag_block_applies_when_base_score_is_zero() -> None:
+    class BlockHook:
+        def apply(self, submission: ScoreSubmission, *, base_score: float) -> RedFlagDecision:
+            del submission, base_score
+            return RedFlagDecision(blocked=True, reason="zero-block")
+
+    submission = ScoreSubmission(
+        manager_id="mgr_zero",
+        asset_class="macro",
+        components=(
+            ScoreComponent("performance_consistency", 0.0),
+            ScoreComponent("risk_adjusted_returns", 0.0),
+            ScoreComponent("operational_quality", 0.0),
+            ScoreComponent("transparency", 0.0),
+            ScoreComponent("team_experience", 0.0),
+        ),
+    )
+
+    result = compute_score(submission, red_flag_hook=BlockHook())
+
+    assert result.base_score == pytest.approx(0.0)
+    assert result.final_score == pytest.approx(0.0)
+    assert result.red_flag_applied is True
+    assert result.red_flag_reason == "zero-block"
+
+
+def test_red_flag_cap_at_or_above_base_does_not_apply_reason() -> None:
+    class CapHook:
+        def apply(self, submission: ScoreSubmission, *, base_score: float) -> RedFlagDecision:
+            del submission, base_score
+            return RedFlagDecision(capped_score=0.95, reason="not-lower")
+
+    result = compute_score(_submission("equity"), red_flag_hook=CapHook())
+
+    assert result.base_score == pytest.approx(0.705)
+    assert result.final_score == pytest.approx(result.base_score)
+    assert result.red_flag_applied is False
+    assert result.red_flag_reason is None
+
+
 def test_compute_score_rejects_unmapped_asset_class() -> None:
     with pytest.raises(ValueError, match="unknown asset class: real_assets"):
         compute_score(_submission("real_assets"))


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:593 -->
> **Source:** Issue #593

Closes #593

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
_Scope section missing from source issue._

#### Tasks
- [ ] `engine.py:141` — on the `decision.blocked` branch set `red_flag_applied = True` (derive from the decision, not the score delta).
- [ ] `engine.py:147-148` — set `red_flag_applied = final_score < base_score`, and only assign `red_flag_reason` when `red_flag_applied` (keep the two consistent).

#### Acceptance criteria
- [ ] New test: a red-flag hook that BLOCKS a submission whose components are all 0.0 -> assert `result.red_flag_applied is True` and `result.final_score == 0.0`. Plus a cap-at-or-above-base case -> assert `red_flag_applied is False` and `red_flag_reason is None`.
- [ ] Deliberate-break -> revert: restore `red_flag_applied = final_score != base_score` -> the blocked-zero test FAILS -> re-apply.

<!-- auto-status-summary:end -->