### PR TITLE
fix: validate intake provenance before document_store.put (atomic collision) (#697)

### DIFF
--- a/src/inv_man_intake/intake/integration.py
+++ b/src/inv_man_intake/intake/integration.py
@@ -18,6 +18,7 @@ from inv_man_intake.data.models import Document, Firm, Fund
 from inv_man_intake.data.repository import CoreRepository
 from inv_man_intake.intake.models import IngestStatus, IntakeFile
 from inv_man_intake.intake.service import IngestionService
+from inv_man_intake.intake.versioning import create_fingerprint
 from inv_man_intake.storage.document_store import (
     DocumentStore,
     DocumentVersionRecord,
@@ -389,6 +390,23 @@ def _persist_accepted_bundle(
         file_name = _as_non_empty_str(entry.get("file_name"))
         document_key = _document_key(fund_id=resolved_fund_id, document_id=document_id)
         content = content_resolver(entry, package_id)
+        existing_document = core_repository.get_document(document_id)
+        if existing_document is not None:
+            # Validate provenance BEFORE the store write so a rejected re-ingest leaves no orphan
+            # version (#697). create_fingerprint is the same hash source document_store.put uses,
+            # so the prospective file_hash matches what would be stored.
+            fingerprint = create_fingerprint(content=content, received_at=received_at)
+            prospective = Document(
+                document_id=document_id,
+                fund_id=resolved_fund_id,
+                file_name=file_name,
+                file_hash=fingerprint.sha256,
+                received_at=fingerprint.received_at,
+                version_date=version_date,
+                source_channel=source_channel,
+                created_at=received_at,
+            )
+            _ensure_document_invariants(existing=existing_document, incoming=prospective)
         version = document_store.put(
             document_key=document_key,
             file_name=file_name,
@@ -405,11 +423,9 @@ def _persist_accepted_bundle(
             source_channel=source_channel,
             created_at=received_at,
         )
-        existing_document = core_repository.get_document(document_id)
         if existing_document is None:
             core_repository.create_document(document)
         else:
-            _ensure_document_invariants(existing=existing_document, incoming=document)
             core_repository.update_document(document)
         version_records.append(version)
 

--- a/tests/intake/test_ingest_core_registry.py
+++ b/tests/intake/test_ingest_core_registry.py
@@ -411,3 +411,55 @@ def _write_bundle(path: Path, *, package_id: str, received_at: str) -> None:
         ),
         encoding="utf-8",
     )
+
+
+def test_rejected_reingest_leaves_document_store_unchanged(tmp_path: Path) -> None:
+    """A rejected re-ingest (different content, same document_id) must not leave an orphan version
+    in the document store: provenance is validated before the store write (#697)."""
+    repository, store = _registry()
+
+    def _bundle(package_id: str, file_name: str, received_at: str) -> dict[str, object]:
+        return {
+            "package_id": package_id,
+            "metadata": {
+                "firm_id": "firm_atomic",
+                "fund_id": "fund_atomic",
+                "firm_name": "Atomic Firm",
+                "fund_name": "Atomic Fund",
+                "received_at": received_at,
+                "source_channel": "email",
+            },
+            "files": [
+                {
+                    "file_name": file_name,
+                    "role": "investment_deck",
+                    "source_ref": f"email:{package_id}",
+                    "document_id": "atomic_doc_id",
+                }
+            ],
+        }
+
+    first = tmp_path / "first.json"
+    second = tmp_path / "second.json"
+    first.write_text(
+        json.dumps(_bundle("pkg_atomic_a", "deck.pdf", "2026-03-01T09:00:00Z")), encoding="utf-8"
+    )
+    second.write_text(
+        json.dumps(_bundle("pkg_atomic_b", "deck-changed.pdf", "2026-03-02T09:00:00Z")),
+        encoding="utf-8",
+    )
+
+    first_result = register_intake_bundle_file(
+        first, IngestionService(), core_repository=repository, document_store=store
+    )
+    assert first_result.accepted is True
+    document_key = "fund_atomic/atomic_doc_id"
+    assert len(store.list_versions(document_key)) == 1
+
+    with pytest.raises(ValueError, match="document_id='atomic_doc_id' collision"):
+        register_intake_bundle_file(
+            second, IngestionService(), core_repository=repository, document_store=store
+        )
+
+    # No orphan version may be left by the rejected re-ingest.
+    assert len(store.list_versions(document_key)) == 1


### PR DESCRIPTION
## Why
`register_intake_bundle_file` called `document_store.put(...)` and only **afterward** ran `_ensure_document_invariants`. A rejected re-ingest (same `document_id`, different content) therefore left a durable **orphan version** in the store that looked like an accepted document version. Residual of #595. Closes #697.

## What
Compute `create_fingerprint(content, received_at)` (the same hash source `put` uses) and run `_ensure_document_invariants` against a prospective `Document` **before** the store write. The persisted document is still built from the returned version record — unchanged behavior on the accept path.

## Verification
- New `tests/intake/test_ingest_core_registry.py::test_rejected_reingest_leaves_document_store_unchanged`: after a rejected different-content re-ingest, `store.list_versions(key)` stays at **1** (no orphan).
- `tests/intake tests/v1 tests/run` + smoke → 85 passed; full cache-cleared intake run → 9 passed. black/ruff/mypy clean.
- **Deliberate-break demonstrated:** moving `put` back before the validation makes the named test FAIL (orphan version → count 2); restored → passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-preamble:start -->
<!-- meta:issue:697 -->
> **Source:** Issue #697

Closes #697

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Document collision detection runs **after** the document-store write, so a rejected re-ingest can leave a
durable orphan version. In `src/inv_man_intake/intake/integration.py:392`, `document_store.put(...)` creates a
new stored version, and only afterward does the code call `core_repository.get_document(document_id)` and
`_ensure_document_invariants(existing, incoming)` (`integration.py:~406`, helper at `:613`), which raises when
`fund_id`/`file_hash`/`source_channel` differ. So a same-`document_id` re-ingest with a different `file_hash` or
`source_channel` **raises** (good — #595's silent-overwrite is fixed) but only **after** a new version/artifact
is already persisted in the store. The operation is **not atomic**: durable version history can show what looks
like an accepted version for a document that was actually rejected. **codex-verified** by line order; this is
**latent fragility** (correctness of the rejection holds; the side effect is the gap).

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#595](https://github.com/stranske/Inv-Man-Intake/issues/595)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] In `integration.py`, move the `get_document` + `_ensure_document_invariants` check **before**
  `document_store.put` (look up existing provenance first), OR wrap the put so a raised invariant rolls back the
  new version.
- [ ] Extend `tests/intake/test_ingest_core_registry.py` with
  `test_rejected_reingest_leaves_document_store_unchanged` asserting the store's version list for the
  `document_id` is identical before and after a rejected different-`file_hash`/`source_channel` re-ingest.

#### Acceptance criteria
- [ ] Named test `test_rejected_reingest_leaves_document_store_unchanged` passes: after a rejected re-ingest, the
  document store has **no** new version for that `document_id`.
- [ ] **Deliberate-break gate:** temporarily restore the original ordering (put before check); the named test
  **must FAIL** (an orphan version remains). Restore; test passes. Capture both.
- [ ] `pytest tests/intake/ -q` green (existing collision tests still pass).

**Head SHA:** 5dbf5c868b4a30460afb379a73f774a640a0b943
**Latest Runs:** ❔ in progress — Gate
**Required:** gate: ❔ in progress

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents PR Event Hub | ❔ in progress | [View run](https://github.com/stranske/Inv-Man-Intake/actions/runs/28342273711) |
| Backplane Conformance | ❔ in progress | [View run](https://github.com/stranske/Inv-Man-Intake/actions/runs/28342273690) |
| Cross-Repo Smoke | ⏭️ skipped | [View run](https://github.com/stranske/Inv-Man-Intake/actions/runs/28342273683) |
| Gate | ❔ in progress | [View run](https://github.com/stranske/Inv-Man-Intake/actions/runs/28342273679) |
| Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/Inv-Man-Intake/actions/runs/28342273500) |
<!-- auto-status-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ingest handling so rejected re-ingests no longer leave behind extra document versions in storage.
  * Strengthened validation during bundle acceptance to ensure document state stays consistent when a document ID collision occurs.
  * Updated behavior so existing documents are safely created or updated after checks complete, reducing the risk of partial writes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->