### PR TITLE
Add regulatory lineage packet assembly

### DIFF
--- a/src/inv_man_intake/audit/lineage.py
+++ b/src/inv_man_intake/audit/lineage.py
@@ -38,10 +38,7 @@ def build_lineage_packet(
             "trace_refs": sorted(trace_refs),
         },
         "documents": [_document_payload(document) for document in _sort_documents(documents)],
-        "extracted_fields": [
-            _field_payload(field, correction_history.get(field.field_id, ()))
-            for field in _sort_fields(extracted_fields)
-        ],
+        "extracted_fields": _field_payloads(extracted_fields, correction_history),
         "threshold_decision": _threshold_payload(threshold_decision),
         "score": _score_payload(score),
     }
@@ -59,6 +56,26 @@ def _sort_corrections(corrections: Sequence[CorrectionRecord]) -> list[Correctio
     return sorted(
         corrections, key=lambda correction: (correction.corrected_at, correction.correction_id)
     )
+
+
+def _field_payloads(
+    fields: Sequence[ExtractedFieldRecord],
+    correction_history: Mapping[str, Sequence[CorrectionRecord]],
+) -> list[dict[str, Any]]:
+    corrections_by_field_id: dict[str, dict[int, CorrectionRecord]] = {}
+    for corrections in correction_history.values():
+        for correction in corrections:
+            corrections_by_field_id.setdefault(correction.field_id, {})[
+                correction.correction_id
+            ] = correction
+
+    return [
+        _field_payload(
+            field,
+            tuple(corrections_by_field_id.get(field.field_id, {}).values()),
+        )
+        for field in _sort_fields(fields)
+    ]
 
 
 def _document_payload(document: Document) -> dict[str, Any]:

--- a/src/inv_man_intake/audit/lineage.py
+++ b/src/inv_man_intake/audit/lineage.py
@@ -1,0 +1,129 @@
+"""Regulatory lineage packet assembly for one intake scoring decision."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from inv_man_intake.data.models import Document
+from inv_man_intake.data.provenance import CorrectionRecord, ExtractedFieldRecord
+from inv_man_intake.extraction.confidence import ThresholdDecision
+from inv_man_intake.scoring.contracts import ScoreResult
+
+
+def build_lineage_packet(
+    *,
+    run_id: str,
+    manifest_ref: str,
+    documents: Sequence[Document],
+    extracted_fields: Sequence[ExtractedFieldRecord],
+    correction_history: Mapping[str, Sequence[CorrectionRecord]],
+    score: ScoreResult,
+    threshold_decision: ThresholdDecision,
+    trace_refs: Sequence[str] = (),
+) -> dict[str, Any]:
+    """Assemble a deterministic JSON-ready packet from existing run artifacts.
+
+    The packet intentionally does not capture new data. Callers provide the run
+    manifest reference, document versions, extracted-field provenance, correction
+    history, score output, and threshold decision already produced by the intake
+    pipeline.
+    """
+
+    return {
+        "schema_version": "lineage-packet/v1",
+        "run": {
+            "run_id": run_id,
+            "manifest_ref": manifest_ref,
+            "trace_refs": sorted(trace_refs),
+        },
+        "documents": [_document_payload(document) for document in _sort_documents(documents)],
+        "extracted_fields": [
+            _field_payload(field, correction_history.get(field.field_id, ()))
+            for field in _sort_fields(extracted_fields)
+        ],
+        "threshold_decision": _threshold_payload(threshold_decision),
+        "score": _score_payload(score),
+    }
+
+
+def _sort_documents(documents: Sequence[Document]) -> list[Document]:
+    return sorted(documents, key=lambda document: document.document_id)
+
+
+def _sort_fields(fields: Sequence[ExtractedFieldRecord]) -> list[ExtractedFieldRecord]:
+    return sorted(fields, key=lambda field: (field.document_id, field.field_key, field.field_id))
+
+
+def _sort_corrections(corrections: Sequence[CorrectionRecord]) -> list[CorrectionRecord]:
+    return sorted(
+        corrections, key=lambda correction: (correction.corrected_at, correction.correction_id)
+    )
+
+
+def _document_payload(document: Document) -> dict[str, Any]:
+    return {
+        "document_id": document.document_id,
+        "fund_id": document.fund_id,
+        "file_name": document.file_name,
+        "file_hash": document.file_hash,
+        "received_at": document.received_at,
+        "version_date": document.version_date,
+        "source_channel": document.source_channel,
+        "created_at": document.created_at,
+    }
+
+
+def _field_payload(
+    field: ExtractedFieldRecord,
+    corrections: Sequence[CorrectionRecord],
+) -> dict[str, Any]:
+    ordered_corrections = _sort_corrections(corrections)
+    latest_value = ordered_corrections[-1].corrected_value if ordered_corrections else field.value
+    return {
+        "field_id": field.field_id,
+        "document_id": field.document_id,
+        "field_key": field.field_key,
+        "original_value": field.value,
+        "latest_value": latest_value,
+        "confidence": field.confidence,
+        "source_page": field.source_page,
+        "source_snippet": field.source_snippet,
+        "extracted_at": field.extracted_at,
+        "corrections": [_correction_payload(correction) for correction in ordered_corrections],
+    }
+
+
+def _correction_payload(correction: CorrectionRecord) -> dict[str, Any]:
+    return {
+        "correction_id": correction.correction_id,
+        "field_id": correction.field_id,
+        "corrected_value": correction.corrected_value,
+        "reason": correction.reason,
+        "corrected_by": correction.corrected_by,
+        "corrected_at": correction.corrected_at,
+    }
+
+
+def _threshold_payload(decision: ThresholdDecision) -> dict[str, Any]:
+    return {
+        "auto_accept_fields": sorted(decision.auto_accept_fields),
+        "key_field_coverage_ratio": decision.key_field_coverage_ratio,
+        "auto_pass_document": decision.auto_pass_document,
+        "escalate": decision.escalate,
+        "escalation_reason": decision.escalation_reason,
+    }
+
+
+def _score_payload(score: ScoreResult) -> dict[str, Any]:
+    return {
+        "manager_id": score.manager_id,
+        "asset_class": score.asset_class,
+        "base_score": score.base_score,
+        "final_score": score.final_score,
+        "contributions": {key: score.contributions[key] for key in sorted(score.contributions)},
+        "red_flag_applied": score.red_flag_applied,
+        "red_flag_reason": score.red_flag_reason,
+        "peer_group_percentile": score.peer_group_percentile,
+        "peer_group_size": score.peer_group_size,
+    }

--- a/tests/test_lineage_packet.py
+++ b/tests/test_lineage_packet.py
@@ -119,3 +119,107 @@ def test_lineage_packet_contains_required_sections() -> None:
         "peer_group_size": 40,
     }
     assert json.dumps(packet, sort_keys=True) == json.dumps(packet_again, sort_keys=True)
+
+
+def test_lineage_packet_matches_corrections_by_field_id_not_history_key() -> None:
+    document = _document()
+    field = _field(field_id="field_1", value="2.00%")
+    duplicate_correction = CorrectionRecord(
+        correction_id=1,
+        field_id="field_1",
+        corrected_value="1.90%",
+        reason="First analyst correction",
+        corrected_by="analyst@example.com",
+        corrected_at="2026-03-01T10:00:00Z",
+    )
+    latest_correction = CorrectionRecord(
+        correction_id=2,
+        field_id="field_1",
+        corrected_value="1.85%",
+        reason="Final analyst correction",
+        corrected_by="analyst@example.com",
+        corrected_at="2026-03-01T10:05:00Z",
+    )
+
+    packet = build_lineage_packet(
+        run_id="run_123",
+        manifest_ref="artifact:manifest.json",
+        documents=(document,),
+        extracted_fields=(field,),
+        correction_history={
+            "legacy-source-key": (duplicate_correction, latest_correction),
+            "field_1": (duplicate_correction,),
+        },
+        score=_score(),
+        threshold_decision=_decision(),
+    )
+
+    field_payload = packet["extracted_fields"][0]
+    assert field_payload["latest_value"] == "1.85%"
+    assert [correction["correction_id"] for correction in field_payload["corrections"]] == [1, 2]
+
+
+def test_lineage_packet_preserves_original_value_without_corrections() -> None:
+    packet = build_lineage_packet(
+        run_id="run_123",
+        manifest_ref="artifact:manifest.json",
+        documents=(_document(),),
+        extracted_fields=(_field(field_id="field_without_correction", value="2.00%"),),
+        correction_history={},
+        score=_score(),
+        threshold_decision=_decision(),
+    )
+
+    field_payload = packet["extracted_fields"][0]
+    assert field_payload["latest_value"] == "2.00%"
+    assert field_payload["corrections"] == []
+
+
+def _document() -> Document:
+    return Document(
+        document_id="doc_1",
+        fund_id="fund_1",
+        file_name="alpha_ppm.pdf",
+        file_hash="sha256:abc123",
+        received_at="2026-03-01T09:00:00Z",
+        version_date="2026-03-01",
+        source_channel="email",
+        created_at="2026-03-01T09:00:00Z",
+    )
+
+
+def _field(*, field_id: str, value: str) -> ExtractedFieldRecord:
+    return ExtractedFieldRecord(
+        field_id=field_id,
+        document_id="doc_1",
+        field_key="terms.management_fee",
+        value=value,
+        confidence=0.82,
+        source_page=4,
+        source_snippet="Management fee: 2.00%",
+        extracted_at="2026-03-01T09:05:00Z",
+    )
+
+
+def _score() -> ScoreResult:
+    return ScoreResult(
+        manager_id="mgr_1",
+        asset_class="equity_market_neutral",
+        base_score=0.72,
+        final_score=0.68,
+        contributions={"terms": 0.20, "performance": 0.52},
+        red_flag_applied=True,
+        red_flag_reason="threshold_escalation",
+        peer_group_percentile=62.5,
+        peer_group_size=40,
+    )
+
+
+def _decision() -> ThresholdDecision:
+    return ThresholdDecision(
+        auto_accept_fields=("performance.net_return_1y",),
+        key_field_coverage_ratio=0.75,
+        auto_pass_document=False,
+        escalate=True,
+        escalation_reason="confidence_below_threshold:terms.management_fee",
+    )

--- a/tests/test_lineage_packet.py
+++ b/tests/test_lineage_packet.py
@@ -1,0 +1,121 @@
+"""Tests for regulatory lineage packet assembly."""
+
+from __future__ import annotations
+
+import json
+
+from inv_man_intake.audit.lineage import build_lineage_packet
+from inv_man_intake.data.models import Document
+from inv_man_intake.data.provenance import CorrectionRecord, ExtractedFieldRecord
+from inv_man_intake.extraction.confidence import ThresholdDecision
+from inv_man_intake.scoring.contracts import ScoreResult
+
+
+def test_lineage_packet_contains_required_sections() -> None:
+    document = Document(
+        document_id="doc_1",
+        fund_id="fund_1",
+        file_name="alpha_ppm.pdf",
+        file_hash="sha256:abc123",
+        received_at="2026-03-01T09:00:00Z",
+        version_date="2026-03-01",
+        source_channel="email",
+        created_at="2026-03-01T09:00:00Z",
+    )
+    field = ExtractedFieldRecord(
+        field_id="field_1",
+        document_id="doc_1",
+        field_key="terms.management_fee",
+        value="2.00%",
+        confidence=0.82,
+        source_page=4,
+        source_snippet="Management fee: 2.00%",
+        extracted_at="2026-03-01T09:05:00Z",
+    )
+    correction = CorrectionRecord(
+        correction_id=1,
+        field_id="field_1",
+        corrected_value="1.85%",
+        reason="Analyst corrected against final PPM",
+        corrected_by="analyst@example.com",
+        corrected_at="2026-03-01T10:00:00Z",
+    )
+    score = ScoreResult(
+        manager_id="mgr_1",
+        asset_class="equity_market_neutral",
+        base_score=0.72,
+        final_score=0.68,
+        contributions={"terms": 0.20, "performance": 0.52},
+        red_flag_applied=True,
+        red_flag_reason="threshold_escalation",
+        peer_group_percentile=62.5,
+        peer_group_size=40,
+    )
+    decision = ThresholdDecision(
+        auto_accept_fields=("performance.net_return_1y",),
+        key_field_coverage_ratio=0.75,
+        auto_pass_document=False,
+        escalate=True,
+        escalation_reason="confidence_below_threshold:terms.management_fee",
+    )
+
+    packet = build_lineage_packet(
+        run_id="run_123",
+        manifest_ref="artifact:manifest.json",
+        documents=(document,),
+        extracted_fields=(field,),
+        correction_history={"field_1": (correction,)},
+        score=score,
+        threshold_decision=decision,
+        trace_refs=("trace:abc",),
+    )
+    packet_again = build_lineage_packet(
+        run_id="run_123",
+        manifest_ref="artifact:manifest.json",
+        documents=(document,),
+        extracted_fields=(field,),
+        correction_history={"field_1": (correction,)},
+        score=score,
+        threshold_decision=decision,
+        trace_refs=("trace:abc",),
+    )
+
+    assert packet["run"]["run_id"] == "run_123"
+    assert packet["run"]["manifest_ref"] == "artifact:manifest.json"
+    assert packet["documents"] == [
+        {
+            "document_id": "doc_1",
+            "fund_id": "fund_1",
+            "file_name": "alpha_ppm.pdf",
+            "file_hash": "sha256:abc123",
+            "received_at": "2026-03-01T09:00:00Z",
+            "version_date": "2026-03-01",
+            "source_channel": "email",
+            "created_at": "2026-03-01T09:00:00Z",
+        }
+    ]
+    assert packet["extracted_fields"][0]["field_key"] == "terms.management_fee"
+    assert packet["extracted_fields"][0]["confidence"] == 0.82
+    assert packet["extracted_fields"][0]["latest_value"] == "1.85%"
+    assert packet["extracted_fields"][0]["corrections"][0]["reason"] == (
+        "Analyst corrected against final PPM"
+    )
+    assert packet["threshold_decision"] == {
+        "auto_accept_fields": ["performance.net_return_1y"],
+        "key_field_coverage_ratio": 0.75,
+        "auto_pass_document": False,
+        "escalate": True,
+        "escalation_reason": "confidence_below_threshold:terms.management_fee",
+    }
+    assert packet["score"] == {
+        "manager_id": "mgr_1",
+        "asset_class": "equity_market_neutral",
+        "base_score": 0.72,
+        "final_score": 0.68,
+        "contributions": {"performance": 0.52, "terms": 0.20},
+        "red_flag_applied": True,
+        "red_flag_reason": "threshold_escalation",
+        "peer_group_percentile": 62.5,
+        "peer_group_size": 40,
+    }
+    assert json.dumps(packet, sort_keys=True) == json.dumps(packet_again, sort_keys=True)


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:712 -->
> **Source:** Issue #712

Closes #712

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
All the pieces of a regulatory-defensibility audit trail already exist but are unassembled: field provenance + correction history (`src/inv_man_intake/data/provenance.py`), document version history (`src/inv_man_intake/data/migrations/provenance_history.py`), the per-run manifest (`src/inv_man_intake/run_manifest.py`), the score + threshold decision, and trace context. A diligence/compliance reviewer needs a single per-decision **lineage packet** that shows "this score came from these documents, these extracted fields (with confidence + corrections), under this threshold policy." Latent opportunity (not a break) — the data is captured, just never exported together.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#699](https://github.com/stranske/Inv-Man-Intake/issues/699)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] Add `src/inv_man_intake/run_manifest.py` helper (or a new `audit/lineage.py`) `build_lineage_packet(...)` that takes the run artifacts (documents + versions, extracted fields + provenance/corrections, score result, threshold decision) and returns a structured packet.
- [ ] Include, per packet: run id / manifest ref, document versions (id + hash), extracted fields with confidence + correction history, the threshold policy + decision, and the final score with red-flag reason.
- [ ] Add `tests/test_lineage_packet.py::test_lineage_packet_contains_required_sections`.

#### Acceptance criteria
- [ ] Named test `tests/test_lineage_packet.py::test_lineage_packet_contains_required_sections` passes: the packet built from a seeded run contains non-empty `documents`, `extracted_fields` (with provenance), `threshold_decision`, and `score` sections, and is deterministic for the same input.
- [ ] **Deliberate-break gate:** remove the threshold-decision assembly line; the named test **must FAIL** (missing section); revert → passes.
- [ ] No runtime behavior change to existing pipelines (existing suites stay green).

<!-- auto-status-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a lineage packet export for intake scoring decisions, delivering a deterministic JSON-ready summary of run metadata, documents, extracted fields (including latest corrected value and correction details), threshold decision, and score output.
  * Produces stable, repeatable ordering across key elements to ensure identical packet serialization for identical inputs.
* **Tests**
  * Added tests validating required packet sections and exact output structure.
  * Verified corrections are matched by field ID (not history keys), latest-value selection, original value fallback when no corrections exist, and determinism across repeated generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->