### PR TITLE
[codex] Add SLA breach idempotency test

### DIFF
--- a/tests/queue/test_assignment_sla.py
+++ b/tests/queue/test_assignment_sla.py
@@ -89,11 +89,28 @@ def test_same_day_breach_flag_set_after_due_time() -> None:
     assert breached.sla.breached_at == datetime(2026, 3, 9, 0, 0, 0, tzinfo=UTC)
 
 
-def test_same_day_breach_flag_not_set_before_due_time() -> None:
+def test_same_day_breach_idempotent_preserves_first_timestamp() -> None:
     created = datetime(2026, 3, 8, 9, 0, 0, tzinfo=UTC)
+    first_observed_at = datetime(2026, 3, 9, 0, 0, 0, tzinfo=UTC)
+    second_observed_at = datetime(2026, 3, 9, 1, 15, 0, tzinfo=UTC)
     record = create_analyst_first_assignment(
         item_id="queue-41-5",
         analyst_id="analyst-6",
+        created_at=created,
+    )
+
+    breached = update_sla_breach(record, now=first_observed_at)
+    breached_again = update_sla_breach(breached, now=second_observed_at)
+
+    assert breached.sla.breached_at == first_observed_at
+    assert breached_again.sla.breached_at == first_observed_at
+
+
+def test_same_day_breach_flag_not_set_before_due_time() -> None:
+    created = datetime(2026, 3, 8, 9, 0, 0, tzinfo=UTC)
+    record = create_analyst_first_assignment(
+        item_id="queue-41-6",
+        analyst_id="analyst-7",
         created_at=created,
     )
 
@@ -106,7 +123,7 @@ def test_sla_requires_timezone_aware_created_at() -> None:
 
     with pytest.raises(ValueError, match="created_at must be timezone-aware"):
         create_analyst_first_assignment(
-            item_id="queue-41-6",
-            analyst_id="analyst-7",
+            item_id="queue-41-7",
+            analyst_id="analyst-8",
             created_at=naive,
         )


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:682 -->
> **Source:** Issue #682

Closes #682

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
`src/inv_man_intake/queue/sla.py` records when a queue item first breaches SLA. Current tests cover the first breach observation, but not repeated observations. This is a safe Route-Weight `testgen` opener because the behavior is deterministic and uses existing queue test fixtures.

#### Tasks
- [ ] Add a focused test for `mark_breach_if_due()` / SLA breach recording.
- [ ] Verify that after an item's `breached_at` timestamp is set, a later call does not overwrite the original timestamp.
- [ ] Keep the test in the existing assignment/SLA test surface unless a sibling test file better matches local conventions.

#### Acceptance criteria
- [ ] Tests are deterministic and do not require network, browser, or external services.
- [ ] The first breach timestamp is preserved across repeated breach observations.
- [ ] Existing queue/SLA behavior is preserved.

<!-- auto-status-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage to ensure repeated SLA breach updates keep the original timestamp for the same day.
  * Refined existing SLA timing test data to better validate behavior before the due time.
  * Updated timezone validation test setup while preserving the expected error for timezone-naive timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->