### PR TITLE
style: black-format 2 test files to fix red main (#691)

### DIFF
--- a/tests/app/test_streamlit_app_smoke.py
+++ b/tests/app/test_streamlit_app_smoke.py
@@ -299,6 +299,5 @@ def test_stlite_mount_bundles_package_and_fixture_files() -> None:
     }
     assert '<script src="./vendor/stlite@0.75.0/stlite.js"></script>' in content
     assert (
-        'pyodideUrl: new URL("./vendor/pyodide@0.26.2/pyodide.js", '
-        "window.location.href).href"
+        'pyodideUrl: new URL("./vendor/pyodide@0.26.2/pyodide.js", ' "window.location.href).href"
     ) in content

--- a/tests/test_stlite_no_external_cdn.py
+++ b/tests/test_stlite_no_external_cdn.py
@@ -55,18 +55,24 @@ def test_design_system_stylesheets_present() -> None:
 def test_design_system_stylesheet_gate_fails_when_link_removed() -> None:
     index_html = INDEX_HTML.read_text(encoding="utf-8")
 
-    assert _has_design_system_stylesheets(
-        index_html.replace(
-            '<link rel="stylesheet" href="../design-system/tokens.css" />',
-            "",
+    assert (
+        _has_design_system_stylesheets(
+            index_html.replace(
+                '<link rel="stylesheet" href="../design-system/tokens.css" />',
+                "",
+            )
         )
-    ) is False
-    assert _has_design_system_stylesheets(
-        index_html.replace(
-            '<link rel="stylesheet" href="../design-system/components.css" />',
-            "",
+        is False
+    )
+    assert (
+        _has_design_system_stylesheets(
+            index_html.replace(
+                '<link rel="stylesheet" href="../design-system/components.css" />',
+                "",
+            )
         )
-    ) is False
+        is False
+    )
 
 
 def test_vendored_pyodide_runtime_files_exist_and_are_non_empty() -> None:


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:691 -->
> **Source:** Issue #691

Closes #691

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
`main` is currently RED. The `Python CI / lint-format` job of `ci.yml` runs
`black --check --line-length 100 --exclude '(\.venv|\.workflows-lib|node_modules)' .`
and reports **2 files would be reformatted** on the tip commit `7935f76`:
`tests/app/test_streamlit_app_smoke.py` and `tests/test_stlite_no_external_cdn.py`.
Reproduced locally with the CI-pinned `black==26.5.1` (33-line diff). This is a **current break**
(post-merge CI on `main` has failed on every push since these files landed via the route-weight
testgen PRs). ruff and pytest are green. `ci.yml` triggers only on `push:[main]`, so the format
violation merged through the PR gate and reddened `main`.

#### Tasks
- [ ] Run `black --line-length 100 tests/app/test_streamlit_app_smoke.py tests/test_stlite_no_external_cdn.py`
  and commit the result.
- [ ] Perform the deliberate-break verification below and capture output.

#### Acceptance criteria
- [ ] `black --check --line-length 100 tests/app/test_streamlit_app_smoke.py tests/test_stlite_no_external_cdn.py`
  returns exit 0 (0 files would be reformatted).
- [ ] **Deliberate-break gate:** re-introduce a formatting violation (e.g. collapse a multi-line call onto
  one >100-char line in `tests/test_stlite_no_external_cdn.py`); `black --check --line-length 100 .` **must
  report it as "would reformat"** (non-zero exit). Revert; the check passes. Capture both outputs.
- [ ] The next `ci.yml` run on `main` (or `gh workflow run ci.yml`) shows `Python CI / lint-format` = success.

**Head SHA:** 6fc5009c4e362d175cfad7bd3e6e0272a82ce5f9
**Latest Runs:** ✅ success — Gate
**Required:** gate: ✅ success

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents PR Event Hub | ❔ in progress | [View run](https://github.com/stranske/Inv-Man-Intake/actions/runs/28340718742) |
| Cross-Repo Smoke | ⏭️ skipped | [View run](https://github.com/stranske/Inv-Man-Intake/actions/runs/28340689142) |
| Gate | ✅ success | [View run](https://github.com/stranske/Inv-Man-Intake/actions/runs/28340689130) |
| Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/Inv-Man-Intake/actions/runs/28340688988) |
<!-- auto-status-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test assertions for readability and consistency.
  * Refined an existing smoke test string check without changing behavior.
  * Kept validation coverage for stylesheet and app bundle checks unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->