### PR TITLE
Follow up #629: persist analyst queue actions

### DIFF
--- a/app/streamlit_app.py
+++ b/app/streamlit_app.py
@@ -43,6 +43,8 @@ class StreamlitLike(Protocol):
     def subheader(self, body: str) -> None: ...
     def table(self, data: object) -> None: ...
     def button(self, label: str, *, key: str) -> bool: ...
+    @property
+    def session_state(self) -> dict[str, object]: ...
     def write(self, *args: object, **kwargs: object) -> None: ...
     def success(self, body: str) -> None: ...
 
@@ -72,7 +74,7 @@ class AnalystQueueCard:
     state: str
 
 
-QUEUE_ACTION_STATE: dict[str, str] = {}
+QUEUE_ACTION_STATE_KEY = "analyst_queue_action_state"
 
 
 def _suppress_langsmith_env() -> dict[str, str]:
@@ -174,7 +176,10 @@ def _browser_safe_demo_fixture(fixture_name: str) -> DemoResult:
     )
 
 
-def build_analyst_queue_card(result: DemoResult) -> AnalystQueueCard:
+def build_analyst_queue_card(
+    result: DemoResult,
+    action_state: dict[str, str] | None = None,
+) -> AnalystQueueCard:
     """Decode the internal queue item id into a readable analyst work item."""
 
     tokens = result.item_id.split(":")
@@ -196,7 +201,7 @@ def build_analyst_queue_card(result: DemoResult) -> AnalystQueueCard:
             "Open the package evidence, confirm the conflict, then accept the score, "
             "escalate to ops, or request missing information."
         ),
-        state=QUEUE_ACTION_STATE.get(result.item_id, "Waiting for analyst action"),
+        state=(action_state or {}).get(result.item_id, "Waiting for analyst action"),
     )
 
 
@@ -204,20 +209,29 @@ def _label_from_token(token: str) -> str:
     return token.replace("_", " ").replace("-", " ").title()
 
 
-def _record_queue_action(item_id: str, action: str) -> None:
-    QUEUE_ACTION_STATE[item_id] = action
+def _queue_action_state(st: StreamlitLike) -> dict[str, str]:
+    state = st.session_state.setdefault(QUEUE_ACTION_STATE_KEY, {})
+    if not isinstance(state, dict):
+        state = {}
+        st.session_state[QUEUE_ACTION_STATE_KEY] = state
+    return cast(dict[str, str], state)
+
+
+def _record_queue_action(action_state: dict[str, str], item_id: str, action: str) -> None:
+    action_state[item_id] = action
 
 
 def render_analyst_queue(st: StreamlitLike, result: DemoResult) -> AnalystQueueCard:
     """Render a readable queue card and in-memory action controls."""
 
+    action_state = _queue_action_state(st)
     if st.button("Accept", key=f"{result.item_id}:accept"):
-        _record_queue_action(result.item_id, "Accepted")
+        _record_queue_action(action_state, result.item_id, "Accepted")
     if st.button("Escalate", key=f"{result.item_id}:escalate"):
-        _record_queue_action(result.item_id, "Escalated to ops")
+        _record_queue_action(action_state, result.item_id, "Escalated to ops")
     if st.button("Needs-info", key=f"{result.item_id}:needs-info"):
-        _record_queue_action(result.item_id, "Needs information")
-    card = build_analyst_queue_card(result)
+        _record_queue_action(action_state, result.item_id, "Needs information")
+    card = build_analyst_queue_card(result, action_state)
     st.table(
         [
             {

--- a/tests/app/test_streamlit_app_smoke.py
+++ b/tests/app/test_streamlit_app_smoke.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 import pytest
-from app.streamlit_app import QUEUE_ACTION_STATE, render_app
+from app.streamlit_app import QUEUE_ACTION_STATE_KEY, render_app
 
 from inv_man_intake.observability import InMemoryTraceSink
 
@@ -16,6 +16,7 @@ class _StreamlitRecorder:
         self.tables: list[object] = []
         self.buttons: list[tuple[str, str]] = []
         self.clicked_keys: set[str] = set()
+        self.session_state: dict[str, object] = {}
 
     def set_page_config(self, **kwargs: object) -> None:
         return None
@@ -144,7 +145,6 @@ def test_analyst_queue_renders_readable_item_and_actions(
             queue_assignment=_FakeQueueAssignment(owner_role="analyst", item_id=item_id),
         )
 
-    QUEUE_ACTION_STATE.clear()
     monkeypatch.setattr("app.streamlit_app.run_v1_smoke_pipeline", _fake_pipeline)
 
     recorder = _StreamlitRecorder()
@@ -176,7 +176,7 @@ def test_analyst_queue_renders_readable_item_and_actions(
         ("Escalate", f"{item_id}:escalate"),
         ("Needs-info", f"{item_id}:needs-info"),
     ]
-    assert QUEUE_ACTION_STATE[result.item_id] == "Escalated to ops"
+    assert recorder.session_state[QUEUE_ACTION_STATE_KEY] == {result.item_id: "Escalated to ops"}
 
 
 def test_app_uses_browser_safe_score_when_pyodide_lacks_sqlite(

--- a/tests/test_analyst_queue_render.py
+++ b/tests/test_analyst_queue_render.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from app.streamlit_app import (
+    QUEUE_ACTION_STATE_KEY,
+    DemoResult,
+    render_analyst_queue,
+)
+
+
+class StreamlitRecorder:
+    def __init__(self) -> None:
+        self.tables: list[object] = []
+        self.buttons: list[tuple[str, str]] = []
+        self.clicked_keys: set[str] = set()
+        self.session_state: dict[str, object] = {}
+
+    def button(self, label: str, *, key: str) -> bool:
+        self.buttons.append((label, key))
+        return key in self.clicked_keys
+
+    def table(self, data: object) -> None:
+        self.tables.append(data)
+
+
+def _demo_result(item_id: str) -> DemoResult:
+    return DemoResult(
+        fixture_name="pdf_primary_mixed_bundle.json",
+        package_id="pkg_pdf_mixed_001",
+        final_score=0.4321,
+        components=[],
+        owner_role="analyst",
+        item_id=item_id,
+        sink_type="InMemoryTraceSink",
+        trace_tags={},
+    )
+
+
+def test_analyst_queue_render_decodes_item_id_and_records_session_action() -> None:
+    item_id = "pkg_pdf_mixed_001:validation:performance_conflict:corr_4d03914dd557"
+    recorder = StreamlitRecorder()
+    recorder.clicked_keys.add(f"{item_id}:needs-info")
+
+    card = render_analyst_queue(recorder, _demo_result(item_id))
+
+    assert card.owner == "Analyst"
+    assert card.package == "pkg_pdf_mixed_001"
+    assert card.headline == "Performance Conflict requires validation review"
+    assert card.state == "Needs information"
+    assert recorder.buttons == [
+        ("Accept", f"{item_id}:accept"),
+        ("Escalate", f"{item_id}:escalate"),
+        ("Needs-info", f"{item_id}:needs-info"),
+    ]
+    assert recorder.session_state[QUEUE_ACTION_STATE_KEY] == {item_id: "Needs information"}
+
+    assert recorder.tables == [
+        [
+            {
+                "Owner": "Analyst",
+                "Package": "pkg_pdf_mixed_001",
+                "Issue": "Performance Conflict requires validation review",
+                "Reason": (
+                    "The scoring pipeline routed this package for analyst review because "
+                    "performance conflict evidence needs confirmation."
+                ),
+                "Affected evidence": "Package pkg_pdf_mixed_001; evidence marker corr_4d03914dd557",
+                "Suggested resolution": (
+                    "Open the package evidence, confirm the conflict, then accept the score, "
+                    "escalate to ops, or request missing information."
+                ),
+                "State": "Needs information",
+            }
+        ]
+    ]
+    assert item_id not in str(recorder.tables)


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:629 -->
> **Source:** Issue #629

Closes #629

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
_Scope section missing from source issue._

#### Tasks
- [ ] `app/streamlit_app.py:177-178` — render each queue item as a **readable card/row, not raw JSON**: decode the `item_id` into display fields (package, validation rule violated, conflict type) and show an issue headline + reason + affected evidence + a suggested resolution path. (panel fix-hint)
- [ ] Add **per-item actions** (e.g. Accept / Escalate / Needs-info) that write back to the queue state, so the analyst can resolve items rather than just view an id. (panel fix-hint)

#### Acceptance criteria
- [ ] Named test: `tests/test_analyst_queue_render.py` (new) — given a demo result with a flagged queue item, assert the analyst-queue render produces a human-readable issue description (package + validation rule + conflict), NOT the raw `item_id` string, and exposes action controls (Accept/Escalate/Needs-info).
- [ ] Deliberate-break → revert: render the queue as `st.write({...item_id...})` (today's behavior) → confirm the test FAILS (no human-readable description / no actions) → revert.

<!-- auto-status-summary:end -->