### PR TITLE
Codex bootstrap for #630

### DIFF
--- a/agents/codex-630.md
+++ b/agents/codex-630.md
@@ -1,0 +1,1 @@
+<!-- bootstrap for codex on issue #630 -->


### PR DESCRIPTION
<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The demo surfaces developer/observability details in the main UI. Observed live, 2026-06-22 (HEAD `b91b4a9`):

`app/streamlit_app.py:179` renders `st.success(f"Trace sink: {result.sink_type}; LangSmith and LangChain tracing env vars are off.")` as a green success banner in the main content, showing an internal observability detail a user shouldn't see.

`app/streamlit_app.py:171` uses `st.selectbox("Synthetic intake bundle", FIXTURE_OPTIONS)` and shows raw fixture filenames (for example, `pdf_primary_mixed_bundle.json`) instead of friendly labels.

User-facing consequence: the primary surface reads like a developer fixture harness rather than an analyst tool. The UX-Review panel grouped these as usability/confusion sev4 (4/4).

#### Tasks
- [ ] Update `app/streamlit_app.py:179` to remove the trace-sink line from the user-facing surface, or gate it behind a collapsed debug expander (`st.expander`) or `logging`.
- [ ] Update `app/streamlit_app.py:171` to map fixture filenames to friendly display names plus a one-line description, while keeping the filename as secondary/caption text if useful.
- [ ] Write `tests/test_demo_presentation.py` to assert the bundle selector uses friendly display labels instead of raw `*.json` filenames and that the trace-sink/observability string is not rendered via `st.success` or `st.write` in the main content.
- [ ] Test the deliberate-break case by restoring the raw-filename options and the `st.success("Trace sink…")` call, confirming `tests/test_demo_presentation.py` fails, then reverting.

#### Acceptance criteria
- [ ] `app/streamlit_app.py` no longer renders the trace-sink/observability string in main content via `st.success` or `st.write`.
- [ ] The synthetic intake bundle selector in `app/streamlit_app.py` presents friendly display names rather than raw `*.json` filenames.
- [ ] Underlying fixture filenames remain unchanged and are used only as backing values or secondary/caption text.
- [ ] `tests/test_demo_presentation.py` exists and fails when raw filename options and the `st.success("Trace sink…")` call are restored.
- [ ] `tests/test_demo_presentation.py` passes with the intended UI changes applied.

<!-- auto-status-summary:end -->

<details>

<summary>Full Issue Text</summary>



## Why

The demo surfaces developer/observability details in the main UI. Observed live, 2026-06-22 (HEAD `b91b4a9`):

`app/streamlit_app.py:179` renders `st.success(f"Trace sink: {result.sink_type}; LangSmith and LangChain tracing env vars are off.")` as a green success banner in the main content, showing an internal observability detail a user shouldn't see.

`app/streamlit_app.py:171` uses `st.selectbox("Synthetic intake bundle", FIXTURE_OPTIONS)` and shows raw fixture filenames (for example, `pdf_primary_mixed_bundle.json`) instead of friendly labels.

User-facing consequence: the primary surface reads like a developer fixture harness rather than an analyst tool. The UX-Review panel grouped these as usability/confusion sev4 (4/4).

## Scope

Update the user-facing demo presentation in `app/streamlit_app.py` so the trace-sink message is not shown in main content and the synthetic intake bundle selector uses friendly display names with a one-line description while preserving underlying fixture filenames.

Surfaced by the UX Review (`Code/Orchestrator/ux_review.py`), 2026-06-22 — review_id `stranske/Inv-Man-Intake:uxreview:2026-06-22`. Verified at the cited file:lines + a live capture.

## Non-Goals

Do NOT remove or rename the underlying fixtures — only their display labels.

Keep the LangSmith-disabled behavior; just don't advertise the trace sink in the main UI.

## Tasks

- [ ] Update `app/streamlit_app.py:179` to remove the trace-sink line from the user-facing surface, or gate it behind a collapsed debug expander (`st.expander`) or `logging`.
- [ ] Update `app/streamlit_app.py:171` to map fixture filenames to friendly display names plus a one-line description, while keeping the filename as secondary/caption text if useful.
- [ ] Write `tests/test_demo_presentation.py` to assert the bundle selector uses friendly display labels instead of raw `*.json` filenames and that the trace-sink/observability string is not rendered via `st.success` or `st.write` in the main content.
- [ ] Test the deliberate-break case by restoring the raw-filename options and the `st.success("Trace sink…")` call, confirming `tests/test_demo_presentation.py` fails, then reverting.

## Acceptance Criteria

- [ ] `app/streamlit_app.py` no longer renders the trace-sink/observability string in main content via `st.success` or `st.write`.
- [ ] The synthetic intake bundle selector in `app/streamlit_app.py` presents friendly display names rather than raw `*.json` filenames.
- [ ] Underlying fixture filenames remain unchanged and are used only as backing values or secondary/caption text.
- [ ] `tests/test_demo_presentation.py` exists and fails when raw filename options and the `st.success("Trace sink…")` call are restored.
- [ ] `tests/test_demo_presentation.py` passes with the intended UI changes applied.

## Implementation Notes

Fix hints from the 4/4-corroborated panel: remove the trace-sink line from the main UI or place it behind a collapsed debug expander, and replace raw fixture filenames with friendly display names such as “Mixed-source PDF intake (sample)” plus a one-line description.

<details>
<summary>Original Issue</summary>

```text
## Why (verified evidence)

The demo surfaces developer/observability details in the main UI. Observed live, 2026-06-22 (HEAD `b91b4a9`):

- `app/streamlit_app.py:179` → `st.success(f"Trace sink: {result.sink_type}; LangSmith and LangChain tracing env vars are off.")` renders "Trace sink: InMemoryTraceSink; LangSmith and LangChain tracing env vars are off." as a green success banner in the main content — an internal observability detail a user shouldn't see.
- `app/streamlit_app.py:171` → `st.selectbox("Synthetic intake bundle", FIXTURE_OPTIONS)` shows raw fixture **filenames** (e.g. "pdf_primary_mixed_bundle.json") instead of friendly labels.

**User-facing consequence:** the primary surface reads like a developer fixture harness rather than an analyst tool. The UX-Review panel grouped these as usability/confusion **sev4 (4/4)**.

## Tasks
- [ ] `app/streamlit_app.py:179` — remove the trace-sink line from the user-facing surface, or gate it behind a collapsed debug expander (`st.expander`)/`logging`. (panel fix-hint)
- [ ] `app/streamlit_app.py:171` — map fixture filenames to **friendly display names + a one-line description** (e.g. "Mixed-source PDF intake (sample)"); keep the filename as secondary/caption text if useful. (panel fix-hint)

## Test gate
- Named test: `tests/test_demo_presentation.py` (new) — assert the bundle selector's option labels are friendly display names (not raw `*.json` filenames) and that the trace-sink/observability string is NOT rendered via `st.success`/`st.write` in the main content (patch/spy Streamlit).
- Deliberate-break → revert: restore the raw-filename options + the `st.success("Trace sink…")` call → confirm the test FAILS → revert.

## Non-Goals
- Do NOT remove or rename the underlying fixtures — only their display labels.
- Keep the LangSmith-disabled behavior; just don't advertise the trace sink in the main UI.

_Surfaced by the UX Review (`Code/Orchestrator/ux_review.py`), 2026-06-22 — review_id `stranske/Inv-Man-Intake:uxreview:2026-06-22`. Verified at the cited file:lines + a live capture. Fix hints from the 4/4-corroborated panel._
```
</details>

<!-- issue-pr-context:formatted-body:v1 {"sha256":"7d1bde06180307e3d2be8c84b452db30df997b4c9c0cb53cae743a760f00e1c4","workflows":["agents-auto-pilot","agents-issue-optimizer","agents-63-issue-intake","issue_formatter","issue_optimizer"]} -->



</details>

—
PR created automatically to engage Codex.

<!-- pr-preamble:start -->
<!-- meta:issue:630 -->
> **Source:** Issue #630

Closes #630

<!-- pr-preamble:end -->