### PR TITLE
fix: fail closed on non-finite/out-of-range values at perf + threshold boundaries (#695)

### DIFF
--- a/src/inv_man_intake/extraction/confidence.py
+++ b/src/inv_man_intake/extraction/confidence.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -76,12 +77,25 @@ def load_threshold_config(path: str | Path) -> ThresholdConfig:
         raise ValueError(f"missing threshold config keys: {', '.join(missing)}")
 
     return ThresholdConfig(
-        field_auto_accept_min=float(values["field_auto_accept_min"]),
-        key_field_confidence_min=float(values["key_field_confidence_min"]),
-        document_key_field_coverage_min=float(values["document_key_field_coverage_min"]),
-        mandatory_field_min=float(values["mandatory_field_min"]),
+        field_auto_accept_min=_threshold_value("field_auto_accept_min", values),
+        key_field_confidence_min=_threshold_value("key_field_confidence_min", values),
+        document_key_field_coverage_min=_threshold_value("document_key_field_coverage_min", values),
+        mandatory_field_min=_threshold_value("mandatory_field_min", values),
         mandatory_fields=tuple(mandatory_fields),
     )
+
+
+def _threshold_value(name: str, values: dict[str, str]) -> float:
+    """Parse a threshold float and fail closed if it is not finite and within [0, 1].
+
+    A policy gate must reject malformed config deterministically rather than silently change
+    routing (a negative coverage floor auto-passes every document; NaN flips comparisons). See #695.
+    """
+
+    value = float(values[name])
+    if not math.isfinite(value) or not (0.0 <= value <= 1.0):
+        raise ValueError(f"threshold {name} must be a finite value in [0, 1]; got {values[name]!r}")
+    return value
 
 
 def evaluate_thresholds(

--- a/src/inv_man_intake/performance/contracts.py
+++ b/src/inv_man_intake/performance/contracts.py
@@ -13,6 +13,7 @@ For every present series:
 
 from __future__ import annotations
 
+import math
 from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import date
@@ -127,6 +128,8 @@ def validate_series(series: PerformanceSeries) -> None:
     seen_days: set[date] = set()
 
     for idx, point in enumerate(series.points):
+        if not math.isfinite(point.value):
+            raise ValueError(f"{series.frequency}[{idx}].value must be finite")
         if point.as_of in seen_days:
             raise ValueError(f"{series.frequency}[{idx}].as_of duplicates a previous date")
         seen_days.add(point.as_of)

--- a/tests/extraction/test_thresholds.py
+++ b/tests/extraction/test_thresholds.py
@@ -84,6 +84,28 @@ def test_load_threshold_config_rejects_unknown_keys(tmp_path: Path) -> None:
         load_threshold_config(config_path)
 
 
+def test_load_threshold_config_rejects_out_of_range_value(tmp_path: Path) -> None:
+    config_path = tmp_path / "thresholds.yaml"
+    config_path.write_text(
+        "\n".join(
+            (
+                "field_auto_accept_min: 0.85",
+                "key_field_confidence_min: 0.75",
+                "document_key_field_coverage_min: -1.0",
+                "mandatory_field_min: 0.60",
+                "mandatory_fields:",
+                "  - terms.management_fee",
+            )
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(
+        ValueError, match=r"threshold document_key_field_coverage_min must be a finite value"
+    ):
+        load_threshold_config(config_path)
+
+
 def test_load_threshold_config_reports_missing_required_keys(tmp_path: Path) -> None:
     config_path = tmp_path / "thresholds.yaml"
     config_path.write_text(

--- a/tests/performance/test_conflict_resolver.py
+++ b/tests/performance/test_conflict_resolver.py
@@ -211,3 +211,17 @@ def _month_end_from_index(index: int) -> date:
     if month in {4, 6, 9, 11}:
         return date(year, month, 30)
     return date(year, month, 31)
+
+
+def test_resolve_source_conflicts_rejects_non_finite_value() -> None:
+    """A non-finite source value must fail closed, not silently report conflict_count=0 (#695)."""
+    xlsx = PerformanceSeries(
+        "monthly",
+        (PerformancePoint(as_of=date(2025, 1, 31), value=float("nan")),),
+    )
+    other = PerformanceSeries(
+        "monthly",
+        (PerformancePoint(as_of=date(2025, 1, 31), value=0.10),),
+    )
+    with pytest.raises(ValueError, match="value must be finite"):
+        resolve_source_conflicts(xlsx_series=xlsx, other_series=other)

--- a/tests/performance/test_metrics.py
+++ b/tests/performance/test_metrics.py
@@ -422,3 +422,18 @@ def test_to_canonical_dict_rejects_negative_counts() -> None:
         metrics.to_canonical_dict()
 
     assert "observation_count cannot be negative" in str(exc.value)
+
+
+def test_compute_metrics_rejects_non_finite_value() -> None:
+    """A NaN/inf monthly return must fail closed, not silently produce nan metrics (#695)."""
+    payload = PerformancePayload(
+        monthly=PerformanceSeries(
+            "monthly",
+            (
+                PerformancePoint(as_of=date(2025, 1, 31), value=0.02),
+                PerformancePoint(as_of=date(2025, 2, 28), value=float("nan")),
+            ),
+        )
+    )
+    with pytest.raises(ValueError, match="value must be finite"):
+        compute_metrics(payload)


### PR DESCRIPTION
## Why
Two numeric trust boundaries failed open: `performance/metrics.py` + `conflict_resolver.py` (a NaN return → nan metrics, `max_drawdown=0`, and a NaN source → `conflict_count=0`), and `extraction/confidence.load_threshold_config` accepted out-of-range/non-finite thresholds (a negative coverage floor auto-passes every document). Closes #695.

## What
- `performance/contracts.validate_series`: reject non-finite `point.value` — the single choke point used by both `compute_metrics` (via `validate_payload`) and `resolve_source_conflicts`.
- `extraction/confidence._threshold_value`: parse each threshold and require finite & within [0,1].

## Verification
- New: `tests/performance/test_metrics.py::test_compute_metrics_rejects_non_finite_value`, `tests/performance/test_conflict_resolver.py::test_resolve_source_conflicts_rejects_non_finite_value`, `tests/extraction/test_thresholds.py::test_load_threshold_config_rejects_out_of_range_value`.
- `tests/performance tests/extraction tests/run tests/v1 tests/intake` + smoke → 178 passed. black/ruff/mypy clean.
- **Deliberate-break demonstrated:** removing the threshold bounds check makes the out-of-range test FAIL; restored → passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-preamble:start -->
<!-- meta:issue:695 -->
> **Source:** Issue #695

Closes #695

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Two numeric trust boundaries accept non-finite / out-of-range input and fail open instead of closed:

1. **Performance metrics & conflict resolution** — `src/inv_man_intake/performance/metrics.py:95`
   reads `monthly_returns = [point.value for point in payload.monthly.points]` with no finite check; a `NaN`
   point yields `annualized_volatility=nan`, `sharpe_ratio=nan`, and `max_drawdown=0.0` (the
   `drawdown > max_drawdown` compare is false for nan), and those fields are **not** added to
   `insufficient_data` (they aren't `None`). In `performance/conflict_resolver.py:119`,
   `abs(nan - other) > _FLOAT_TOLERANCE` is false, so a `nan` source value reports `conflict_count=0` while the
   resolved point stays `nan`. (codex-verified by execution.)
2. **Threshold policy config** — `src/inv_man_intake/extraction/confidence.py:78` parses
   `field_auto_accept_min`/`key_field_confidence_min`/`document_key_field_coverage_min`/`mandatory_field_min`
   as floats with no finiteness or `[0,1]` bounds check. A negative coverage floor auto-passes every document; a
   negative `mandatory_field_min` makes mandatory checks pass too easily; `NaN` thresholds make comparisons false
   in surprising directions. A policy gate should fail closed.

Both are **latent fragility** (no current caller injects NaN), but they are silent-corruption paths in
score-/routing-bearing code.

#### Tasks
- [ ] In `performance/metrics.py` (around line 95, before the metric math), reject non-finite monthly/return
  values (or route them into `insufficient_data` with a named reason) — pick one and make it explicit.
- [ ] In `performance/conflict_resolver.py:119`, treat a non-finite source value as a conflict / data error
  rather than silently `conflict_count=0`.
- [ ] In `extraction/confidence.py:59-78` (`load_threshold_config`), raise `ValueError` if any threshold is not
  `math.isfinite` or not in `[0,1]`.
- [ ] Add `tests/performance/test_metrics.py::test_non_finite_returns_flagged`,
  `tests/performance/test_conflict_resolver.py::test_non_finite_value_is_conflict`, and
  `tests/extraction/test_thresholds.py::test_out_of_range_threshold_rejected`.

#### Acceptance criteria
- [ ] The three named tests pass: NaN/inf monthly value is flagged (not silently `max_drawdown=0`); a non-finite
  conflict source is reported as a conflict/error; an out-of-range or non-finite threshold raises `ValueError`.
- [ ] **Deliberate-break gate:** revert the threshold-config bounds check; `test_out_of_range_threshold_rejected`
  **must FAIL** (a `document_key_field_coverage_min = -1.0` is accepted and auto-passes documents). Restore;
  test passes. Capture both.
- [ ] `pytest tests/performance/ tests/extraction/ -q` green.

**Head SHA:** bfe752403cebc2868fb584ac6de40f48f59971ad
**Latest Runs:** ❔ in progress — Gate
**Required:** gate: ❔ in progress

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents PR Event Hub | ❔ in progress | [View run](https://github.com/stranske/Inv-Man-Intake/actions/runs/28341921396) |
| Backplane Conformance | ❔ in progress | [View run](https://github.com/stranske/Inv-Man-Intake/actions/runs/28341921388) |
| Cross-Repo Smoke | ⏭️ skipped | [View run](https://github.com/stranske/Inv-Man-Intake/actions/runs/28341921358) |
| Gate | ❔ in progress | [View run](https://github.com/stranske/Inv-Man-Intake/actions/runs/28341921405) |
| Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/Inv-Man-Intake/actions/runs/28341921299) |
<!-- auto-status-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened validation for configuration thresholds so invalid, non-finite, or out-of-range values are rejected instead of being accepted.
  * Added checks to ensure performance values are finite during metric and conflict processing, preventing invalid numbers from affecting results.

* **Tests**
  * Added regression coverage for invalid threshold values and non-finite performance data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->