### PR TITLE
fix: reject NaN/non-finite values in scoring engine (#692)

### DIFF
--- a/src/inv_man_intake/scoring/engine.py
+++ b/src/inv_man_intake/scoring/engine.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from typing import Protocol
 
 from inv_man_intake.scoring.contracts import (
@@ -141,6 +142,8 @@ def compute_score(
             red_flag_applied = True
             red_flag_reason = decision.reason or "blocked"
         elif decision.capped_score is not None:
+            if not math.isfinite(decision.capped_score):
+                raise ValueError("red flag capped_score must be finite")
             if decision.capped_score < 0 or decision.capped_score > 1:
                 raise ValueError("red flag capped_score must be between 0 and 1")
             final_score = min(base_score, round(decision.capped_score, 6))
@@ -165,6 +168,8 @@ def _normalize_components(submission: ScoreSubmission) -> dict[str, float]:
             raise ValueError("component name must be non-empty")
         if component.name in values:
             raise ValueError(f"duplicate component: {component.name}")
+        if not math.isfinite(component.value):
+            raise ValueError(f"component {component.name} must be finite")
         if component.value < 0 or component.value > 1:
             raise ValueError(f"component {component.name} must be between 0 and 1")
         values[component.name] = component.value
@@ -191,6 +196,8 @@ def _validate_weight_set(weights: dict[str, float]) -> None:
     total = 0.0
     for name in _COMPONENT_ORDER:
         value = weights[name]
+        if not math.isfinite(value):
+            raise ValueError(f"weight {name} must be finite")
         if value < 0 or value > 1:
             raise ValueError(f"weight {name} must be between 0 and 1")
         total += value

--- a/tests/scoring/test_engine.py
+++ b/tests/scoring/test_engine.py
@@ -141,3 +141,49 @@ def test_compute_score_reports_missing_canonical_weight_set_for_alias() -> None:
         ),
     ):
         compute_score(_submission("equity"), weights_by_asset_class={"macro": {}})
+
+
+def _valid_weights() -> dict[str, float]:
+    return {
+        "performance_consistency": 0.30,
+        "risk_adjusted_returns": 0.25,
+        "operational_quality": 0.15,
+        "transparency": 0.15,
+        "team_experience": 0.15,
+    }
+
+
+@pytest.mark.parametrize("bad", [float("nan"), float("inf"), float("-inf")])
+def test_compute_score_rejects_non_finite_component(bad: float) -> None:
+    submission = ScoreSubmission(
+        manager_id="mgr_nan",
+        asset_class="equity_market_neutral",
+        components=(
+            ScoreComponent("performance_consistency", bad),
+            ScoreComponent("risk_adjusted_returns", 0.60),
+            ScoreComponent("operational_quality", 0.90),
+            ScoreComponent("transparency", 0.70),
+            ScoreComponent("team_experience", 0.50),
+        ),
+    )
+    with pytest.raises(ValueError, match="component performance_consistency must be finite"):
+        compute_score(submission)
+
+
+def test_compute_score_rejects_non_finite_weight() -> None:
+    weights = _valid_weights()
+    weights["risk_adjusted_returns"] = float("nan")
+    with pytest.raises(ValueError, match="weight risk_adjusted_returns must be finite"):
+        compute_score(
+            _submission("equity_market_neutral"),
+            weights_by_asset_class={"equity_market_neutral": weights},
+        )
+
+
+def test_compute_score_rejects_non_finite_cap() -> None:
+    class NanCapHook:
+        def apply(self, submission: ScoreSubmission, *, base_score: float) -> RedFlagDecision:
+            return RedFlagDecision(capped_score=float("nan"), reason="bad-cap")
+
+    with pytest.raises(ValueError, match="red flag capped_score must be finite"):
+        compute_score(_submission("equity_market_neutral"), red_flag_hook=NanCapHook())


### PR DESCRIPTION
## Why
`compute_score` accepted NaN/non-finite component values, weights, and red-flag caps: `NaN` fails both the `<0` and `>1` bounds checks (`scoring/engine.py:168/194`), so it passed validation and produced `base_score=nan`/`final_score=nan`. Verified by execution pre-fix.

## What
Add `math.isfinite` guards (fail-closed `ValueError`) at all three numeric trust boundaries:
- component values (`_normalize_components`)
- supplied weight sets (`_validate_weight_set`)
- red-flag `capped_score` (`compute_score` cap branch)

Closes #692.

## Verification
- New: `tests/scoring/test_engine.py::test_compute_score_rejects_non_finite_component` (nan/inf/-inf), `::...non_finite_weight`, `::...non_finite_cap` — all pass.
- Full `tests/scoring/` → 46 passed. black/ruff/mypy clean.
- **Deliberate-break demonstrated:** removing the component guard makes `test_...non_finite_component` FAIL (NaN falls through to "must be between 0 and 1"); restored → passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-preamble:start -->
<!-- meta:issue:692 -->
> **Source:** Issue #692

Closes #692

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The scoring engine accepts **NaN / non-finite** component values, weights, and red-flag caps, producing
non-finite scores — breaking the core invariant that scores are finite values in `[0, 1]`.
`scoring/engine.py:168` guards components with `if component.value < 0 or component.value > 1:` and
`:194` guards weights with `if value < 0 or value > 1:`. `float('nan')` fails **both** comparisons, so it
passes validation and propagates into `contributions`, `base_score`, and `final_score`. The cap path
(`engine.py:144`) has the same gap (`capped_score < 0 or > 1`).

**Verified by execution** (`PYTHONPATH=src`): a `ScoreSubmission` with one `math.nan` component returns
`base_score=nan, final_score=nan` rather than raising. This is a **current break** (latent: no production
caller passes NaN today, but extraction-derived components are floats with no upstream finite guard).
`scoring/explainability.py` already uses `math.isfinite`; the engine does not.

#### Tasks
- [ ] In `_normalize_components` (`engine.py:161-171`), reject `not math.isfinite(component.value)` with a
  `ValueError` before the `< 0 / > 1` check.
- [ ] In `_validate_weight_set` (`engine.py:183-198`), reject non-finite weight values.
- [ ] In `compute_score` cap branch (`engine.py:143-146`), reject non-finite `decision.capped_score`.
- [ ] Add `tests/scoring/test_engine.py::test_compute_score_rejects_non_finite` parametrized over a NaN
  component, an `inf` component, a NaN weight, and a NaN cap — each asserts `ValueError`.
- [ ] Perform the deliberate-break verification and revert.

#### Acceptance criteria
- [ ] Named test `tests/scoring/test_engine.py::test_compute_score_rejects_non_finite` passes; `compute_score`
  raises `ValueError` for each non-finite input and never returns a non-finite `final_score`.
- [ ] **Deliberate-break gate:** temporarily revert the component finite-check; the named test **must FAIL**
  (a NaN component yields `base_score=nan` instead of raising). Restore; test passes. Capture both.
- [ ] Full suite still green: `pytest tests/scoring/ -q`.

**Head SHA:** ec666b22d2a7b57ed7e13e8278c53afb3896328b
**Latest Runs:** ❔ in progress — Gate
**Required:** gate: ❔ in progress

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents PR Event Hub | ❔ in progress | [View run](https://github.com/stranske/Inv-Man-Intake/actions/runs/28341177287) |
| Backplane Conformance | ❔ in progress | [View run](https://github.com/stranske/Inv-Man-Intake/actions/runs/28341177266) |
| Cross-Repo Smoke | ⏭️ skipped | [View run](https://github.com/stranske/Inv-Man-Intake/actions/runs/28341177271) |
| Gate | ❔ in progress | [View run](https://github.com/stranske/Inv-Man-Intake/actions/runs/28341177278) |
| Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/Inv-Man-Intake/actions/runs/28341177112) |
<!-- auto-status-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added stricter validation to score calculations so non-finite values like `NaN` and infinity are rejected.
  * Improved error handling for invalid component scores, weight values, and red-flag cap values.
  * This makes scoring more reliable and prevents unexpected results from invalid numeric inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->