### PR TITLE
Fix threshold escalation bookkeeping

### DIFF
--- a/src/inv_man_intake/extraction/confidence.py
+++ b/src/inv_man_intake/extraction/confidence.py
@@ -103,27 +103,26 @@ def evaluate_thresholds(
         for key in key_fields
         if key in field_by_key and field_by_key[key].confidence >= config.key_field_confidence_min
     ]
-    key_field_coverage_ratio = len(eligible_key_fields) / len(key_fields) if key_fields else 0.0
+    key_field_coverage_ratio = len(eligible_key_fields) / len(key_fields) if key_fields else 1.0
     auto_pass_document = key_field_coverage_ratio >= config.document_key_field_coverage_min
 
+    mandatory_failures: list[str] = []
     for mandatory_field in config.mandatory_fields:
         candidate = field_by_key.get(mandatory_field)
         if candidate is None:
-            return ThresholdDecision(
-                auto_accept_fields=auto_accept_fields,
-                key_field_coverage_ratio=key_field_coverage_ratio,
-                auto_pass_document=False,
-                escalate=True,
-                escalation_reason=f"missing_mandatory_field:{mandatory_field}",
-            )
+            mandatory_failures.append(f"missing_mandatory_field:{mandatory_field}")
+            continue
         if candidate.confidence < config.mandatory_field_min:
-            return ThresholdDecision(
-                auto_accept_fields=auto_accept_fields,
-                key_field_coverage_ratio=key_field_coverage_ratio,
-                auto_pass_document=False,
-                escalate=True,
-                escalation_reason=f"confidence_below_threshold:{mandatory_field}",
-            )
+            mandatory_failures.append(f"confidence_below_threshold:{mandatory_field}")
+
+    if mandatory_failures:
+        return ThresholdDecision(
+            auto_accept_fields=auto_accept_fields,
+            key_field_coverage_ratio=key_field_coverage_ratio,
+            auto_pass_document=False,
+            escalate=True,
+            escalation_reason=";".join(mandatory_failures),
+        )
 
     escalate = not auto_pass_document
     reason = None if auto_pass_document else "low_key_field_coverage"

--- a/tests/extraction/test_thresholds.py
+++ b/tests/extraction/test_thresholds.py
@@ -112,6 +112,28 @@ def test_evaluate_thresholds_escalates_when_mandatory_field_is_missing() -> None
     assert decision.escalation_reason == "missing_mandatory_field:operations.aum"
 
 
+def test_evaluate_thresholds_reports_all_mandatory_field_failures() -> None:
+    config = load_threshold_config(_CONFIG_PATH)
+    result = _result(
+        ("terms.management_fee", 0.59),
+        ("performance.net_return_1y", 0.91),
+    )
+
+    decision = evaluate_thresholds(
+        result=result,
+        key_fields=(
+            "terms.management_fee",
+            "performance.net_return_1y",
+        ),
+        config=config,
+    )
+
+    assert decision.escalate is True
+    assert decision.escalation_reason is not None
+    assert "confidence_below_threshold:terms.management_fee" in decision.escalation_reason
+    assert "missing_mandatory_field:operations.aum" in decision.escalation_reason
+
+
 def test_attach_threshold_summary_adds_document_policy_fields() -> None:
     config = load_threshold_config(_CONFIG_PATH)
     result = _result(
@@ -136,7 +158,7 @@ def test_attach_threshold_summary_adds_document_policy_fields() -> None:
     assert by_key["confidence.document.escalation_reason"].value == "none"
 
 
-def test_evaluate_thresholds_empty_key_fields_forces_escalation() -> None:
+def test_evaluate_thresholds_empty_key_fields_do_not_force_escalation() -> None:
     config = load_threshold_config(_CONFIG_PATH)
     result = _result(
         ("terms.management_fee", 0.95),
@@ -146,7 +168,7 @@ def test_evaluate_thresholds_empty_key_fields_forces_escalation() -> None:
 
     decision = evaluate_thresholds(result=result, key_fields=(), config=config)
 
-    assert decision.key_field_coverage_ratio == 0.0
-    assert decision.auto_pass_document is False
-    assert decision.escalate is True
-    assert decision.escalation_reason == "low_key_field_coverage"
+    assert decision.key_field_coverage_ratio == 1.0
+    assert decision.auto_pass_document is True
+    assert decision.escalate is False
+    assert decision.escalation_reason is None


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:594 -->
> **Source:** Issue #594

Closes #594

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
_Scope section missing from source issue._

#### Tasks
- [ ] `confidence.py:106` — define the empty-`key_fields` case explicitly (pass, or raise a clear error) instead of defaulting to 0.0 coverage.
- [ ] `confidence.py:109-126` — accumulate ALL failing mandatory fields, then return one `ThresholdDecision` listing every reason.

#### Acceptance criteria
- [ ] Named test: `key_fields=()` asserts the intended non-escalation (or explicit error); a fixture with 2 failing mandatory fields asserts BOTH reasons surface.
- [ ] Deliberate-break -> revert: restore the early `return` / `else 0.0` -> the new tests FAIL -> revert.

<!-- auto-status-summary:end -->