### PR TITLE
test: add capped_score bounds guard coverage

### DIFF
--- a/tests/scoring/test_engine.py
+++ b/tests/scoring/test_engine.py
@@ -112,11 +112,16 @@ def test_red_flag_cap_at_or_above_base_does_not_apply_reason() -> None:
     assert result.red_flag_reason is None
 
 
-def test_red_flag_hook_rejects_out_of_range_capped_score() -> None:
+@pytest.mark.parametrize(
+    "invalid_cap",
+    [-0.01, 1.01],
+    ids=["below_zero", "above_one"],
+)
+def test_capped_score_bounds_rejects_invalid_red_flag_cap(invalid_cap: float) -> None:
     class InvalidCapHook:
         def apply(self, submission: ScoreSubmission, *, base_score: float) -> RedFlagDecision:
             del submission, base_score
-            return RedFlagDecision(capped_score=1.5, reason="invalid-cap")
+            return RedFlagDecision(capped_score=invalid_cap, reason="invalid-cap")
 
     with pytest.raises(ValueError, match="red flag capped_score must be between 0 and 1"):
         compute_score(_submission("equity"), red_flag_hook=InvalidCapHook())


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:681 -->
> **Source:** Issue #681

Closes #681

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
`src/inv_man_intake/scoring/engine.py` rejects red-flag `capped_score` values outside `[0, 1]`, but the audit did not find direct coverage for that guard. This is a safe Route-Weight `testgen` opener because it is pure scoring logic with a narrow validation path.

#### Tasks
- [ ] Add focused tests for `compute_score()` handling invalid `RedFlagDecision.capped_score` values.
- [ ] Cover values below `0` and above `1`.
- [ ] Keep valid capped-score behavior unchanged.

#### Acceptance criteria
- [ ] Tests are deterministic and use existing scoring test conventions.
- [ ] Invalid capped scores raise the existing `ValueError` contract.
- [ ] No production behavior changes unless required to preserve the documented contract.

**Head SHA:** 887c437bcaa8be4a5a0eb3dd2b573cb486e5dc7f
**Latest Runs:** ✅ success — Gate
**Required:** gate: ✅ success

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents PR Event Hub | ❔ in progress | [View run](https://github.com/stranske/Inv-Man-Intake/actions/runs/28325374269) |
| Claude Code Review (Opt-in) | ✅ success | [View run](https://github.com/stranske/Inv-Man-Intake/actions/runs/28325295092) |
| Cross-Repo Smoke | ⏭️ skipped | [View run](https://github.com/stranske/Inv-Man-Intake/actions/runs/28325295259) |
| Gate | ✅ success | [View run](https://github.com/stranske/Inv-Man-Intake/actions/runs/28325295262) |
| Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/Inv-Man-Intake/actions/runs/28325295117) |
<!-- auto-status-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for invalid capped score values with a parametrized test.
  * Now checks both below-zero and above-one values to ensure score validation rejects out-of-range caps consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->