### PR TITLE
Add peer-group percentile scoring

### DIFF
--- a/src/inv_man_intake/scoring/__init__.py
+++ b/src/inv_man_intake/scoring/__init__.py
@@ -18,6 +18,12 @@ from inv_man_intake.scoring.explainability import (
     build_explainability_payload,
     format_explainability_payload,
 )
+from inv_man_intake.scoring.peer_group import (
+    CohortScore,
+    CohortStore,
+    InMemoryCohortStore,
+    percentile_rank,
+)
 from inv_man_intake.scoring.regression import (
     CalibrationStats,
     DriftAlert,
@@ -42,9 +48,12 @@ __all__ = [
     "ASSET_CLASS_ALIASES",
     "COMPONENT_NAMES",
     "CalibrationStats",
+    "CohortScore",
+    "CohortStore",
     "DriftAlert",
     "DriftReport",
     "ExplainabilityPayload",
+    "InMemoryCohortStore",
     "LAUNCH_ASSET_CLASSES",
     "RedFlagDecision",
     "RedFlagHook",
@@ -64,6 +73,7 @@ __all__ = [
     "get_weight_set",
     "load_weight_registry",
     "normalize_asset_class",
+    "percentile_rank",
     "rank_by_asset_class",
     "weights_by_asset_class_for",
 ]

--- a/src/inv_man_intake/scoring/contracts.py
+++ b/src/inv_man_intake/scoring/contracts.py
@@ -44,6 +44,8 @@ class ScoreResult:
     contributions: Mapping[str, float]
     red_flag_applied: bool
     red_flag_reason: str | None
+    peer_group_percentile: float | None = None
+    peer_group_size: int | None = None
 
 
 def freeze_mapping(values: dict[str, float]) -> Mapping[str, float]:

--- a/src/inv_man_intake/scoring/engine.py
+++ b/src/inv_man_intake/scoring/engine.py
@@ -11,7 +11,7 @@ from inv_man_intake.scoring.contracts import (
     ScoreSubmission,
     freeze_mapping,
 )
-from inv_man_intake.scoring.peer_group import CohortStore, percentile_rank
+from inv_man_intake.scoring.peer_group import CohortStore, percentile_rank_from_scores
 from inv_man_intake.scoring.weights import LAUNCH_ASSET_CLASSES, normalize_asset_class
 
 _COMPONENT_ORDER: tuple[str, ...] = (
@@ -157,11 +157,7 @@ def compute_score(
     if peer_group_store is not None:
         peer_scores = peer_group_store.scores_for_asset_class(canonical_asset_class)
         if peer_scores:
-            peer_group_percentile = percentile_rank(
-                final_score,
-                canonical_asset_class,
-                peer_group_store,
-            )
+            peer_group_percentile = percentile_rank_from_scores(final_score, peer_scores)
             peer_group_size = len(peer_scores)
 
     return ScoreResult(

--- a/src/inv_man_intake/scoring/engine.py
+++ b/src/inv_man_intake/scoring/engine.py
@@ -11,6 +11,7 @@ from inv_man_intake.scoring.contracts import (
     ScoreSubmission,
     freeze_mapping,
 )
+from inv_man_intake.scoring.peer_group import CohortStore, percentile_rank
 from inv_man_intake.scoring.weights import LAUNCH_ASSET_CLASSES, normalize_asset_class
 
 _COMPONENT_ORDER: tuple[str, ...] = (
@@ -97,6 +98,7 @@ def compute_score(
     *,
     weights_by_asset_class: dict[str, dict[str, float]] | None = None,
     red_flag_hook: RedFlagHook | None = None,
+    peer_group_store: CohortStore | None = None,
 ) -> ScoreResult:
     """Compute deterministic total score with optional red-flag overrides."""
 
@@ -150,6 +152,18 @@ def compute_score(
             red_flag_applied = final_score < base_score
             red_flag_reason = decision.reason if red_flag_applied else None
 
+    peer_group_percentile: float | None = None
+    peer_group_size: int | None = None
+    if peer_group_store is not None:
+        peer_scores = peer_group_store.scores_for_asset_class(canonical_asset_class)
+        if peer_scores:
+            peer_group_percentile = percentile_rank(
+                final_score,
+                canonical_asset_class,
+                peer_group_store,
+            )
+            peer_group_size = len(peer_scores)
+
     return ScoreResult(
         manager_id=submission.manager_id,
         asset_class=canonical_asset_class,
@@ -158,6 +172,8 @@ def compute_score(
         contributions=freeze_mapping(contributions),
         red_flag_applied=red_flag_applied,
         red_flag_reason=red_flag_reason,
+        peer_group_percentile=peer_group_percentile,
+        peer_group_size=peer_group_size,
     )
 
 

--- a/src/inv_man_intake/scoring/peer_group.py
+++ b/src/inv_man_intake/scoring/peer_group.py
@@ -31,7 +31,7 @@ class InMemoryCohortStore:
     """Dependency-light cohort store keyed by canonical launch asset class."""
 
     def __init__(self, rows: Iterable[CohortScore] = ()) -> None:
-        self._scores_by_asset_class: dict[str, list[float]] = defaultdict(list)
+        self._scores_by_asset_class: dict[str, dict[str, float]] = defaultdict(dict)
         for row in rows:
             self.add_score(row.asset_class, row.manager_id, row.base_score)
 
@@ -46,13 +46,13 @@ class InMemoryCohortStore:
             raise ValueError("base_score must be between 0 and 1")
 
         canonical_asset_class = normalize_asset_class(asset_class)
-        self._scores_by_asset_class[canonical_asset_class].append(float(base_score))
+        self._scores_by_asset_class[canonical_asset_class][manager_id] = float(base_score)
 
     def scores_for_asset_class(self, asset_class: str) -> tuple[float, ...]:
         """Return cohort base scores for a canonical or alias asset class."""
 
         canonical_asset_class = normalize_asset_class(asset_class)
-        return tuple(self._scores_by_asset_class.get(canonical_asset_class, ()))
+        return tuple(self._scores_by_asset_class.get(canonical_asset_class, {}).values())
 
 
 def percentile_rank(score: float, asset_class: str, cohort: CohortStore) -> float:
@@ -72,7 +72,7 @@ def percentile_rank(score: float, asset_class: str, cohort: CohortStore) -> floa
     if not scores:
         raise ValueError(f"cohort is empty for asset class: {canonical_asset_class}")
 
-    less = sum(1 for value in scores if value < score)
-    equal = sum(1 for value in scores if value == score)
+    less = sum(1 for value in scores if value < score and not math.isclose(value, score))
+    equal = sum(1 for value in scores if math.isclose(value, score))
     percentile = ((less + (equal * 0.5)) / len(scores)) * 100.0
     return round(percentile, 6)

--- a/src/inv_man_intake/scoring/peer_group.py
+++ b/src/inv_man_intake/scoring/peer_group.py
@@ -72,6 +72,19 @@ def percentile_rank(score: float, asset_class: str, cohort: CohortStore) -> floa
     if not scores:
         raise ValueError(f"cohort is empty for asset class: {canonical_asset_class}")
 
+    return percentile_rank_from_scores(score, scores)
+
+
+def percentile_rank_from_scores(score: float, scores: tuple[float, ...]) -> float:
+    """Return midpoint empirical percentile rank for ``score`` against ``scores``."""
+
+    if not math.isfinite(score):
+        raise ValueError("score must be finite")
+    if score < 0.0 or score > 1.0:
+        raise ValueError("score must be between 0 and 1")
+    if not scores:
+        raise ValueError("cohort scores must be non-empty")
+
     less = sum(1 for value in scores if value < score and not math.isclose(value, score))
     equal = sum(1 for value in scores if math.isclose(value, score))
     percentile = ((less + (equal * 0.5)) / len(scores)) * 100.0

--- a/src/inv_man_intake/scoring/peer_group.py
+++ b/src/inv_man_intake/scoring/peer_group.py
@@ -1,0 +1,78 @@
+"""Deterministic peer-group cohort storage and percentile ranks."""
+
+from __future__ import annotations
+
+import math
+from collections import defaultdict
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import Protocol
+
+from inv_man_intake.scoring.weights import normalize_asset_class
+
+
+@dataclass(frozen=True)
+class CohortScore:
+    """One prior manager score in an asset-class cohort."""
+
+    asset_class: str
+    manager_id: str
+    base_score: float
+
+
+class CohortStore(Protocol):
+    """Minimal cohort lookup contract for peer-group percentile scoring."""
+
+    def scores_for_asset_class(self, asset_class: str) -> tuple[float, ...]:
+        """Return cohort base scores for a canonical or alias asset class."""
+
+
+class InMemoryCohortStore:
+    """Dependency-light cohort store keyed by canonical launch asset class."""
+
+    def __init__(self, rows: Iterable[CohortScore] = ()) -> None:
+        self._scores_by_asset_class: dict[str, list[float]] = defaultdict(list)
+        for row in rows:
+            self.add_score(row.asset_class, row.manager_id, row.base_score)
+
+    def add_score(self, asset_class: str, manager_id: str, base_score: float) -> None:
+        """Record one historical base score for a manager in an asset-class cohort."""
+
+        if not manager_id:
+            raise ValueError("manager_id must be non-empty")
+        if not math.isfinite(base_score):
+            raise ValueError("base_score must be finite")
+        if base_score < 0.0 or base_score > 1.0:
+            raise ValueError("base_score must be between 0 and 1")
+
+        canonical_asset_class = normalize_asset_class(asset_class)
+        self._scores_by_asset_class[canonical_asset_class].append(float(base_score))
+
+    def scores_for_asset_class(self, asset_class: str) -> tuple[float, ...]:
+        """Return cohort base scores for a canonical or alias asset class."""
+
+        canonical_asset_class = normalize_asset_class(asset_class)
+        return tuple(self._scores_by_asset_class.get(canonical_asset_class, ()))
+
+
+def percentile_rank(score: float, asset_class: str, cohort: CohortStore) -> float:
+    """Return midpoint empirical percentile rank for ``score`` within ``asset_class``.
+
+    Ties use a midpoint rank: values below the score plus half of equal values, divided
+    by cohort size. For example, 0.60 in [0.40, 0.50, 0.60, 0.70, 0.80] returns 50.0.
+    """
+
+    if not math.isfinite(score):
+        raise ValueError("score must be finite")
+    if score < 0.0 or score > 1.0:
+        raise ValueError("score must be between 0 and 1")
+
+    scores = cohort.scores_for_asset_class(asset_class)
+    canonical_asset_class = normalize_asset_class(asset_class)
+    if not scores:
+        raise ValueError(f"cohort is empty for asset class: {canonical_asset_class}")
+
+    less = sum(1 for value in scores if value < score)
+    equal = sum(1 for value in scores if value == score)
+    percentile = ((less + (equal * 0.5)) / len(scores)) * 100.0
+    return round(percentile, 6)

--- a/tests/scoring/test_peer_group.py
+++ b/tests/scoring/test_peer_group.py
@@ -45,6 +45,11 @@ def test_percentile_rank_against_seeded_cohort() -> None:
     assert percentile == pytest.approx(50.0)
     assert repeated == percentile
 
+    cohort.add_score("macro", "macro_90", 0.90)
+    shifted_percentile = percentile_rank(0.60, "macro", cohort)
+
+    assert shifted_percentile != pytest.approx(percentile)
+
 
 def test_compute_score_exposes_peer_group_percentile_without_changing_final_score() -> None:
     result = compute_score(_flat_submission(), peer_group_store=_seeded_macro_cohort())
@@ -98,3 +103,9 @@ def test_peer_group_rejects_invalid_scores() -> None:
 
     with pytest.raises(ValueError, match="cohort is empty for asset class"):
         percentile_rank(0.50, "macro", InMemoryCohortStore())
+
+    with pytest.raises(ValueError, match="score must be between 0 and 1"):
+        percentile_rank(1.01, "macro", _seeded_macro_cohort())
+
+    with pytest.raises(ValueError, match="score must be finite"):
+        percentile_rank(float("nan"), "macro", _seeded_macro_cohort())

--- a/tests/scoring/test_peer_group.py
+++ b/tests/scoring/test_peer_group.py
@@ -1,0 +1,75 @@
+"""Tests for deterministic peer-group percentile scoring."""
+
+from __future__ import annotations
+
+import pytest
+
+from inv_man_intake.scoring.contracts import ScoreComponent, ScoreSubmission
+from inv_man_intake.scoring.engine import compute_score
+from inv_man_intake.scoring.peer_group import CohortScore, InMemoryCohortStore, percentile_rank
+
+
+def _seeded_macro_cohort() -> InMemoryCohortStore:
+    return InMemoryCohortStore(
+        CohortScore(asset_class="macro", manager_id=manager_id, base_score=score)
+        for manager_id, score in (
+            ("macro_40", 0.40),
+            ("macro_50", 0.50),
+            ("macro_60", 0.60),
+            ("macro_70", 0.70),
+            ("macro_80", 0.80),
+        )
+    )
+
+
+def _flat_submission(score: float = 0.60) -> ScoreSubmission:
+    return ScoreSubmission(
+        manager_id="candidate_macro",
+        asset_class="macro",
+        components=(
+            ScoreComponent("performance_consistency", score),
+            ScoreComponent("risk_adjusted_returns", score),
+            ScoreComponent("operational_quality", score),
+            ScoreComponent("transparency", score),
+            ScoreComponent("team_experience", score),
+        ),
+    )
+
+
+def test_percentile_rank_against_seeded_cohort() -> None:
+    cohort = _seeded_macro_cohort()
+
+    percentile = percentile_rank(0.60, "macro", cohort)
+    repeated = percentile_rank(0.60, "macro", cohort)
+
+    assert percentile == pytest.approx(50.0)
+    assert repeated == percentile
+
+
+def test_compute_score_exposes_peer_group_percentile_without_changing_final_score() -> None:
+    result = compute_score(_flat_submission(), peer_group_store=_seeded_macro_cohort())
+
+    assert result.final_score == pytest.approx(0.60)
+    assert result.peer_group_percentile == pytest.approx(50.0)
+    assert result.peer_group_size == 5
+
+
+def test_percentile_rank_uses_midpoint_tie_rule() -> None:
+    cohort = InMemoryCohortStore(
+        (
+            CohortScore(asset_class="macro", manager_id="a", base_score=0.50),
+            CohortScore(asset_class="macro", manager_id="b", base_score=0.60),
+            CohortScore(asset_class="macro", manager_id="c", base_score=0.60),
+            CohortScore(asset_class="macro", manager_id="d", base_score=0.80),
+        )
+    )
+
+    assert percentile_rank(0.60, "macro", cohort) == pytest.approx(50.0)
+
+
+def test_peer_group_rejects_invalid_scores() -> None:
+    with pytest.raises(ValueError, match="base_score must be between 0 and 1"):
+        InMemoryCohortStore((CohortScore(asset_class="macro", manager_id="bad", base_score=1.01),))
+
+    with pytest.raises(ValueError, match="cohort is empty for asset class"):
+        percentile_rank(0.50, "macro", InMemoryCohortStore())

--- a/tests/scoring/test_peer_group.py
+++ b/tests/scoring/test_peer_group.py
@@ -67,6 +67,31 @@ def test_percentile_rank_uses_midpoint_tie_rule() -> None:
     assert percentile_rank(0.60, "macro", cohort) == pytest.approx(50.0)
 
 
+def test_cohort_store_overwrites_existing_manager_score() -> None:
+    cohort = InMemoryCohortStore(
+        (
+            CohortScore(asset_class="macro", manager_id="manager_a", base_score=0.40),
+            CohortScore(asset_class="macro", manager_id="manager_b", base_score=0.60),
+            CohortScore(asset_class="macro", manager_id="manager_a", base_score=0.80),
+        )
+    )
+
+    assert cohort.scores_for_asset_class("macro") == pytest.approx((0.80, 0.60))
+
+
+def test_percentile_rank_treats_rounding_noise_as_tie() -> None:
+    cohort = InMemoryCohortStore(
+        (
+            CohortScore(asset_class="macro", manager_id="a", base_score=0.50),
+            CohortScore(asset_class="macro", manager_id="b", base_score=0.1 + 0.2 + 0.3),
+            CohortScore(asset_class="macro", manager_id="c", base_score=0.60),
+            CohortScore(asset_class="macro", manager_id="d", base_score=0.80),
+        )
+    )
+
+    assert percentile_rank(0.60, "macro", cohort) == pytest.approx(50.0)
+
+
 def test_peer_group_rejects_invalid_scores() -> None:
     with pytest.raises(ValueError, match="base_score must be between 0 and 1"):
         InMemoryCohortStore((CohortScore(asset_class="macro", manager_id="bad", base_score=1.01),))


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:710 -->
> **Source:** Issue #710

Closes #710

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The scoring engine emits an **absolute** 0-1 score (`scoring/engine.py` `compute_score` → `ScoreResult.final_score`), but the institutional manager-DD field consumes a **percentile rank within an asset-class cohort** (e.g. "top-quartile credit_long_short"). The asset-class partition already exists (`scoring/weights.py:19` `LAUNCH_ASSET_CLASSES`) and component metrics are computed per manager — so the only missing piece is a cohort store + a percentile function. This is the highest-leverage gap from the audit and needs **no ML**. Latent capability gap (not a break): there is currently no way to express relative standing.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#699](https://github.com/stranske/Inv-Man-Intake/issues/699)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] Add a cohort store under `src/inv_man_intake/scoring/` (SQLite or in-memory + DuckDB optional) that records `(asset_class, manager_id, base_score)` rows and supports querying the cohort for one asset class.
- [ ] Add `percentile_rank(score: float, asset_class: str, cohort) -> float` returning the empirical percentile (0-100) of `score` within the asset-class cohort, with a documented tie/interpolation rule.
- [ ] Expose the percentile in the scoring output (sidecar dataclass or an optional `ScoreResult` field) without altering `final_score`.
- [ ] Add `tests/scoring/test_peer_group.py::test_percentile_rank_against_seeded_cohort`.

#### Acceptance criteria
- [ ] Named test `tests/scoring/test_peer_group.py::test_percentile_rank_against_seeded_cohort` passes: against a fixed seeded cohort (e.g. scores [0.40,0.50,0.60,0.70,0.80] for `macro`), a manager scoring 0.60 returns the documented percentile (e.g. 50.0), and the same input always returns the same percentile (deterministic).
- [ ] **Deliberate-break gate:** change one seeded cohort value so the median shifts; the named test **must FAIL** (percentile changes); revert → passes. Capture both.
- [ ] `pytest tests/scoring/ -q` stays green; absolute `final_score` is unchanged for existing tests.

<!-- auto-status-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added peer-group percentile metrics to scoring results, including percentile rank and cohort size.
  * Exposed new scoring helpers for working with cohort-based peer comparisons.

* **Bug Fixes**
  * Improved scoring output to include consistent peer-group context when available.
  * Added validation for invalid or empty cohort data during percentile calculations.

* **Tests**
  * Added coverage for percentile ranking, tie handling, floating-point edge cases, and score result integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->