### PR TITLE
Follow-up #601: route scripts through shared LLM adapter

### DIFF
--- a/scripts/langchain/followup_issue_generator.py
+++ b/scripts/langchain/followup_issue_generator.py
@@ -908,19 +908,22 @@ def _parse_checklist(lines: list[str]) -> list[str]:
 def _get_llm_client(reasoning: bool = False) -> tuple[Any, str] | None:
     """Get LLM client using slot order with optional reasoning model override."""
     try:
-        from tools.langchain_client import build_chat_client
+        from scripts.langchain._llm_client import build_client
     except ImportError as e:
-        print(f"Warning: langchain_client not available: {e}", file=sys.stderr)
-        return None
+        try:
+            from _llm_client import build_client
+        except ImportError:
+            print(f"Warning: shared LLM client adapter not available: {e}", file=sys.stderr)
+            return None
 
     if reasoning:
         model = os.environ.get("FOLLOWUP_REASONING_MODEL", "o3-mini")
-        resolved = build_chat_client(model=model, provider="openai")
+        resolved = build_client(model=model, provider="openai")
         if not resolved:
-            resolved = build_chat_client()
+            resolved = build_client()
     else:
         model = os.environ.get("FOLLOWUP_MODEL", "gpt-5.4")
-        resolved = build_chat_client(model=model)
+        resolved = build_client(model=model)
 
     if not resolved:
         print("Warning: No LLM API keys found", file=sys.stderr)

--- a/scripts/langchain/progress_reviewer.py
+++ b/scripts/langchain/progress_reviewer.py
@@ -427,11 +427,14 @@ def review_progress_with_llm(
         rounds_without_completion,
     )
     try:
-        from tools.langchain_client import build_chat_client
+        from scripts.langchain._llm_client import build_client
     except ImportError:
-        build_chat_client = None
+        try:
+            from _llm_client import build_client
+        except ImportError:
+            build_client = None
 
-    resolved = build_chat_client(model=model) if build_chat_client else None
+    resolved = build_client(model=model) if build_client else None
     if not resolved:
         score, aligned, unaligned = heuristic_alignment_check(
             acceptance_criteria, recent_commits, files_changed

--- a/tests/tools/test_llm_client_single_source.py
+++ b/tests/tools/test_llm_client_single_source.py
@@ -82,6 +82,10 @@ def test_scripts_do_not_bypass_shared_llm_client_adapter() -> None:
             if (
                 isinstance(node, ast.ImportFrom)
                 and node.module == "tools.langchain_client"
-                and any(alias.name == "build_chat_client" for alias in node.names)
+                and any(alias.name in {"build_chat_client", "*"} for alias in node.names)
+            ):
+                raise AssertionError(path.relative_to(REPO_ROOT).as_posix())
+            if isinstance(node, ast.Import) and any(
+                alias.name == "tools.langchain_client" for alias in node.names
             ):
                 raise AssertionError(path.relative_to(REPO_ROOT).as_posix())

--- a/tests/tools/test_llm_client_single_source.py
+++ b/tests/tools/test_llm_client_single_source.py
@@ -85,6 +85,12 @@ def test_scripts_do_not_bypass_shared_llm_client_adapter() -> None:
                 and any(alias.name in {"build_chat_client", "*"} for alias in node.names)
             ):
                 raise AssertionError(path.relative_to(REPO_ROOT).as_posix())
+            if (
+                isinstance(node, ast.ImportFrom)
+                and node.module == "tools"
+                and any(alias.name == "langchain_client" for alias in node.names)
+            ):
+                raise AssertionError(path.relative_to(REPO_ROOT).as_posix())
             if isinstance(node, ast.Import) and any(
                 alias.name == "tools.langchain_client" for alias in node.names
             ):

--- a/tests/tools/test_llm_client_single_source.py
+++ b/tests/tools/test_llm_client_single_source.py
@@ -70,3 +70,13 @@ def test_script_llm_client_adapter_delegates_to_langchain_client(monkeypatch) ->
             "force_openai": False,
         }
     ]
+
+
+def test_scripts_do_not_bypass_shared_llm_client_adapter() -> None:
+    direct_import = "from tools.langchain_client import build_chat_client"
+
+    for path in (REPO_ROOT / "scripts").rglob("*.py"):
+        if path.as_posix().endswith("scripts/langchain/_llm_client.py"):
+            continue
+        source = path.read_text(encoding="utf-8")
+        assert direct_import not in source, path.relative_to(REPO_ROOT).as_posix()

--- a/tests/tools/test_llm_client_single_source.py
+++ b/tests/tools/test_llm_client_single_source.py
@@ -73,10 +73,15 @@ def test_script_llm_client_adapter_delegates_to_langchain_client(monkeypatch) ->
 
 
 def test_scripts_do_not_bypass_shared_llm_client_adapter() -> None:
-    direct_import = "from tools.langchain_client import build_chat_client"
-
     for path in (REPO_ROOT / "scripts").rglob("*.py"):
         if path.as_posix().endswith("scripts/langchain/_llm_client.py"):
             continue
         source = path.read_text(encoding="utf-8")
-        assert direct_import not in source, path.relative_to(REPO_ROOT).as_posix()
+        tree = ast.parse(source, filename=path.as_posix())
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.ImportFrom)
+                and node.module == "tools.langchain_client"
+                and any(alias.name == "build_chat_client" for alias in node.names)
+            ):
+                raise AssertionError(path.relative_to(REPO_ROOT).as_posix())


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:601 -->
> **Source:** Issue #601

Closes #601

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
_Scope section missing from source issue._

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#596](https://github.com/stranske/Inv-Man-Intake/issues/596)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] Choose the canonical module (likely `tools/llm_provider.py`), migrate all callers to it, and remove the redundant module(s).
- [ ] Route provider/model resolution — including loading `config/model_registry.json` + `config/llm_slots.json` (see #596) — through the one module.

#### Acceptance criteria
- [ ] Named test: provider resolution for a given slot goes through the canonical module and honors the registry. Deliberate-break -> revert: re-add a second resolver path a caller uses -> a "single source of truth" assertion (or the registry test) FAILS -> revert.
- [ ] `grep -rl <removed module>` returns no callers after migration.

<!-- auto-status-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated LLM client construction to route through a unified shared client adapter, with clearer warning behavior and safe early return when adapter imports fail.
  * Standard and reasoning model paths now build clients directly via the shared adapter while preserving existing fallback behavior.

* **Tests**
  * Added a test that scans `scripts/**/*.py` (excluding the shared adapter) to ensure legacy direct imports are not used, failing on any detected usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->