### PR TITLE
test: enforce red_flag_applied directional for blocked base scenario

### DIFF
--- a/tests/baseline/catalog.yaml
+++ b/tests/baseline/catalog.yaml
@@ -290,6 +290,13 @@ directionals:
     metric: red_flag_applied
     direction: increase
     enforce: true
+  # A red-flag block on the non-floor base also sets the applied flag (0 -> 1).
+  - id: block_sets_red_flag_applied
+    scenario: red_flag_blocked
+    control: base
+    metric: red_flag_applied
+    direction: increase
+    enforce: true
   # Blocked-zero keeps final_score at the floor, but must still surface that a
   # blocking red flag applied.
   - id: blocked_floor_keeps_final_score_at_floor

--- a/tests/baseline/test_coverage_manifest.py
+++ b/tests/baseline/test_coverage_manifest.py
@@ -54,7 +54,7 @@ def test_catalog_contract_shape():
 
     assert "base" in catalog
     assert len(scenarios) == 20
-    assert len(directionals) == 20
+    assert len(directionals) == 21
     assert priority_metrics
 
 


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:679 -->
> **Source:** Issue #679

Closes #679

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
`tests/baseline/catalog.yaml` has a `red_flag_blocked` scenario and existing red-flag cap directional coverage, but the audit did not find an enforced directional assertion for `red_flag_applied` on the non-floor blocked scenario. This is a safe Route-Weight `testgen` opener because it extends the existing baseline contract without changing production scoring logic.

#### Tasks
- [ ] Add an enforced baseline directional for scenario `red_flag_blocked`, control `base`, metric `red_flag_applied`, direction `increase`.
- [ ] Keep the scope to the non-floor base scenario where the expected flag behavior is already unambiguous.
- [ ] Update only the catalog/test artifacts required by the existing baseline suite.

#### Acceptance criteria
- [ ] Existing baseline directionals pass.
- [ ] The new directional fails if `red_flag_blocked` stops setting `red_flag_applied`.
- [ ] No production scoring code changes are introduced.

**Head SHA:** e7916d3df612ccf67af5c51c39b728d540bdde52
**Latest Runs:** ✅ success — Gate
**Required:** gate: ✅ success

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents PR Event Hub | ❔ in progress | [View run](https://github.com/stranske/Inv-Man-Intake/actions/runs/28325383414) |
| Claude Code Review (Opt-in) | ✅ success | [View run](https://github.com/stranske/Inv-Man-Intake/actions/runs/28325294418) |
| Cross-Repo Smoke | ⏭️ skipped | [View run](https://github.com/stranske/Inv-Man-Intake/actions/runs/28325294566) |
| Gate | ✅ success | [View run](https://github.com/stranske/Inv-Man-Intake/actions/runs/28325294590) |
| Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/Inv-Man-Intake/actions/runs/28325294412) |
<!-- auto-status-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded baseline coverage with an additional directional test case.
  * Updated the manifest expectations to account for one more catalog entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->