### PR TITLE
Render actionable analyst queue cards

### DIFF
--- a/app/streamlit_app.py
+++ b/app/streamlit_app.py
@@ -42,6 +42,7 @@ class StreamlitLike(Protocol):
     def metric(self, label: str, value: str) -> None: ...
     def subheader(self, body: str) -> None: ...
     def table(self, data: object) -> None: ...
+    def button(self, label: str, *, key: str) -> bool: ...
     def write(self, *args: object, **kwargs: object) -> None: ...
     def success(self, body: str) -> None: ...
 
@@ -56,6 +57,22 @@ class DemoResult:
     item_id: str
     sink_type: str
     trace_tags: dict[str, str]
+
+
+@dataclass(frozen=True)
+class AnalystQueueCard:
+    """Human-readable queue row for the demo analyst workflow."""
+
+    owner: str
+    package: str
+    headline: str
+    reason: str
+    affected_evidence: str
+    suggested_resolution: str
+    state: str
+
+
+QUEUE_ACTION_STATE: dict[str, str] = {}
 
 
 def _suppress_langsmith_env() -> dict[str, str]:
@@ -157,6 +174,66 @@ def _browser_safe_demo_fixture(fixture_name: str) -> DemoResult:
     )
 
 
+def build_analyst_queue_card(result: DemoResult) -> AnalystQueueCard:
+    """Decode the internal queue item id into a readable analyst work item."""
+
+    tokens = result.item_id.split(":")
+    package_id = tokens[0] if tokens and tokens[0] else result.package_id
+    validation_rule = _label_from_token(tokens[1]) if len(tokens) > 1 else "Validation"
+    conflict_type = _label_from_token(tokens[2]) if len(tokens) > 2 else "Review needed"
+    correlation = tokens[3] if len(tokens) > 3 else "demo item"
+
+    return AnalystQueueCard(
+        owner=result.owner_role.title(),
+        package=package_id,
+        headline=f"{conflict_type} requires {validation_rule.lower()} review",
+        reason=(
+            "The scoring pipeline routed this package for analyst review because "
+            f"{conflict_type.lower()} evidence needs confirmation."
+        ),
+        affected_evidence=f"Package {package_id}; evidence marker {correlation}",
+        suggested_resolution=(
+            "Open the package evidence, confirm the conflict, then accept the score, "
+            "escalate to ops, or request missing information."
+        ),
+        state=QUEUE_ACTION_STATE.get(result.item_id, "Waiting for analyst action"),
+    )
+
+
+def _label_from_token(token: str) -> str:
+    return token.replace("_", " ").replace("-", " ").title()
+
+
+def _record_queue_action(item_id: str, action: str) -> None:
+    QUEUE_ACTION_STATE[item_id] = action
+
+
+def render_analyst_queue(st: StreamlitLike, result: DemoResult) -> AnalystQueueCard:
+    """Render a readable queue card and in-memory action controls."""
+
+    if st.button("Accept", key=f"{result.item_id}:accept"):
+        _record_queue_action(result.item_id, "Accepted")
+    if st.button("Escalate", key=f"{result.item_id}:escalate"):
+        _record_queue_action(result.item_id, "Escalated to ops")
+    if st.button("Needs-info", key=f"{result.item_id}:needs-info"):
+        _record_queue_action(result.item_id, "Needs information")
+    card = build_analyst_queue_card(result)
+    st.table(
+        [
+            {
+                "Owner": card.owner,
+                "Package": card.package,
+                "Issue": card.headline,
+                "Reason": card.reason,
+                "Affected evidence": card.affected_evidence,
+                "Suggested resolution": card.suggested_resolution,
+                "State": card.state,
+            }
+        ]
+    )
+    return card
+
+
 def render_app(st: StreamlitLike | None = None) -> DemoResult:
     """Render the browser demo and return the underlying deterministic result."""
 
@@ -175,7 +252,7 @@ def render_app(st: StreamlitLike | None = None) -> DemoResult:
     st.subheader("Explainability")
     st.table(result.components)
     st.subheader("Analyst queue")
-    st.write({"owner_role": result.owner_role, "item_id": result.item_id})
+    render_analyst_queue(st, result)
     st.success(f"Trace sink: {result.sink_type}; LangSmith and LangChain tracing env vars are off.")
     return result
 

--- a/tests/app/test_streamlit_app_smoke.py
+++ b/tests/app/test_streamlit_app_smoke.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 import pytest
-from app.streamlit_app import render_app
+from app.streamlit_app import QUEUE_ACTION_STATE, render_app
 
 from inv_man_intake.observability import InMemoryTraceSink
 
@@ -14,6 +14,8 @@ class _StreamlitRecorder:
     def __init__(self) -> None:
         self.metrics: list[tuple[str, str]] = []
         self.tables: list[object] = []
+        self.buttons: list[tuple[str, str]] = []
+        self.clicked_keys: set[str] = set()
 
     def set_page_config(self, **kwargs: object) -> None:
         return None
@@ -35,6 +37,10 @@ class _StreamlitRecorder:
 
     def table(self, data: object) -> None:
         self.tables.append(data)
+
+    def button(self, label: str, *, key: str) -> bool:
+        self.buttons.append((label, key))
+        return key in self.clicked_keys
 
     def write(self, *args: object, **kwargs: object) -> None:
         return None
@@ -84,7 +90,7 @@ def test_app_renders_score_for_fixture_bundle(monkeypatch: pytest.MonkeyPatch) -
     assert "langsmith_enabled" not in result.trace_tags
     assert "langsmith_project" not in result.trace_tags
     assert recorder.metrics == [("Final score", "0.7809")]
-    assert recorder.tables == [result.components]
+    assert recorder.tables[0] == result.components
 
 
 def test_app_temporarily_disables_langsmith_and_langchain_env(
@@ -122,6 +128,55 @@ def test_app_temporarily_disables_langsmith_and_langchain_env(
     assert os.environ["LANGCHAIN_API_KEY"] == "lsv2_pt_live"
     assert os.environ["LANGSMITH_TRACING_ENABLED"] == "true"
     assert os.environ["LANGCHAIN_TRACING_V2"] == "true"
+
+
+def test_analyst_queue_renders_readable_item_and_actions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    item_id = "pkg_pdf_mixed_001:validation:performance_conflict:corr_4d03914dd557"
+
+    def _fake_pipeline(**_: object) -> _FakeArtifacts:
+        return _FakeArtifacts(
+            sink=InMemoryTraceSink(),
+            trace_context=_FakeTraceContext(tags={"stage": "intake"}),
+            formatted_explainability={"components": [{"component": "risk_adjusted_returns"}]},
+            score=_FakeScore(final_score=0.4321),
+            queue_assignment=_FakeQueueAssignment(owner_role="analyst", item_id=item_id),
+        )
+
+    QUEUE_ACTION_STATE.clear()
+    monkeypatch.setattr("app.streamlit_app.run_v1_smoke_pipeline", _fake_pipeline)
+
+    recorder = _StreamlitRecorder()
+    recorder.clicked_keys.add(f"{item_id}:escalate")
+    result = render_app(recorder)
+
+    queue_rows = recorder.tables[1]
+    assert isinstance(queue_rows, list)
+    assert queue_rows == [
+        {
+            "Owner": "Analyst",
+            "Package": "pkg_pdf_mixed_001",
+            "Issue": "Performance Conflict requires validation review",
+            "Reason": (
+                "The scoring pipeline routed this package for analyst review because "
+                "performance conflict evidence needs confirmation."
+            ),
+            "Affected evidence": "Package pkg_pdf_mixed_001; evidence marker corr_4d03914dd557",
+            "Suggested resolution": (
+                "Open the package evidence, confirm the conflict, then accept the score, "
+                "escalate to ops, or request missing information."
+            ),
+            "State": "Escalated to ops",
+        }
+    ]
+    assert item_id not in str(queue_rows)
+    assert recorder.buttons == [
+        ("Accept", f"{item_id}:accept"),
+        ("Escalate", f"{item_id}:escalate"),
+        ("Needs-info", f"{item_id}:needs-info"),
+    ]
+    assert QUEUE_ACTION_STATE[result.item_id] == "Escalated to ops"
 
 
 def test_app_uses_browser_safe_score_when_pyodide_lacks_sqlite(


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:629 -->
> **Source:** Issue #629

Closes #629

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
_Scope section missing from source issue._

#### Tasks
- [ ] `app/streamlit_app.py:177-178` — render each queue item as a **readable card/row, not raw JSON**: decode the `item_id` into display fields (package, validation rule violated, conflict type) and show an issue headline + reason + affected evidence + a suggested resolution path. (panel fix-hint)
- [ ] Add **per-item actions** (e.g. Accept / Escalate / Needs-info) that write back to the queue state, so the analyst can resolve items rather than just view an id. (panel fix-hint)

#### Acceptance criteria
- [ ] Named test: `tests/test_analyst_queue_render.py` (new) — given a demo result with a flagged queue item, assert the analyst-queue render produces a human-readable issue description (package + validation rule + conflict), NOT the raw `item_id` string, and exposes action controls (Accept/Escalate/Needs-info).
- [ ] Deliberate-break → revert: render the queue as `st.write({...item_id...})` (today's behavior) → confirm the test FAILS (no human-readable description / no actions) → revert.

<!-- auto-status-summary:end -->