### PR TITLE
deps: sync dev tool versions

### DIFF
--- a/.github/workflows/autofix-versions.env
+++ b/.github/workflows/autofix-versions.env
@@ -1,11 +1,11 @@
-# Shared formatter/type checker pins consumed by CI workflows and local scripts.
-# Update in lock-step when bumping tooling and keep values in sync with autofix images.
+# Canonical formatter/type checker pins for Workflows and Maint 52 consumer dev-tool sync.
+# Update in lock-step with pyproject.toml, requirements.lock, and template defaults.
 #
 # NOTE: Only include dev tools here (linters, formatters, test runners).
 # Runtime dependencies (PyYAML, Pydantic, Hypothesis) should be managed via Dependabot
 # in each consumer repo's pyproject.toml directly, NOT synced from this file.
 BLACK_VERSION=26.5.1
-RUFF_VERSION=0.15.18
+RUFF_VERSION=0.15.19
 ISORT_VERSION=8.0.1
 DOCFORMATTER_VERSION=1.7.8
 MYPY_VERSION=2.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dev = [
     "playwright>=1.56.0",
     "pytest==9.1.1",
     "pytest-cov==7.1.0",
-    "ruff==0.15.18",
+    "ruff==0.15.19",
     "mypy>=2.1.0",
     "black>=26.5.1",
     "tomlkit==0.15.0",

--- a/requirements.lock
+++ b/requirements.lock
@@ -167,7 +167,7 @@ rpds-py==2026.5.1
     # via
     #   jsonschema
     #   referencing
-ruff==0.15.18
+ruff==0.15.19
     # via inv-man-intake (pyproject.toml)
 six==1.17.0
     # via python-dateutil


### PR DESCRIPTION
## Dev Tool Version Sync

This PR updates dev tool versions in `pyproject.toml` to match the central
version pins from [stranske/Workflows](https://github.com/stranske/Workflows).

### Changes
```
Found 2 version updates:
  - ruff: ==0.15.18 -> ==0.15.19
  - requirements.lock:ruff: 0.15.18 -> ==0.15.19

Run with --apply to update dependency files
```

### Why
Consistent dev tool versions across repos ensures:
- CI behaviors match between repos
- No surprises from version drift
- Easier debugging when tools behave the same everywhere

---
**Source:** `.github/workflows/autofix-versions.env`