### PR TITLE
chore: hygiene — gitignore coverage.xml, fix phantom-script doc, real queue-card reason (#698)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ autofix_report_enriched.json
 Issues.txt
 pr73-thread-review.md
 coverage.json
+coverage.xml
 pytest-junit.xml
 
 # Local readiness reports

--- a/app/streamlit_app.py
+++ b/app/streamlit_app.py
@@ -97,6 +97,7 @@ class DemoResult:
     item_id: str
     sink_type: str
     trace_tags: dict[str, str]
+    decision_reason: str
 
 
 @dataclass(frozen=True)
@@ -159,6 +160,17 @@ def run_demo_fixture(fixture_name: str) -> DemoResult:
     assert "langsmith_enabled" not in trace_tags
     assert "langsmith_project" not in trace_tags
     components = cast(list[dict[str, object]], artifacts.formatted_explainability["components"])
+    decision = artifacts.threshold_decision
+    escalation_reason = (
+        getattr(decision, "escalation_reason", None)
+        if getattr(decision, "escalate", False)
+        else None
+    )
+    decision_reason = (
+        escalation_reason
+        or artifacts.score.red_flag_reason
+        or "auto-pass: no escalation or red flags"
+    )
     return DemoResult(
         fixture_name=fixture_name,
         package_id=package["package_id"],
@@ -168,6 +180,7 @@ def run_demo_fixture(fixture_name: str) -> DemoResult:
         item_id=str(artifacts.queue_assignment.item_id),
         sink_type=type(artifacts.sink).__name__,
         trace_tags=trace_tags,
+        decision_reason=str(decision_reason),
     )
 
 
@@ -211,6 +224,7 @@ def _browser_safe_demo_fixture(fixture_name: str) -> DemoResult:
         item_id=f"{package['package_id']}:validation:browser-demo",
         sink_type=InMemoryTraceSink.__name__,
         trace_tags={"stage": "browser-demo", "sqlite_fallback": "true"},
+        decision_reason=score.red_flag_reason or "auto-pass: no red flags (synthetic browser demo)",
     )
 
 
@@ -230,10 +244,9 @@ def build_analyst_queue_card(
         owner=result.owner_role.title(),
         package=package_id,
         headline=f"{conflict_type} requires {validation_rule.lower()} review",
-        reason=(
-            "The scoring pipeline routed this package for analyst review because "
-            f"{conflict_type.lower()} evidence needs confirmation."
-        ),
+        # Surface the REAL pipeline decision (threshold escalation / red-flag reason), not a
+        # template derived from the item_id tokens (#698).
+        reason=f"Pipeline decision: {result.decision_reason}",
         affected_evidence=f"Package {package_id}; evidence marker {correlation}",
         suggested_resolution=(
             "Open the package evidence, confirm the conflict, then accept the score, "

--- a/docs/pr-74-unresolved-threads.md
+++ b/docs/pr-74-unresolved-threads.md
@@ -1,29 +1,23 @@
 # PR #74 Unresolved Review Threads
 
-Source issue: #142  
+Source issue: #142
 Source PR: #74
 
 ## Status
 
-- Blocked in this runner: live GitHub API/`gh` access is unavailable.
-- Added local extraction tooling in `scripts/list_unresolved_review_threads.py` with tests in
-  `tests/test_list_unresolved_review_threads.py`.
+- Blocked in this runner: live GitHub API/`gh` access was unavailable when this note was written.
+- The unresolved-thread listing tool is `scripts/list_unresolved_pr_threads.sh`, covered by
+  `tests/test_list_unresolved_pr_threads.py`. (An earlier draft of this doc referenced a
+  `scripts/list_unresolved_review_threads.py` that was never committed; the shell script is the
+  real tool — see #698.)
 
 ## Identification Command
 
-Run this from an environment with valid `GH_TOKEN`:
+Run this from an environment with valid `GH_TOKEN`/`gh` auth:
 
 ```bash
-python scripts/list_unresolved_review_threads.py --owner stranske --repo Inv-Man-Intake --pr 74 --format checklist
+REPO=stranske/Inv-Man-Intake ./scripts/list_unresolved_pr_threads.sh 74
 ```
 
-The checklist output documents each unresolved thread with:
-- Thread URL
-- File/line location
-- Quoted comment text (blockquoted)
-
-For offline verification with a saved GraphQL payload:
-
-```bash
-python scripts/list_unresolved_review_threads.py --pr 74 --input-json /path/to/pr74-review-threads.json --format checklist
-```
+The output is a tab-separated table with one row per unresolved thread:
+`thread_id`, `path`, `line`, `author`, `comment_url`.

--- a/tests/app/test_streamlit_app_smoke.py
+++ b/tests/app/test_streamlit_app_smoke.py
@@ -69,6 +69,7 @@ class _StreamlitRecorder:
 @dataclass(frozen=True)
 class _FakeScore:
     final_score: float
+    red_flag_reason: str | None = None
 
 
 @dataclass(frozen=True)
@@ -78,12 +79,19 @@ class _FakeQueueAssignment:
 
 
 @dataclass(frozen=True)
+class _FakeThresholdDecision:
+    escalate: bool
+    escalation_reason: str | None
+
+
+@dataclass(frozen=True)
 class _FakeArtifacts:
     sink: object
     trace_context: object
     formatted_explainability: dict[str, object]
     score: _FakeScore
     queue_assignment: _FakeQueueAssignment
+    threshold_decision: object = _FakeThresholdDecision(escalate=False, escalation_reason=None)
 
 
 @dataclass(frozen=True)
@@ -178,6 +186,9 @@ def test_analyst_queue_renders_readable_item_and_actions(
             formatted_explainability={"components": [{"component": "risk_adjusted_returns"}]},
             score=_FakeScore(final_score=0.4321),
             queue_assignment=_FakeQueueAssignment(owner_role="analyst", item_id=item_id),
+            threshold_decision=_FakeThresholdDecision(
+                escalate=True, escalation_reason="confidence_below_threshold:terms.management_fee"
+            ),
         )
 
     monkeypatch.setattr("app.streamlit_app.run_v1_smoke_pipeline", _fake_pipeline)
@@ -193,10 +204,7 @@ def test_analyst_queue_renders_readable_item_and_actions(
             "Owner": "Analyst",
             "Package": "pkg_pdf_mixed_001",
             "Issue": "Performance Conflict requires validation review",
-            "Reason": (
-                "The scoring pipeline routed this package for analyst review because "
-                "performance conflict evidence needs confirmation."
-            ),
+            "Reason": "Pipeline decision: confidence_below_threshold:terms.management_fee",
             "Affected evidence": "Package pkg_pdf_mixed_001; evidence marker corr_4d03914dd557",
             "Suggested resolution": (
                 "Open the package evidence, confirm the conflict, then accept the score, "

--- a/tests/test_analyst_queue_render.py
+++ b/tests/test_analyst_queue_render.py
@@ -22,7 +22,10 @@ class StreamlitRecorder:
         self.tables.append(data)
 
 
-def _demo_result(item_id: str) -> DemoResult:
+def _demo_result(
+    item_id: str,
+    decision_reason: str = "confidence_below_threshold:terms.management_fee",
+) -> DemoResult:
     return DemoResult(
         fixture_name="pdf_primary_mixed_bundle.json",
         package_id="pkg_pdf_mixed_001",
@@ -32,6 +35,7 @@ def _demo_result(item_id: str) -> DemoResult:
         item_id=item_id,
         sink_type="InMemoryTraceSink",
         trace_tags={},
+        decision_reason=decision_reason,
     )
 
 
@@ -59,10 +63,7 @@ def test_analyst_queue_render_decodes_item_id_and_records_session_action() -> No
                 "Owner": "Analyst",
                 "Package": "pkg_pdf_mixed_001",
                 "Issue": "Performance Conflict requires validation review",
-                "Reason": (
-                    "The scoring pipeline routed this package for analyst review because "
-                    "performance conflict evidence needs confirmation."
-                ),
+                "Reason": "Pipeline decision: confidence_below_threshold:terms.management_fee",
                 "Affected evidence": "Package pkg_pdf_mixed_001; evidence marker corr_4d03914dd557",
                 "Suggested resolution": (
                     "Open the package evidence, confirm the conflict, then accept the score, "
@@ -73,3 +74,18 @@ def test_analyst_queue_render_decodes_item_id_and_records_session_action() -> No
         ]
     ]
     assert item_id not in str(recorder.tables)
+
+
+def test_analyst_queue_card_reason_reflects_pipeline_decision() -> None:
+    """The card reason must be derived from the real pipeline decision (#698), not a fixed template
+    built from the item_id tokens."""
+    item_id = "pkg_pdf_mixed_001:validation:performance_conflict:corr_4d03914dd557"
+    recorder = StreamlitRecorder()
+
+    card = render_analyst_queue(
+        recorder, _demo_result(item_id, decision_reason="missing_mandatory_field:operations.aum")
+    )
+
+    assert card.reason == "Pipeline decision: missing_mandatory_field:operations.aum"
+    # Not the old token-derived boilerplate.
+    assert "evidence needs confirmation" not in card.reason


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:698 -->
> **Source:** Issue #698

Closes #698

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Three small repo-local hygiene gaps surfaced in the 2026-06-28 audit:

1. **`coverage.xml` not gitignored.** `pyproject.toml:58` sets `--cov-report=xml`, so pytest emits
   `coverage.xml` on every run, but `.gitignore` only covers `.coverage` and `coverage.json` — risk of an
   accidental commit.
2. **Stale doc references a phantom script.** `docs/pr-74-unresolved-threads.md` documents
   `scripts/list_unresolved_review_threads.py` and `tests/test_list_unresolved_review_threads.py` — **neither
   exists** (glob returns 0); superseded by `scripts/list_unresolved_pr_threads.sh` +
   `tests/test_list_unresolved_pr_threads.py`.
3. **Analyst-queue card reason is decorative.** `app/streamlit_app.py:229-243` builds the card's `reason` and
   `suggested_resolution` from `item_id` string tokens (`build_analyst_queue_card`), not from the real
   `red_flag_reason` / threshold `escalation_reason`. The demo looks actionable but the displayed reason does not
   reflect why the pipeline actually routed the item. (Demo-scoped; the product is headless.)

These are **latent** hygiene/clarity issues, not breaks.

#### Tasks
- [ ] Add `coverage.xml` (and `coverage-trend.json` if emitted) to `.gitignore`.
- [ ] Fix `docs/pr-74-unresolved-threads.md` to reference the real `list_unresolved_pr_threads.sh` /
  `tests/test_list_unresolved_pr_threads.py`, or remove the doc if obsolete.
- [ ] In `app/streamlit_app.py`, plumb the real `red_flag_reason` / threshold `escalation_reason` from
  `DemoResult` into `AnalystQueueCard.reason` (extend `DemoResult` if needed) and add a unit test in
  `tests/app/test_streamlit_app_smoke.py` asserting the card reason reflects the pipeline decision.

#### Acceptance criteria
- [ ] `git check-ignore coverage.xml` returns `coverage.xml` (i.e. it is ignored).
- [ ] `grep -rn "list_unresolved_review_threads" docs/` returns no matches (phantom reference gone).
- [ ] Named test in `tests/app/test_streamlit_app_smoke.py` asserts the queue card's reason field is derived from
  the demo result's decision data (not a fixed string). **Deliberate-break gate:** revert the card-reason wiring
  to the token-derived string; the test **must FAIL**; restore and it passes. Capture both.

**Head SHA:** c995604dc8da6743d865645f547fb8b7e7254fde
**Latest Runs:** ✅ success — Gate
**Required:** gate: ✅ success

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents PR Event Hub | ❔ in progress | [View run](https://github.com/stranske/Inv-Man-Intake/actions/runs/28342707101) |
| Cross-Repo Smoke | ⏭️ skipped | [View run](https://github.com/stranske/Inv-Man-Intake/actions/runs/28342513960) |
| Gate | ✅ success | [View run](https://github.com/stranske/Inv-Man-Intake/actions/runs/28342513958) |
| Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/Inv-Man-Intake/actions/runs/28342513805) |
<!-- auto-status-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Analyst queue cards now show the pipeline’s actual decision reason, making queue explanations clearer and more relevant.
* **Bug Fixes**
  * Improved how decision reasons are populated in the demo flow so fallback cases still display a sensible explanation.
* **Documentation**
  * Updated the unresolved-threads guide with current setup and command instructions.
* **Tests**
  * Refreshed smoke and render tests to cover the updated reason text and decision behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->