### PR TITLE
Add HITL extraction calibration report

### DIFF
--- a/src/inv_man_intake/readiness/extraction_calibration.py
+++ b/src/inv_man_intake/readiness/extraction_calibration.py
@@ -11,6 +11,7 @@ from inv_man_intake.data.provenance import CorrectionRecord, ExtractedFieldRecor
 from inv_man_intake.extraction.confidence import ThresholdConfig
 
 DEFAULT_CONFIDENCE_BUCKETS: tuple[float, ...] = (0.0, 0.6, 0.75, 0.85, 1.0)
+type CorrectnessSignal = bool | None
 
 
 @dataclass(frozen=True)
@@ -20,9 +21,9 @@ class FieldCalibrationObservation:
     field_id: str
     field_key: str
     confidence: float
-    observed_correct: bool
+    observed_correct: CorrectnessSignal
     original_value: str
-    latest_value: str
+    latest_value: str | None
 
 
 def build_calibration_report(
@@ -46,30 +47,39 @@ def build_calibration_report(
 
     _validate_buckets(confidence_buckets)
     observations = _observations(fields, corrections)
+    known_observations = tuple(
+        observation for observation in observations if observation.observed_correct is not None
+    )
     observed_by_key = {observation.field_key for observation in observations}
     expected_keys = set(expected_field_keys) or observed_by_key
     missing_expected = sorted(expected_keys.difference(observed_by_key))
 
-    true_positive_count = sum(observation.observed_correct for observation in observations)
-    false_positive_count = len(observations) - true_positive_count
-    false_negative_count = len(missing_expected)
+    true_positive_count = sum(
+        observation.observed_correct is True for observation in known_observations
+    )
+    false_positive_count = sum(
+        observation.observed_correct is False for observation in known_observations
+    )
+    false_negative_count = false_positive_count + len(missing_expected)
 
     precision = _ratio(true_positive_count, true_positive_count + false_positive_count)
     recall = _ratio(true_positive_count, true_positive_count + false_negative_count)
 
     auto_accept = [
         observation
-        for observation in observations
+        for observation in known_observations
         if observation.confidence >= threshold_config.field_auto_accept_min
     ]
     auto_accept_precision = _ratio(
-        sum(observation.observed_correct for observation in auto_accept),
+        sum(observation.observed_correct is True for observation in auto_accept),
         len(auto_accept),
     )
 
     return {
         "summary": {
             "field_count": len(observations),
+            "known_field_count": len(known_observations),
+            "unknown_field_count": len(observations) - len(known_observations),
             "expected_field_count": len(expected_keys),
             "true_positive_count": true_positive_count,
             "false_positive_count": false_positive_count,
@@ -79,8 +89,8 @@ def build_calibration_report(
             "auto_accept_precision": auto_accept_precision,
             "missing_expected_fields": missing_expected,
         },
-        "field_metrics": _field_metrics(observations),
-        "confidence_buckets": _confidence_bucket_metrics(observations, confidence_buckets),
+        "field_metrics": _field_metrics(known_observations),
+        "confidence_buckets": _confidence_bucket_metrics(known_observations, confidence_buckets),
         "threshold_suggestions": _threshold_suggestions(
             precision=precision,
             recall=recall,
@@ -100,13 +110,13 @@ def _observations(
         if not 0.0 <= field.confidence <= 1.0:
             raise ValueError(f"field {field.field_id} confidence must be within [0, 1]")
         correction = latest_correction.get(field.field_id)
-        latest_value = field.value if correction is None else correction.corrected_value
+        latest_value = None if correction is None else correction.corrected_value
         observations.append(
             FieldCalibrationObservation(
                 field_id=field.field_id,
                 field_key=field.field_key,
                 confidence=field.confidence,
-                observed_correct=latest_value == field.value,
+                observed_correct=None if latest_value is None else latest_value == field.value,
                 original_value=field.value,
                 latest_value=latest_value,
             )
@@ -138,9 +148,9 @@ def _field_metrics(
     return {
         field_key: {
             "count": len(items),
-            "precision": _ratio(sum(item.observed_correct for item in items), len(items)),
-            "correct_count": sum(item.observed_correct for item in items),
-            "corrected_count": sum(not item.observed_correct for item in items),
+            "precision": _ratio(sum(item.observed_correct is True for item in items), len(items)),
+            "correct_count": sum(item.observed_correct is True for item in items),
+            "corrected_count": sum(item.observed_correct is False for item in items),
             "mean_confidence": _rounded(sum(item.confidence for item in items) / len(items)),
         }
         for field_key, items in sorted(by_key.items())
@@ -160,7 +170,7 @@ def _confidence_bucket_metrics(
         ]
         if not items:
             continue
-        observed_accuracy = _ratio(sum(item.observed_correct for item in items), len(items))
+        observed_accuracy = _ratio(sum(item.observed_correct is True for item in items), len(items))
         mean_confidence = _rounded(sum(item.confidence for item in items) / len(items))
         bucketed.append(
             {

--- a/src/inv_man_intake/readiness/extraction_calibration.py
+++ b/src/inv_man_intake/readiness/extraction_calibration.py
@@ -1,0 +1,242 @@
+"""Read-only extraction calibration metrics from human corrections."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Iterable
+from dataclasses import dataclass
+from itertools import pairwise
+
+from inv_man_intake.data.provenance import CorrectionRecord, ExtractedFieldRecord
+from inv_man_intake.extraction.confidence import ThresholdConfig
+
+DEFAULT_CONFIDENCE_BUCKETS: tuple[float, ...] = (0.0, 0.6, 0.75, 0.85, 1.0)
+
+
+@dataclass(frozen=True)
+class FieldCalibrationObservation:
+    """Correctness signal for one extracted field."""
+
+    field_id: str
+    field_key: str
+    confidence: float
+    observed_correct: bool
+    original_value: str
+    latest_value: str
+
+
+def build_calibration_report(
+    *,
+    extracted_fields: Iterable[ExtractedFieldRecord],
+    corrections: Iterable[CorrectionRecord],
+    threshold_config: ThresholdConfig,
+    expected_field_keys: Iterable[str] = (),
+    confidence_buckets: tuple[float, ...] = DEFAULT_CONFIDENCE_BUCKETS,
+) -> dict[str, object]:
+    """Compute precision, recall, confidence calibration, and threshold suggestions.
+
+    The report is intentionally read-only: callers provide the extracted fields and correction
+    history, and this function returns deterministic JSON-compatible data without touching
+    threshold config files.
+    """
+
+    fields = tuple(extracted_fields)
+    if not fields:
+        raise ValueError("at least one extracted field is required")
+
+    _validate_buckets(confidence_buckets)
+    observations = _observations(fields, corrections)
+    observed_by_key = {observation.field_key for observation in observations}
+    expected_keys = set(expected_field_keys) or observed_by_key
+    missing_expected = sorted(expected_keys.difference(observed_by_key))
+
+    true_positive_count = sum(observation.observed_correct for observation in observations)
+    false_positive_count = len(observations) - true_positive_count
+    false_negative_count = len(missing_expected)
+
+    precision = _ratio(true_positive_count, true_positive_count + false_positive_count)
+    recall = _ratio(true_positive_count, true_positive_count + false_negative_count)
+
+    auto_accept = [
+        observation
+        for observation in observations
+        if observation.confidence >= threshold_config.field_auto_accept_min
+    ]
+    auto_accept_precision = _ratio(
+        sum(observation.observed_correct for observation in auto_accept),
+        len(auto_accept),
+    )
+
+    return {
+        "summary": {
+            "field_count": len(observations),
+            "expected_field_count": len(expected_keys),
+            "true_positive_count": true_positive_count,
+            "false_positive_count": false_positive_count,
+            "false_negative_count": false_negative_count,
+            "precision": precision,
+            "recall": recall,
+            "auto_accept_precision": auto_accept_precision,
+            "missing_expected_fields": missing_expected,
+        },
+        "field_metrics": _field_metrics(observations),
+        "confidence_buckets": _confidence_bucket_metrics(observations, confidence_buckets),
+        "threshold_suggestions": _threshold_suggestions(
+            precision=precision,
+            recall=recall,
+            auto_accept_precision=auto_accept_precision,
+            threshold_config=threshold_config,
+        ),
+    }
+
+
+def _observations(
+    fields: tuple[ExtractedFieldRecord, ...],
+    corrections: Iterable[CorrectionRecord],
+) -> tuple[FieldCalibrationObservation, ...]:
+    latest_correction = _latest_corrections(corrections)
+    observations: list[FieldCalibrationObservation] = []
+    for field in sorted(fields, key=lambda record: (record.field_key, record.field_id)):
+        if not 0.0 <= field.confidence <= 1.0:
+            raise ValueError(f"field {field.field_id} confidence must be within [0, 1]")
+        correction = latest_correction.get(field.field_id)
+        latest_value = field.value if correction is None else correction.corrected_value
+        observations.append(
+            FieldCalibrationObservation(
+                field_id=field.field_id,
+                field_key=field.field_key,
+                confidence=field.confidence,
+                observed_correct=latest_value == field.value,
+                original_value=field.value,
+                latest_value=latest_value,
+            )
+        )
+    return tuple(observations)
+
+
+def _latest_corrections(
+    corrections: Iterable[CorrectionRecord],
+) -> dict[str, CorrectionRecord]:
+    latest: dict[str, CorrectionRecord] = {}
+    for correction in corrections:
+        current = latest.get(correction.field_id)
+        if current is None or (correction.corrected_at, correction.correction_id) > (
+            current.corrected_at,
+            current.correction_id,
+        ):
+            latest[correction.field_id] = correction
+    return latest
+
+
+def _field_metrics(
+    observations: tuple[FieldCalibrationObservation, ...],
+) -> dict[str, dict[str, object]]:
+    by_key: dict[str, list[FieldCalibrationObservation]] = defaultdict(list)
+    for observation in observations:
+        by_key[observation.field_key].append(observation)
+
+    return {
+        field_key: {
+            "count": len(items),
+            "precision": _ratio(sum(item.observed_correct for item in items), len(items)),
+            "correct_count": sum(item.observed_correct for item in items),
+            "corrected_count": sum(not item.observed_correct for item in items),
+            "mean_confidence": _rounded(sum(item.confidence for item in items) / len(items)),
+        }
+        for field_key, items in sorted(by_key.items())
+    }
+
+
+def _confidence_bucket_metrics(
+    observations: tuple[FieldCalibrationObservation, ...],
+    buckets: tuple[float, ...],
+) -> list[dict[str, object]]:
+    bucketed: list[dict[str, object]] = []
+    for start, end in pairwise(buckets):
+        items = [
+            observation
+            for observation in observations
+            if _in_bucket(observation.confidence, start, end)
+        ]
+        if not items:
+            continue
+        observed_accuracy = _ratio(sum(item.observed_correct for item in items), len(items))
+        mean_confidence = _rounded(sum(item.confidence for item in items) / len(items))
+        bucketed.append(
+            {
+                "bucket": f"{start:.2f}-{end:.2f}",
+                "count": len(items),
+                "mean_confidence": mean_confidence,
+                "observed_accuracy": observed_accuracy,
+                "calibration_gap": _rounded(mean_confidence - observed_accuracy),
+            }
+        )
+    return bucketed
+
+
+def _threshold_suggestions(
+    *,
+    precision: float,
+    recall: float,
+    auto_accept_precision: float,
+    threshold_config: ThresholdConfig,
+) -> dict[str, dict[str, object]]:
+    return {
+        "field_auto_accept_min": {
+            "current": threshold_config.field_auto_accept_min,
+            "direction": _direction(auto_accept_precision, high_water=0.95, low_water=0.85),
+            "basis": "auto_accept_precision",
+            "observed": auto_accept_precision,
+        },
+        "key_field_confidence_min": {
+            "current": threshold_config.key_field_confidence_min,
+            "direction": _direction(precision, high_water=0.92, low_water=0.8),
+            "basis": "overall_precision",
+            "observed": precision,
+        },
+        "document_key_field_coverage_min": {
+            "current": threshold_config.document_key_field_coverage_min,
+            "direction": _direction(recall, high_water=0.9, low_water=0.75),
+            "basis": "overall_recall",
+            "observed": recall,
+        },
+        "mandatory_field_min": {
+            "current": threshold_config.mandatory_field_min,
+            "direction": _direction(precision, high_water=0.95, low_water=0.85),
+            "basis": "overall_precision",
+            "observed": precision,
+        },
+    }
+
+
+def _direction(observed: float, *, high_water: float, low_water: float) -> str:
+    if observed < low_water:
+        return "raise"
+    if observed >= high_water:
+        return "consider_lowering"
+    return "hold"
+
+
+def _validate_buckets(buckets: tuple[float, ...]) -> None:
+    if len(buckets) < 2:
+        raise ValueError("at least two confidence bucket boundaries are required")
+    if buckets[0] != 0.0 or buckets[-1] != 1.0:
+        raise ValueError("confidence buckets must start at 0.0 and end at 1.0")
+    if any(left >= right for left, right in pairwise(buckets)):
+        raise ValueError("confidence buckets must be strictly increasing")
+
+
+def _in_bucket(value: float, start: float, end: float) -> bool:
+    if end == 1.0:
+        return start <= value <= end
+    return start <= value < end
+
+
+def _ratio(numerator: int, denominator: int) -> float:
+    if denominator == 0:
+        return 0.0
+    return _rounded(numerator / denominator)
+
+
+def _rounded(value: float) -> float:
+    return round(value, 4)

--- a/tests/readiness/test_extraction_calibration.py
+++ b/tests/readiness/test_extraction_calibration.py
@@ -1,0 +1,99 @@
+"""Tests for correction-backed extraction calibration reporting."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from inv_man_intake.data.provenance import CorrectionRecord, ExtractedFieldRecord
+from inv_man_intake.extraction.confidence import ThresholdConfig
+from inv_man_intake.readiness.extraction_calibration import build_calibration_report
+
+
+def test_calibration_metrics_on_seeded_corrections(tmp_path: Path) -> None:
+    threshold_path = tmp_path / "extraction_thresholds.yaml"
+    threshold_path.write_text("field_auto_accept_min: 0.85\n", encoding="utf-8")
+    before_thresholds = threshold_path.read_text(encoding="utf-8")
+
+    report = build_calibration_report(
+        extracted_fields=(
+            _field("field-aum", "operations.aum", "100000000", 0.9),
+            _field("field-fee", "terms.management_fee", "1.00%", 0.9),
+            _field("field-strategy", "strategy.asset_class", "Private Equity", 0.9),
+        ),
+        corrections=(
+            CorrectionRecord(
+                correction_id=1,
+                field_id="field-aum",
+                corrected_value="100000000",
+                reason="confirmed",
+                corrected_by="analyst@example.com",
+                corrected_at="2026-07-04T10:00:00Z",
+            ),
+            CorrectionRecord(
+                correction_id=2,
+                field_id="field-fee",
+                corrected_value="1.25%",
+                reason="manager ppm correction",
+                corrected_by="analyst@example.com",
+                corrected_at="2026-07-04T10:05:00Z",
+            ),
+            CorrectionRecord(
+                correction_id=3,
+                field_id="field-strategy",
+                corrected_value="Private Equity",
+                reason="confirmed",
+                corrected_by="analyst@example.com",
+                corrected_at="2026-07-04T10:10:00Z",
+            ),
+        ),
+        expected_field_keys=("operations.aum", "terms.management_fee", "strategy.asset_class"),
+        threshold_config=ThresholdConfig(
+            field_auto_accept_min=0.85,
+            key_field_confidence_min=0.75,
+            document_key_field_coverage_min=0.8,
+            mandatory_field_min=0.6,
+            mandatory_fields=("operations.aum",),
+        ),
+    )
+
+    assert report["summary"] == {
+        "field_count": 3,
+        "expected_field_count": 3,
+        "true_positive_count": 2,
+        "false_positive_count": 1,
+        "false_negative_count": 0,
+        "precision": 0.6667,
+        "recall": 1.0,
+        "auto_accept_precision": 0.6667,
+        "missing_expected_fields": [],
+    }
+    assert report["field_metrics"]["terms.management_fee"]["precision"] == 0.0
+    assert report["confidence_buckets"] == [
+        {
+            "bucket": "0.85-1.00",
+            "count": 3,
+            "mean_confidence": 0.9,
+            "observed_accuracy": 0.6667,
+            "calibration_gap": 0.2333,
+        }
+    ]
+    assert report["threshold_suggestions"]["field_auto_accept_min"] == {
+        "current": 0.85,
+        "direction": "raise",
+        "basis": "auto_accept_precision",
+        "observed": 0.6667,
+    }
+    assert threshold_path.read_text(encoding="utf-8") == before_thresholds
+
+
+def _field(field_id: str, key: str, value: str, confidence: float) -> ExtractedFieldRecord:
+    return ExtractedFieldRecord(
+        field_id=field_id,
+        document_id="doc-1",
+        field_key=key,
+        value=value,
+        confidence=confidence,
+        source_page=1,
+        source_snippet=None,
+        extracted_at="2026-07-04T09:00:00Z",
+    )

--- a/tests/readiness/test_extraction_calibration.py
+++ b/tests/readiness/test_extraction_calibration.py
@@ -9,9 +9,8 @@ from inv_man_intake.extraction.confidence import ThresholdConfig
 from inv_man_intake.readiness.extraction_calibration import build_calibration_report
 
 
-def test_calibration_metrics_on_seeded_corrections(tmp_path: Path) -> None:
-    threshold_path = tmp_path / "extraction_thresholds.yaml"
-    threshold_path.write_text("field_auto_accept_min: 0.85\n", encoding="utf-8")
+def test_calibration_metrics_on_seeded_corrections() -> None:
+    threshold_path = Path("config/extraction_thresholds.yaml")
     before_thresholds = threshold_path.read_text(encoding="utf-8")
 
     report = build_calibration_report(
@@ -19,6 +18,7 @@ def test_calibration_metrics_on_seeded_corrections(tmp_path: Path) -> None:
             _field("field-aum", "operations.aum", "100000000", 0.9),
             _field("field-fee", "terms.management_fee", "1.00%", 0.9),
             _field("field-strategy", "strategy.asset_class", "Private Equity", 0.9),
+            _field("field-vintage", "strategy.vintage_year", "2025", 0.72),
         ),
         corrections=(
             CorrectionRecord(
@@ -46,7 +46,13 @@ def test_calibration_metrics_on_seeded_corrections(tmp_path: Path) -> None:
                 corrected_at="2026-07-04T10:10:00Z",
             ),
         ),
-        expected_field_keys=("operations.aum", "terms.management_fee", "strategy.asset_class"),
+        expected_field_keys=(
+            "operations.aum",
+            "terms.management_fee",
+            "strategy.asset_class",
+            "strategy.vintage_year",
+            "risk.liquidity_terms",
+        ),
         threshold_config=ThresholdConfig(
             field_auto_accept_min=0.85,
             key_field_confidence_min=0.75,
@@ -57,17 +63,20 @@ def test_calibration_metrics_on_seeded_corrections(tmp_path: Path) -> None:
     )
 
     assert report["summary"] == {
-        "field_count": 3,
-        "expected_field_count": 3,
+        "field_count": 4,
+        "known_field_count": 3,
+        "unknown_field_count": 1,
+        "expected_field_count": 5,
         "true_positive_count": 2,
         "false_positive_count": 1,
-        "false_negative_count": 0,
+        "false_negative_count": 2,
         "precision": 0.6667,
-        "recall": 1.0,
+        "recall": 0.5,
         "auto_accept_precision": 0.6667,
-        "missing_expected_fields": [],
+        "missing_expected_fields": ["risk.liquidity_terms"],
     }
     assert report["field_metrics"]["terms.management_fee"]["precision"] == 0.0
+    assert "strategy.vintage_year" not in report["field_metrics"]
     assert report["confidence_buckets"] == [
         {
             "bucket": "0.85-1.00",


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:711 -->
> **Source:** Issue #711

Closes #711

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The pipeline already captures the two signals needed to measure and tune extraction quality, but never measures them: append-only human corrections (`src/inv_man_intake/data/provenance.py:23` `CorrectionRecord`; history helpers at `src/inv_man_intake/data/fixtures.py:86` `correction_history_for_pointer`) and threshold escalations (`src/inv_man_intake/extraction/confidence.py` `evaluate_thresholds` → `ThresholdDecision.escalation_reason`). Joined, corrections-vs-extractions ARE a field-level precision/recall + confidence-calibration ground-truth set that would let the `0.85 / 0.75 / 0.60` thresholds in `config/extraction_thresholds.yaml` be tuned with evidence instead of the V1 guesses. Latent opportunity (not a break).

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#699](https://github.com/stranske/Inv-Man-Intake/issues/699)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] Add `src/inv_man_intake/readiness/extraction_calibration.py` (or similar) that, given a set of extracted fields + their `CorrectionRecord`s, computes per-field precision/recall and per-confidence-bucket calibration (predicted confidence vs observed correctness).
- [ ] Emit a deterministic report (dict/JSON) including a suggested adjustment direction per threshold key, grounded in the calibration.
- [ ] Add `tests/readiness/test_extraction_calibration.py::test_calibration_metrics_on_seeded_corrections`.

#### Acceptance criteria
- [ ] Named test `tests/readiness/test_extraction_calibration.py::test_calibration_metrics_on_seeded_corrections` passes: a seeded set (e.g. 3 fields auto-accepted at 0.9 with 1 later corrected) yields the documented precision/recall and calibration numbers.
- [ ] **Deliberate-break gate:** flip one seeded correction (corrected ↔ confirmed); the named test **must FAIL** (precision/recall changes); revert → passes.
- [ ] The job does NOT write to `config/extraction_thresholds.yaml` (assert no file mutation in the test).

<!-- auto-status-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a read-only extraction calibration report that summarizes extraction quality, including precision, recall, auto-accept precision, field-level metrics, confidence-bucket accuracy, and threshold suggestions.
  * The report also highlights missing expected fields and uses the latest correction data to build per-field observations.

* **Tests**
  * Added coverage for calibration reporting with seeded extraction and correction data, including metric calculations, confidence-bucket output, and threshold suggestion behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->