### PR TITLE
Issue #595: guard document provenance on reingest

### DIFF
--- a/src/inv_man_intake/intake/integration.py
+++ b/src/inv_man_intake/intake/integration.py
@@ -611,12 +611,16 @@ def _merge_fund(*, existing: Fund, incoming: Fund) -> Fund:
 
 
 def _ensure_document_invariants(*, existing: Document, incoming: Document) -> None:
-    """Reject document_id collisions where structural identity has changed."""
+    """Reject document_id collisions where structural identity or provenance changed."""
     mismatches: list[str] = []
     if existing.fund_id != incoming.fund_id:
         mismatches.append(f"fund_id={existing.fund_id!r}->{incoming.fund_id!r}")
     if existing.file_hash != incoming.file_hash:
         mismatches.append(f"file_hash={existing.file_hash!r}->{incoming.file_hash!r}")
+    if existing.source_channel != incoming.source_channel:
+        mismatches.append(
+            f"source_channel={existing.source_channel!r}->{incoming.source_channel!r}"
+        )
     if mismatches:
         raise ValueError(
             f"document_id={incoming.document_id!r} collision: " + ", ".join(mismatches)

--- a/tests/intake/test_ingest_core_registry.py
+++ b/tests/intake/test_ingest_core_registry.py
@@ -280,6 +280,71 @@ def test_document_id_collision_with_different_content_raises(tmp_path: Path) -> 
         )
 
 
+def test_document_id_collision_with_different_source_channel_raises(tmp_path: Path) -> None:
+    repository, store = _registry()
+
+    first = tmp_path / "first.json"
+    second = tmp_path / "second.json"
+    bundle = {
+        "metadata": {
+            "firm_id": "firm_source_collision",
+            "fund_id": "fund_source_collision",
+            "firm_name": "Source Collision Firm",
+            "fund_name": "Source Collision Fund",
+            "received_at": "2026-03-01T09:00:00Z",
+            "source_channel": "email",
+        },
+        "files": [
+            {
+                "file_name": "deck.pdf",
+                "role": "investment_deck",
+                "source_ref": "shared:deck",
+                "document_id": "source_shared_doc_id",
+            }
+        ],
+    }
+    first.write_text(json.dumps({"package_id": "pkg_source_a", **bundle}), encoding="utf-8")
+    second_bundle = {
+        **bundle,
+        "metadata": {
+            **bundle["metadata"],
+            "received_at": "2026-03-02T09:00:00Z",
+            "source_channel": "portal_upload",
+        },
+    }
+    second.write_text(json.dumps({"package_id": "pkg_source_b", **second_bundle}), encoding="utf-8")
+
+    first_result = register_intake_bundle_file(
+        first,
+        IngestionService(),
+        core_repository=repository,
+        document_store=store,
+        content_resolver=lambda _entry, _package_id: b"same deck bytes",
+    )
+    assert first_result.accepted is True
+    original = repository.get_document("source_shared_doc_id")
+    assert original is not None
+    assert original.source_channel == "email"
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "document_id='source_shared_doc_id' collision: "
+            "source_channel='email'->'portal_upload'"
+        ),
+    ):
+        register_intake_bundle_file(
+            second,
+            IngestionService(),
+            core_repository=repository,
+            document_store=store,
+            content_resolver=lambda _entry, _package_id: b"same deck bytes",
+        )
+
+    preserved = repository.get_document("source_shared_doc_id")
+    assert preserved == original
+
+
 def test_invalid_version_date_falls_back_to_received_at(tmp_path: Path) -> None:
     service = IngestionService()
     repository, store = _registry()


### PR DESCRIPTION
Closes #595

## Summary
- Treat source_channel as immutable document provenance for existing document_id records.
- Raise a document_id collision instead of silently overwriting source provenance on same-byte reingest.
- Add regression coverage proving original provenance is preserved when a conflicting source is submitted.

## Validation
- ruff check src/inv_man_intake/intake/integration.py tests/intake/test_ingest_core_registry.py
- pytest tests/intake/test_ingest_core_registry.py tests/intake/test_real_content_resolver.py tests/intake/test_versioning.py -q --no-cov
- Deliberate break: temporarily removed the source_channel invariant and confirmed test_document_id_collision_with_different_source_channel_raises fails.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced document validation to prevent duplicate document IDs from different sources from being registered, ensuring better data integrity.

* **Tests**
  * Added test coverage for document ID collision detection across different source channels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->