### PR TITLE
chore: sync workflow templates

### DIFF
--- a/design-system/README.md
+++ b/design-system/README.md
@@ -47,4 +47,4 @@ That's the "default with per-app customization" model: the base is canonical; an
 
 ## Status & next step
 
-This kit is managed from `Workflows/templates/consumer-repo/design-system/` and distributed by the Maint 68 Sync Consumer Repos GitHub Actions workflow through `.github/sync-manifest.yml`. Update it here first, then let the sync workflow replace consumer copies.
+This kit is managed from `stranske/Workflows/templates/consumer-repo/design-system/` and distributed by the Maint 68 Sync Consumer Repos GitHub Actions workflow through `.github/sync-manifest.yml`. Update the Workflows template first, then let the sync workflow replace consumer copies.

--- a/design-system/ds_streamlit.py
+++ b/design-system/ds_streamlit.py
@@ -25,9 +25,11 @@ Usage:
 from __future__ import annotations
 
 import logging
+import re
 from collections.abc import Callable, Mapping
 from contextlib import contextmanager
 from html import escape
+from importlib import import_module
 from typing import Any
 
 logger = logging.getLogger("ds")
@@ -52,11 +54,18 @@ _NOTICE_STYLE = {
     "ok": (_POS, _POS_WEAK, "✓"),
 }
 
+_HEX_CHARS = frozenset("0123456789abcdef")
+_UUID_RE = re.compile(r"(?i)^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$")
+
+
+def _streamlit() -> Any:
+    return import_module("streamlit")
+
 
 def inject_theme() -> None:
     """P1 — apply the light/understated theme. Pair with .streamlit/config.toml
     ([theme] base=\"light\"); this nudges spacing/headings to match the system."""
-    import streamlit as st
+    st = _streamlit()
 
     st.markdown(
         f"""<style>
@@ -88,7 +97,7 @@ def empty_state(
 ) -> bool:
     """P2 — title + reason + optional next-action. Returns True if the CTA was
     clicked. NEVER pass an internal filename/path as `desc`."""
-    import streamlit as st
+    st = _streamlit()
 
     safe_icon = escape(str(icon))
     safe_title = escape(str(title))
@@ -109,7 +118,7 @@ def empty_state(
 def notice(kind: str, title: str = "", body: str = "", action: str | None = None) -> None:
     """P3/P4 — the one container for user-facing messages. kind in
     {error,warn,info,ok}. `action` is optional literal remediation text."""
-    import streamlit as st
+    st = _streamlit()
 
     color, bg, ic = _NOTICE_STYLE.get(kind, _NOTICE_STYLE["info"])
     head = f"<strong>{escape(str(title))}</strong><br>" if title else ""
@@ -165,7 +174,7 @@ def dev_note(msg: str) -> None:
 @contextmanager
 def diagnostics_expander(label: str = "Diagnostics", *, expanded: bool = False):
     """P4 — explicit opt-in container for diagnostics that must be visible."""
-    import streamlit as st
+    st = _streamlit()
 
     with st.expander(label, expanded=expanded):
         yield
@@ -197,15 +206,35 @@ def humanize_id(raw: str, mapping: Mapping[str, str] | None = None) -> str:
 
 
 def _human_label_segment(segment: str) -> str:
+    if _is_opaque_id_segment(segment):
+        return ""
     words = [part for part in segment.replace("-", "_").split("_") if part]
     meaningful = []
     for word in words:
         lowered = word.lower()
-        if lowered.isdigit():
-            continue
-        if len(lowered) >= 8 and all(ch in "0123456789abcdef" for ch in lowered):
+        if lowered.isdigit() or _is_opaque_id_token(lowered):
             continue
         meaningful.append(word)
     if not meaningful:
         return ""
     return " ".join(meaningful).strip()
+
+
+def _is_opaque_id_segment(segment: str) -> bool:
+    value = segment.strip().lower()
+    if not value:
+        return True
+    if _UUID_RE.fullmatch(value):
+        return True
+    compact = value.replace("-", "").replace("_", "")
+    return len(compact) >= 8 and all(ch in _HEX_CHARS for ch in compact)
+
+
+def _is_opaque_id_token(value: str) -> bool:
+    if len(value) >= 8 and all(ch in _HEX_CHARS for ch in value):
+        return True
+    return (
+        len(value) == 4
+        and any(ch.isdigit() for ch in value)
+        and all(ch in _HEX_CHARS for ch in value)
+    )


### PR DESCRIPTION
## Sync Summary

### Files Updated
- ds_streamlit.py: Streamlit adapter for the design system (inject_theme/empty_state/notice/error/translate_error/dev_note/availability_badge/humanize_id) so Streamlit apps consume the same presentation patterns.
- README.md: Design-system usage guide: how to apply the theme + components/kit per app type.

### Files Skipped
- pr-00-gate.yml: File exists and sync_mode is create_only
- ci.yml: File exists and sync_mode is create_only
- renovate.json: File exists and sync_mode is create_only
- cross-repo-smoke.yml: File exists and sync_mode is create_only
- llm_slots.json: None

---

### Review Checklist
- [ ] CI passes with updated workflows
- [ ] No repo-specific customizations were overwritten

**Source:** stranske/Workflows
**Source SHA:** `96021efe31cc7378fd7e3c8d92d4dd8c5b58b440`
**Template hash:** `c45de68fdd89`
**Sync branch:** `sync/workflows-c45de68fdd89`
**Consumer repo:** `stranske/Inv-Man-Intake`
**Manifest:** `.github/sync-manifest.yml`

<!-- workflows-consumer-sync:v1 {"schema":"workflows-consumer-sync-pr/v1","consumer_repo":"stranske/Inv-Man-Intake","source_repository":"stranske/Workflows","source_sha":"96021efe31cc7378fd7e3c8d92d4dd8c5b58b440","template_hash":"c45de68fdd89","sync_branch":"sync/workflows-c45de68fdd89","manifest":".github/sync-manifest.yml","lifecycle_state":"opened","run_id":"28026273986","run_attempt":"1","changes_count":2} -->