### PR TITLE
Follow up #630: complete demo presentation verifier coverage

### DIFF
--- a/app/streamlit_app.py
+++ b/app/streamlit_app.py
@@ -26,9 +26,15 @@ FIXTURE_ROOT = Path(__file__).resolve().parents[1] / "tests" / "fixtures" / "int
 FIXTURE_OPTIONS = tuple(
     cast(str, package["intake_bundle_file"]) for package in DEFAULT_BATCH_PACKAGES
 )
-FIXTURE_DISPLAY_LABELS = {
-    "pdf_primary_mixed_bundle.json": "Mixed-source PDF intake sample",
-    "pptx_primary_mixed_bundle.json": "Mixed presentation intake sample",
+FIXTURE_DISPLAY_METADATA = {
+    "pdf_primary_mixed_bundle.json": {
+        "label": "Mixed-source PDF intake sample",
+        "description": "PDF-led sample package with mixed evidence for the analyst queue demo.",
+    },
+    "pptx_primary_mixed_bundle.json": {
+        "label": "Mixed presentation intake sample",
+        "description": "Presentation-led sample package for checking intake and scoring output.",
+    },
 }
 PACKAGE_CONFIG_BY_FIXTURE = {
     cast(str, package["intake_bundle_file"]): {
@@ -38,6 +44,24 @@ PACKAGE_CONFIG_BY_FIXTURE = {
     for package in DEFAULT_BATCH_PACKAGES
 }
 run_v1_smoke_pipeline: Any | None = None
+
+
+def fixture_display_label(fixture_name: str) -> str:
+    """Return the analyst-facing label for a committed fixture bundle."""
+
+    metadata = FIXTURE_DISPLAY_METADATA.get(fixture_name)
+    if metadata:
+        return metadata["label"]
+    return fixture_name.removesuffix(".json").replace("_", " ").title()
+
+
+def fixture_display_description(fixture_name: str) -> str:
+    """Return a one-line description for the selected fixture bundle."""
+
+    metadata = FIXTURE_DISPLAY_METADATA.get(fixture_name)
+    if metadata:
+        return metadata["description"]
+    return "Sample intake bundle for the deterministic browser demo."
 
 
 class StreamlitLike(Protocol):
@@ -281,10 +305,9 @@ def render_app(st: StreamlitLike | None = None) -> DemoResult:
     fixture_name = st.selectbox(
         "Synthetic intake bundle",
         FIXTURE_OPTIONS,
-        format_func=lambda fixture: FIXTURE_DISPLAY_LABELS.get(
-            fixture, fixture.removesuffix(".json").replace("_", " ").title()
-        ),
+        format_func=fixture_display_label,
     )
+    st.caption(f"{fixture_display_description(fixture_name)} Backing fixture: `{fixture_name}`.")
     result = run_demo_fixture(fixture_name)
 
     st.metric("Final score", f"{result.final_score:.4f}")

--- a/tests/test_demo_presentation.py
+++ b/tests/test_demo_presentation.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from app.streamlit_app import FIXTURE_OPTIONS, render_app
+
+
+class _PresentationRecorder:
+    def __init__(self) -> None:
+        self.captions: list[str] = []
+        self.selectboxes: list[tuple[str, tuple[str, ...], tuple[str, ...]]] = []
+        self.success_messages: list[str] = []
+        self.write_calls: list[tuple[object, ...]] = []
+        self.session_state: dict[str, object] = {}
+
+    def set_page_config(self, **kwargs: object) -> None:
+        return None
+
+    def title(self, body: str) -> None:
+        return None
+
+    def caption(self, body: str) -> None:
+        self.captions.append(body)
+
+    def selectbox(
+        self,
+        label: str,
+        options: tuple[str, ...],
+        *,
+        format_func: Callable[[str], str] | None = None,
+    ) -> str:
+        display_options = tuple(
+            format_func(option) if format_func else option for option in options
+        )
+        self.selectboxes.append((label, options, display_options))
+        return "pdf_primary_mixed_bundle.json"
+
+    def metric(self, label: str, value: str) -> None:
+        return None
+
+    def subheader(self, body: str) -> None:
+        return None
+
+    def table(self, data: object) -> None:
+        return None
+
+    def button(self, label: str, *, key: str) -> bool:
+        return False
+
+    def write(self, *args: object, **kwargs: object) -> None:
+        self.write_calls.append(args)
+
+    def success(self, body: str) -> None:
+        self.success_messages.append(body)
+
+
+def test_fixture_selector_uses_friendly_labels_and_selected_description() -> None:
+    recorder = _PresentationRecorder()
+
+    render_app(recorder)
+
+    assert recorder.selectboxes == [
+        (
+            "Synthetic intake bundle",
+            FIXTURE_OPTIONS,
+            (
+                "Mixed-source PDF intake sample",
+                "Mixed presentation intake sample",
+            ),
+        )
+    ]
+    _, backing_options, display_options = recorder.selectboxes[0]
+    assert set(backing_options) == {
+        "pdf_primary_mixed_bundle.json",
+        "pptx_primary_mixed_bundle.json",
+    }
+    assert all(not option.endswith(".json") for option in display_options)
+    assert any(
+        "PDF-led sample package with mixed evidence" in caption
+        and "Backing fixture: `pdf_primary_mixed_bundle.json`." in caption
+        for caption in recorder.captions
+    )
+
+
+def test_trace_sink_observability_details_are_not_rendered_in_main_content() -> None:
+    recorder = _PresentationRecorder()
+
+    render_app(recorder)
+
+    rendered_main_content = " ".join(
+        [
+            *recorder.success_messages,
+            *(" ".join(map(str, call)) for call in recorder.write_calls),
+        ]
+    )
+    assert "Trace sink:" not in rendered_main_content
+    assert "LangSmith and LangChain tracing env vars are off" not in rendered_main_content


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:630 -->
> **Source:** Issue #630

Closes #630

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The demo surfaces developer/observability details in the main UI. Observed live, 2026-06-22 (HEAD `b91b4a9`):

`app/streamlit_app.py:179` renders `st.success(f"Trace sink: {result.sink_type}; LangSmith and LangChain tracing env vars are off.")` as a green success banner in the main content, showing an internal observability detail a user shouldn't see.

`app/streamlit_app.py:171` uses `st.selectbox("Synthetic intake bundle", FIXTURE_OPTIONS)` and shows raw fixture filenames (for example, `pdf_primary_mixed_bundle.json`) instead of friendly labels.

User-facing consequence: the primary surface reads like a developer fixture harness rather than an analyst tool. The UX-Review panel grouped these as usability/confusion sev4 (4/4).

#### Tasks
- [ ] Update `app/streamlit_app.py:179` to remove the trace-sink line from the user-facing surface, or gate it behind a collapsed debug expander (`st.expander`) or `logging`.
- [ ] Update `app/streamlit_app.py:171` to map fixture filenames to friendly display names plus a one-line description, while keeping the filename as secondary/caption text if useful.
- [ ] Write `tests/test_demo_presentation.py` to assert the bundle selector uses friendly display labels instead of raw `*.json` filenames and that the trace-sink/observability string is not rendered via `st.success` or `st.write` in the main content.
- [ ] Test the deliberate-break case by restoring the raw-filename options and the `st.success("Trace sink…")` call, confirming `tests/test_demo_presentation.py` fails, then reverting.

#### Acceptance criteria
- [ ] `app/streamlit_app.py` no longer renders the trace-sink/observability string in main content via `st.success` or `st.write`.
- [ ] The synthetic intake bundle selector in `app/streamlit_app.py` presents friendly display names rather than raw `*.json` filenames.
- [ ] Underlying fixture filenames remain unchanged and are used only as backing values or secondary/caption text.
- [ ] `tests/test_demo_presentation.py` exists and fails when raw filename options and the `st.success("Trace sink…")` call are restored.
- [ ] `tests/test_demo_presentation.py` passes with the intended UI changes applied.

<!-- auto-status-summary:end -->