### PR TITLE
test: distinguish rejected queue row next_action

### DIFF
--- a/src/inv_man_intake/workflow_validation.py
+++ b/src/inv_man_intake/workflow_validation.py
@@ -230,6 +230,8 @@ def _next_action_for_state(state: ValidationState) -> str:
         return "Ops policy decision"
     if state == "completed":
         return "No action"
+    if state == "rejected":
+        return "No further action"
     return "No action"
 
 

--- a/tests/test_workflow_validation.py
+++ b/tests/test_workflow_validation.py
@@ -136,3 +136,40 @@ def test_transfer_to_ops_and_dashboard_projection() -> None:
     assert row.owner_role == "ops"
     assert row.state == "ops_review"
     assert row.next_action == "Ops policy decision"
+
+
+def test_rejected_next_action_is_distinct_from_completed() -> None:
+    rejected = create_queue_item(
+        item_id="queue-7",
+        package_id="pkg-107",
+        escalation_reason="policy_exception",
+    )
+    rejected = claim_for_analyst_triage(rejected, analyst_id="analyst-13")
+    rejected = transition_state(
+        rejected,
+        actor_id="analyst-13",
+        actor_role="analyst",
+        to_state="rejected",
+    )
+
+    completed = create_queue_item(
+        item_id="queue-8",
+        package_id="pkg-108",
+        escalation_reason="policy_exception",
+    )
+    completed = claim_for_analyst_triage(completed, analyst_id="analyst-14")
+    completed = transition_state(
+        completed,
+        actor_id="analyst-14",
+        actor_role="analyst",
+        to_state="completed",
+    )
+
+    rejected_row = to_queue_row(rejected)
+    completed_row = to_queue_row(completed)
+
+    assert rejected_row.state == "rejected"
+    assert completed_row.state == "completed"
+    assert completed_row.next_action == "No action"
+    assert rejected_row.next_action == "No further action"
+    assert rejected_row.next_action != completed_row.next_action


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:680 -->
> **Source:** Issue #680

Closes #680

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
`src/inv_man_intake/workflow_validation.py` renders queue rows for terminal states. The audit found that `completed` and fallthrough paths both render `"No action"`, while `docs/contracts/queue_states.md` documents `rejected` as a distinct terminal state. This is a small Route-Weight opener that may need a one-line production fix plus a focused regression test.

#### Tasks
- [ ] Add a focused test that transitions or constructs a rejected queue item and asserts its `next_action` is distinct from the completed-state copy.
- [ ] If needed, make the smallest production change to render rejected items with non-ambiguous copy such as `"No further action"` or `"Archive rejected package"`.
- [ ] Preserve existing completed-state behavior.

#### Acceptance criteria
- [ ] Tests are deterministic and do not require network, browser, or external services.
- [ ] `rejected` queue rows no longer share the exact same `next_action` string as `completed`.
- [ ] The change is limited to queue-row presentation/copy unless existing code proves a narrower helper is needed.

**Head SHA:** 6b7b7d84afcdbf5846433473fac7c04f9d3069a8
**Latest Runs:** ❔ in progress — Agents PR Event Hub
**Required:** gate: ⏸️ not started

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents PR Event Hub | ❔ in progress | [View run](https://github.com/stranske/Inv-Man-Intake/actions/runs/28312006656) |
| Cross-Repo Smoke | ⏭️ skipped | [View run](https://github.com/stranske/Inv-Man-Intake/actions/runs/28310309196) |
<!-- auto-status-summary:end -->