### PR TITLE
fix: deterministic duplicate extracted-field-key handling (#696)

### DIFF
--- a/src/inv_man_intake/extraction/confidence.py
+++ b/src/inv_man_intake/extraction/confidence.py
@@ -106,7 +106,20 @@ def evaluate_thresholds(
 ) -> ThresholdDecision:
     """Apply threshold policy to field/document extraction confidence."""
 
-    field_by_key = {field.key: field for field in result.fields}
+    # Duplicate keys are collapsed deterministically (highest confidence wins) instead of the
+    # previous silent last-wins, which let provider/field order invert the decision. Duplicates
+    # are surfaced as an escalation reason rather than hidden. See #696.
+    field_by_key: dict[str, ExtractedField] = {}
+    duplicate_keys: list[str] = []
+    for field in result.fields:
+        existing = field_by_key.get(field.key)
+        if existing is None:
+            field_by_key[field.key] = field
+            continue
+        if field.key not in duplicate_keys:
+            duplicate_keys.append(field.key)
+        if field.confidence > existing.confidence:
+            field_by_key[field.key] = field
 
     auto_accept_fields = tuple(
         field.key for field in result.fields if field.confidence >= config.field_auto_accept_min
@@ -129,13 +142,15 @@ def evaluate_thresholds(
         if candidate.confidence < config.mandatory_field_min:
             mandatory_failures.append(f"confidence_below_threshold:{mandatory_field}")
 
-    if mandatory_failures:
+    duplicate_reasons = [f"duplicate_field_key:{key}" for key in sorted(duplicate_keys)]
+
+    if mandatory_failures or duplicate_reasons:
         return ThresholdDecision(
             auto_accept_fields=auto_accept_fields,
             key_field_coverage_ratio=key_field_coverage_ratio,
             auto_pass_document=False,
             escalate=True,
-            escalation_reason=";".join(mandatory_failures),
+            escalation_reason=";".join(mandatory_failures + duplicate_reasons),
         )
 
     escalate = not auto_pass_document

--- a/tests/extraction/test_thresholds.py
+++ b/tests/extraction/test_thresholds.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 
 from inv_man_intake.extraction.confidence import (
+    ThresholdConfig,
     attach_threshold_summary,
     evaluate_thresholds,
     load_threshold_config,
@@ -258,3 +259,31 @@ def test_evaluate_thresholds_empty_key_fields_do_not_force_escalation() -> None:
     assert decision.auto_pass_document is True
     assert decision.escalate is False
     assert decision.escalation_reason is None
+
+
+def test_evaluate_thresholds_duplicate_field_keys_are_order_independent() -> None:
+    """Duplicate keys must not let field order flip the decision (#696): highest confidence wins
+    deterministically and the duplicate is surfaced as an escalation reason."""
+    config = ThresholdConfig(
+        field_auto_accept_min=0.85,
+        key_field_confidence_min=0.75,
+        document_key_field_coverage_min=0.80,
+        mandatory_field_min=0.60,
+        mandatory_fields=(),
+    )
+    key_fields = ("terms.management_fee",)
+
+    forward = evaluate_thresholds(
+        result=_result(("terms.management_fee", 0.95), ("terms.management_fee", 0.10)),
+        key_fields=key_fields,
+        config=config,
+    )
+    reverse = evaluate_thresholds(
+        result=_result(("terms.management_fee", 0.10), ("terms.management_fee", 0.95)),
+        key_fields=key_fields,
+        config=config,
+    )
+
+    assert forward == reverse
+    assert forward.escalate is True
+    assert "duplicate_field_key:terms.management_fee" in (forward.escalation_reason or "")


### PR DESCRIPTION
## Why
`evaluate_thresholds` built `field_by_key = {field.key: field for field in result.fields}`, silently keeping the **last** field per key. With duplicate keys, provider/field order could invert the escalation decision (a high-confidence value followed by a low one would escalate; reversed would pass). Verified by execution. Closes #696.

## What
Collapse duplicates deterministically — **highest confidence wins** (order-independent) — and surface duplicates as a `duplicate_field_key:<key>` escalation reason instead of hiding them.

## Verification
- New `tests/extraction/test_thresholds.py::test_evaluate_thresholds_duplicate_field_keys_are_order_independent`: forward/reverse field order produce the **same** ThresholdDecision; duplicates escalate with the reason.
- `tests/extraction tests/run tests/v1 tests/intake tests/app tests/performance` + smoke → 192 passed. black/ruff/mypy clean.
- **Deliberate-break demonstrated:** reverting to the naive last-wins comprehension makes the named test FAIL (order changes the decision); restored → passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-preamble:start -->
<!-- meta:issue:696 -->
> **Source:** Issue #696

Closes #696

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Duplicate extracted-field keys are silently collapsed (last-wins) before threshold decisions, which can invert
escalation. `src/inv_man_intake/extraction/confidence.py:95` builds `field_by_key = {field.key: field for field
in result.fields}` — if a result has two fields with the same key, the **last** one wins with no signal.
**codex-verified by execution**: two `terms.management_fee` fields, first `0.95` then `0.10`, make the document
escalate as low-confidence even though a high-confidence value was present; reversing the order would pass. There
is no conflict signal in `ThresholdDecision`. This is **latent fragility** that depends on provider field order.

#### Tasks
- [ ] In `confidence.py:95`, replace the silent dict-comprehension with logic that detects duplicate keys and
  applies a documented rule (recommend: keep the highest-confidence candidate per key, and record the duplicate
  in the decision's escalation reason).
- [ ] Add `tests/extraction/test_thresholds.py::test_duplicate_field_keys_are_deterministic` asserting the
  decision is independent of field order for duplicate keys.

#### Acceptance criteria
- [ ] Named test `test_duplicate_field_keys_are_deterministic` passes: a result with the same key at confidences
  `0.95` and `0.10` produces the **same** `ThresholdDecision` regardless of order.
- [ ] **Deliberate-break gate:** temporarily restore the naive `{field.key: field ...}` comprehension; the named
  test **must FAIL** (order changes the decision). Restore; test passes. Capture both.
- [ ] `pytest tests/extraction/ -q` green.

**Head SHA:** 93a29dbb5fa17e7c2c0ef982f57755efc28b7d5e
**Latest Runs:** ❔ in progress — Gate
**Required:** gate: ❔ in progress

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents PR Event Hub | ❔ in progress | [View run](https://github.com/stranske/Inv-Man-Intake/actions/runs/28342084338) |
| Backplane Conformance | ❔ in progress | [View run](https://github.com/stranske/Inv-Man-Intake/actions/runs/28342084334) |
| Cross-Repo Smoke | ⏭️ skipped | [View run](https://github.com/stranske/Inv-Man-Intake/actions/runs/28342084353) |
| Gate | ❔ in progress | [View run](https://github.com/stranske/Inv-Man-Intake/actions/runs/28342084343) |
| Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/Inv-Man-Intake/actions/runs/28342084183) |
<!-- auto-status-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved threshold evaluation to handle duplicate extracted field keys consistently.
  * Decisions are now deterministic regardless of result ordering, using the highest-confidence value for each duplicate key.
  * Escalation now occurs when duplicate field keys are detected, with the reason included alongside any mandatory-field issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->