### PR TITLE
Issue #602: preserve engine explainability order

### DIFF
--- a/src/inv_man_intake/scoring/explainability.py
+++ b/src/inv_man_intake/scoring/explainability.py
@@ -5,8 +5,11 @@ from __future__ import annotations
 from dataclasses import dataclass
 from math import isfinite
 
+from inv_man_intake.scoring.engine import _COMPONENT_ORDER
+
 _ROUND_PRECISION = 6
 _RECONCILIATION_TOLERANCE = 1e-6
+_COMPONENT_ORDER_INDEX = {component: index for index, component in enumerate(_COMPONENT_ORDER)}
 
 
 @dataclass(frozen=True)
@@ -54,7 +57,7 @@ def build_explainability_payload(
     component_ids = [component.component for component in normalized]
     if len(component_ids) != len(set(component_ids)):
         raise ValueError("component identifiers must be unique")
-    ordered = tuple(sorted(normalized, key=lambda component: component.component))
+    ordered = tuple(sorted(normalized, key=_component_order_key))
 
     computed_total = _round(sum(component.contribution for component in ordered))
     resolved_overall = computed_total if overall_score is None else _round(overall_score)
@@ -110,6 +113,13 @@ def _normalize_component(component: ScoreComponentInput) -> ScoreComponentOutput
         weight=_round(component.weight),
         contribution=_round(component.weight * component.score),
         rationale=rationale,
+    )
+
+
+def _component_order_key(component: ScoreComponentOutput) -> tuple[int, str]:
+    return (
+        _COMPONENT_ORDER_INDEX.get(component.component, len(_COMPONENT_ORDER_INDEX)),
+        component.component,
     )
 
 

--- a/tests/scoring/test_explainability.py
+++ b/tests/scoring/test_explainability.py
@@ -7,6 +7,8 @@ from typing import Any, cast
 
 import pytest
 
+from inv_man_intake.scoring.contracts import ScoreComponent, ScoreSubmission
+from inv_man_intake.scoring.engine import compute_score, default_weights_by_asset_class
 from inv_man_intake.scoring.explainability import (
     ScoreComponentInput,
     build_explainability_payload,
@@ -88,6 +90,39 @@ def test_formatter_is_stable_for_unordered_input_components() -> None:
         "a_liquidity",
         "z_tail_risk",
     ]
+
+
+def test_payload_component_order_matches_engine_contribution_order() -> None:
+    submission = ScoreSubmission(
+        manager_id="fund-order-check",
+        asset_class="quant",
+        components=(
+            ScoreComponent("transparency", 0.70),
+            ScoreComponent("risk_adjusted_returns", 0.60),
+            ScoreComponent("team_experience", 0.50),
+            ScoreComponent("performance_consistency", 0.80),
+            ScoreComponent("operational_quality", 0.90),
+        ),
+    )
+    weights = default_weights_by_asset_class()["quant"]
+    score = compute_score(submission)
+    input_values = {component.name: component.value for component in submission.components}
+    payload = build_explainability_payload(
+        components=tuple(
+            ScoreComponentInput(
+                component=component,
+                weight=weights[component],
+                score=input_values[component],
+                rationale=f"{component} rationale.",
+            )
+            for component in sorted(score.contributions)
+        ),
+        overall_score=score.final_score,
+    )
+
+    assert tuple(component.component for component in payload.components) == tuple(
+        score.contributions
+    )
 
 
 def test_component_validations_enforced() -> None:


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:602 -->
> **Source:** Issue #602

Closes #602

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
_Scope section missing from source issue._

#### Tasks
- [ ] `explainability.py:57` — order components by the engine's `_COMPONENT_ORDER` (import + use it) instead of alphabetically, so explainability and `contributions` agree positionally.

#### Acceptance criteria
- [ ] Named test: assert the explainability payload's component order == the engine's contribution order for a fixed submission.
- [ ] Deliberate-break -> revert: restore the alphabetical `sorted(...)` -> the order test FAILS -> revert.

<!-- auto-status-summary:end -->