### PR TITLE
Issue #598: cover edge-path guards

### DIFF
--- a/tests/extraction/test_thresholds.py
+++ b/tests/extraction/test_thresholds.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from inv_man_intake.extraction.confidence import (
     attach_threshold_summary,
     evaluate_thresholds,
@@ -40,6 +42,68 @@ def test_load_threshold_config_reads_policy_values() -> None:
     assert config.document_key_field_coverage_min == 0.80
     assert config.mandatory_field_min == 0.60
     assert "terms.management_fee" in config.mandatory_fields
+
+
+def test_load_threshold_config_rejects_inline_mandatory_fields(tmp_path: Path) -> None:
+    config_path = tmp_path / "thresholds.yaml"
+    config_path.write_text(
+        "\n".join(
+            (
+                "field_auto_accept_min: 0.85",
+                "key_field_confidence_min: 0.75",
+                "document_key_field_coverage_min: 0.80",
+                "mandatory_field_min: 0.60",
+                "mandatory_fields: [terms.management_fee]",
+            )
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="unsupported mandatory_fields format"):
+        load_threshold_config(config_path)
+
+
+def test_load_threshold_config_rejects_unknown_keys(tmp_path: Path) -> None:
+    config_path = tmp_path / "thresholds.yaml"
+    config_path.write_text(
+        "\n".join(
+            (
+                "field_auto_accept_min: 0.85",
+                "key_field_confidence_min: 0.75",
+                "document_key_field_coverage_min: 0.80",
+                "mandatory_field_min: 0.60",
+                "unexpected_threshold: 0.10",
+                "mandatory_fields:",
+                "  - terms.management_fee",
+            )
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="unknown threshold config key: unexpected_threshold"):
+        load_threshold_config(config_path)
+
+
+def test_load_threshold_config_reports_missing_required_keys(tmp_path: Path) -> None:
+    config_path = tmp_path / "thresholds.yaml"
+    config_path.write_text(
+        "\n".join(
+            (
+                "field_auto_accept_min: 0.85",
+                "key_field_confidence_min: 0.75",
+                "mandatory_field_min: 0.60",
+                "mandatory_fields:",
+                "  - terms.management_fee",
+            )
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="missing threshold config keys: document_key_field_coverage_min",
+    ):
+        load_threshold_config(config_path)
 
 
 def test_evaluate_thresholds_boundary_values_are_deterministic() -> None:

--- a/tests/performance/test_conflict_resolver.py
+++ b/tests/performance/test_conflict_resolver.py
@@ -109,6 +109,21 @@ def test_resolver_handles_no_overlap_without_escalation() -> None:
     assert result.audit_entries == ()
 
 
+def test_zero_denominator_difference_uses_float_tolerance_without_conflict() -> None:
+    as_of = date(2025, 1, 31)
+    xlsx = PerformanceSeries("monthly", (PerformancePoint(as_of=as_of, value=0.0),))
+    other = PerformanceSeries("monthly", (PerformancePoint(as_of=as_of, value=5e-13),))
+
+    result = resolve_source_conflicts(xlsx_series=xlsx, other_series=other)
+
+    assert result.conflict_count == 0
+    assert len(result.audit_entries) == 1
+    entry = result.audit_entries[0]
+    assert entry.absolute_difference == pytest.approx(5e-13)
+    assert entry.percent_difference == pytest.approx(50.0)
+    assert entry.is_conflict is False
+
+
 def test_resolver_validates_frequency_mismatch() -> None:
     xlsx = PerformanceSeries(
         "monthly",

--- a/tests/queue/test_sla.py
+++ b/tests/queue/test_sla.py
@@ -1,0 +1,19 @@
+"""Tests for SLA lifecycle edge cases."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from inv_man_intake.queue.sla import initialize_sla, mark_breach_if_due
+
+
+def test_mark_breach_if_due_is_idempotent_after_first_breach() -> None:
+    sla = initialize_sla(created_at=datetime(2026, 6, 20, 9, 0, tzinfo=UTC))
+    first_observed_at = datetime(2026, 6, 21, 0, 1, tzinfo=UTC)
+    second_observed_at = datetime(2026, 6, 21, 1, 15, tzinfo=UTC)
+
+    breached = mark_breach_if_due(sla, now=first_observed_at)
+    breached_again = mark_breach_if_due(breached, now=second_observed_at)
+
+    assert breached.breached_at == first_observed_at
+    assert breached_again == breached

--- a/tests/scoring/test_engine.py
+++ b/tests/scoring/test_engine.py
@@ -112,6 +112,16 @@ def test_red_flag_cap_at_or_above_base_does_not_apply_reason() -> None:
     assert result.red_flag_reason is None
 
 
+def test_red_flag_hook_rejects_out_of_range_capped_score() -> None:
+    class InvalidCapHook:
+        def apply(self, submission: ScoreSubmission, *, base_score: float) -> RedFlagDecision:
+            del submission, base_score
+            return RedFlagDecision(capped_score=1.5, reason="invalid-cap")
+
+    with pytest.raises(ValueError, match="red flag capped_score must be between 0 and 1"):
+        compute_score(_submission("equity"), red_flag_hook=InvalidCapHook())
+
+
 def test_compute_score_rejects_unmapped_asset_class() -> None:
     with pytest.raises(ValueError, match="unknown asset class: real_assets"):
         compute_score(_submission("real_assets"))


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:598 -->
> **Source:** Issue #598

Closes #598

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
_Scope section missing from source issue._

#### Tasks
- [ ] Add a test per path: capped_score=1.5 raises; `mark_breach_if_due` called twice on a breached item is idempotent; zero-denominator conflict is handled (assert the computed percent + tolerance); each `load_threshold_config` guard raises on its bad input.

#### Acceptance criteria
- [ ] Each new test asserts the guard fires / the edge is handled.
- [ ] Deliberate-break -> revert: remove one guard (e.g. the capped_score range check) -> its test FAILS -> revert.

<!-- auto-status-summary:end -->