### PR TITLE
ci: run Black format check on PRs (close the lint-format PR-skip gap)

### DIFF
--- a/.github/workflows/pr-00-gate.yml
+++ b/.github/workflows/pr-00-gate.yml
@@ -71,7 +71,10 @@ jobs:
     with:
       python-versions: '["3.12", "3.13"]'
       coverage-min: "80"
-      format_check: false  # Using ruff for formatting
+      # Run the Black format check on PRs too. ci.yml (push-to-main) already enforces
+      # Black (format_check defaults true), so leaving it off here let unformatted code
+      # merge clean and redden main (see #691). ruff check is lint-only, not a formatter.
+      format_check: true
       working-directory: "."
       artifact-prefix: "gate-"
       # Enable soft coverage gate for trend tracking and hotspot reporting


### PR DESCRIPTION
## Why
`pr-00-gate.yml` passed `format_check: false` to the reusable Python CI, so the `lint-format` (Black) job — which `if: ${{ inputs.format_check }}` — was **skipped on PRs**, while `ci.yml` (push-to-main) leaves it defaulted **true**. Net: unformatted code merged clean then reddened `main` (#691). The "Using ruff for formatting" comment was misleading — `ruff check` is lint-only; nothing ran `ruff format --check`.

## What
Set `format_check: true` in `pr-00-gate.yml` so Black runs on PRs, matching the main-branch gate.

## Verification
- Full tree is Black-clean now (`black --check --line-length 100 .` → 244 files unchanged), so enabling the check is safe.
- Self-verifying: this PR modifies `pr-00-gate.yml`, so its own gate run should now show **`Python CI / lint-format` executing (not skipping)** and passing.

## Note
The durable fix is to re-sync `pr-00-gate.yml` from the Workflows consumer template (which computes `format_check` dynamically, default true); this is the minimal consumer-local correction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled stricter code formatting checks for pull requests, helping catch style issues earlier before changes are merged.
  * Updated automated checks to align pull request validation with existing main-branch behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->