### PR TITLE
Add extraction regression gate

### DIFF
--- a/src/inv_man_intake/extraction/regression.py
+++ b/src/inv_man_intake/extraction/regression.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 import json
+import re
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
+from datetime import date, datetime
+from decimal import Decimal, InvalidOperation
 from pathlib import Path
-from typing import Protocol
+from typing import Any, Protocol
 
 from inv_man_intake.extraction.providers.base import ExtractionProvider
 from inv_man_intake.observability.tracing import TraceEvent
@@ -126,10 +129,14 @@ def evaluate_extraction_regression(
     actual_by_source: dict[str, dict[str, str]] = {}
 
     for sample in samples:
-        result = provider.extract(source_doc_id=sample.source_doc_id, content=sample.content)
-        actual_by_source[sample.source_doc_id] = {
-            _normalize(field.key): _normalize(field.value) for field in result.fields
-        }
+        try:
+            result = provider.extract(source_doc_id=sample.source_doc_id, content=sample.content)
+        except Exception:  # noqa: BLE001 - fail closed while preserving a structured report
+            actual_by_source[sample.source_doc_id] = {}
+            continue
+        actual_by_source[sample.source_doc_id] = _field_map(
+            {field.key: field.value for field in result.fields}
+        )
 
     report = _score_fields(
         provider_name=provider.name,
@@ -170,21 +177,23 @@ def score_trace_drift(
 
     actual_by_source: dict[str, dict[str, str]] = {}
     trace_event_count = 0
-    matched_trace_count = 0
+    matched_source_ids: set[str] = set()
     sample_ids = {sample.source_doc_id for sample in samples}
 
     for event in trace_events:
         trace_event_count += 1
+        if event.ended_at is None:
+            continue
         source_doc_id = event.metadata.get("source_doc_id")
         fields = event.metadata.get("fields")
         if not isinstance(source_doc_id, str) or not isinstance(fields, Mapping):
             continue
         if source_doc_id not in sample_ids:
             continue
-        matched_trace_count += 1
-        actual_by_source[source_doc_id] = {
-            _normalize(str(key)): _normalize(str(value)) for key, value in fields.items()
-        }
+        if source_doc_id in matched_source_ids:
+            continue
+        matched_source_ids.add(source_doc_id)
+        actual_by_source[source_doc_id] = _field_map(fields)
 
     report = _score_fields(
         provider_name=provider_name,
@@ -194,7 +203,7 @@ def score_trace_drift(
     )
     return DriftScore(
         trace_event_count=trace_event_count,
-        matched_trace_count=matched_trace_count,
+        matched_trace_count=len(matched_source_ids),
         report=report,
     )
 
@@ -214,9 +223,7 @@ def _score_fields(
     unexpected: list[str] = []
 
     for sample in samples:
-        expected = {
-            _normalize(field.key): _normalize(field.value) for field in sample.expected_fields
-        }
+        expected = _field_map({field.key: field.value for field in sample.expected_fields})
         actual = actual_by_source.get(sample.source_doc_id, {})
         expected_total += len(expected)
         predicted_total += len(actual)
@@ -246,5 +253,58 @@ def _score_fields(
     )
 
 
-def _normalize(value: str) -> str:
-    return " ".join(value.strip().casefold().split())
+def _field_map(fields: Mapping[Any, Any]) -> dict[str, str]:
+    return {_normalize(key): _normalize(value) for key, value in fields.items()}
+
+
+def _normalize(value: Any) -> str:
+    if isinstance(value, datetime):
+        return value.date().isoformat()
+    if isinstance(value, date):
+        return value.isoformat()
+    if isinstance(value, int | float | Decimal) and not isinstance(value, bool):
+        return _normalize_decimal(Decimal(str(value)))
+
+    text = " ".join(str(value).strip().casefold().split())
+    if not text:
+        return text
+
+    date_value = _try_parse_date(text)
+    if date_value is not None:
+        return date_value.isoformat()
+
+    percent_match = re.fullmatch(r"([-+]?\d[\d,]*(?:\.\d+)?)\s*%", text)
+    if percent_match:
+        return f"{_normalize_decimal(_decimal(percent_match.group(1)))}%"
+
+    numeric_match = re.fullmatch(r"[-+]?\d[\d,]*(?:\.\d+)?", text)
+    if numeric_match:
+        return _normalize_decimal(_decimal(text))
+
+    return text
+
+
+def _try_parse_date(text: str) -> date | None:
+    normalized = text.removesuffix("z").replace(" ", "T")
+    try:
+        return datetime.fromisoformat(normalized).date()
+    except ValueError:
+        pass
+    try:
+        return date.fromisoformat(text)
+    except ValueError:
+        return None
+
+
+def _decimal(text: str) -> Decimal:
+    try:
+        return Decimal(text.replace(",", ""))
+    except InvalidOperation:
+        return Decimal(text)
+
+
+def _normalize_decimal(value: Decimal) -> str:
+    normalized = value.normalize()
+    if normalized == normalized.to_integral():
+        return str(normalized.quantize(Decimal("1")))
+    return format(normalized, "f")

--- a/src/inv_man_intake/extraction/regression.py
+++ b/src/inv_man_intake/extraction/regression.py
@@ -1,0 +1,250 @@
+"""Deterministic extraction regression and drift checks."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol
+
+from inv_man_intake.extraction.providers.base import ExtractionProvider
+from inv_man_intake.observability.tracing import TraceEvent
+
+
+@dataclass(frozen=True)
+class GoldenField:
+    """Expected normalized value for one extracted field."""
+
+    key: str
+    value: str
+
+
+@dataclass(frozen=True)
+class GoldenSample:
+    """Offline extraction regression sample."""
+
+    source_doc_id: str
+    content: bytes
+    expected_fields: tuple[GoldenField, ...]
+
+
+@dataclass(frozen=True)
+class ExtractionRegressionReport:
+    """Precision/recall/F1 report for an extraction golden set."""
+
+    provider_name: str
+    evaluated_fields: int
+    predicted_fields: int
+    true_positive_fields: int
+    missing_fields: tuple[str, ...]
+    mismatched_fields: tuple[str, ...]
+    unexpected_fields: tuple[str, ...]
+    minimum_f1: float
+
+    @property
+    def precision(self) -> float:
+        if self.predicted_fields == 0:
+            return 0.0
+        return self.true_positive_fields / self.predicted_fields
+
+    @property
+    def recall(self) -> float:
+        if self.evaluated_fields == 0:
+            return 0.0
+        return self.true_positive_fields / self.evaluated_fields
+
+    @property
+    def f1(self) -> float:
+        precision = self.precision
+        recall = self.recall
+        if precision == 0.0 and recall == 0.0:
+            return 0.0
+        return (2 * precision * recall) / (precision + recall)
+
+    @property
+    def passes(self) -> bool:
+        return self.f1 >= self.minimum_f1
+
+
+@dataclass(frozen=True)
+class DriftScore:
+    """Sampled online drift score derived from trace metadata."""
+
+    trace_event_count: int
+    matched_trace_count: int
+    report: ExtractionRegressionReport
+
+    @property
+    def drift_score(self) -> float:
+        return 1.0 - self.report.f1
+
+
+class _ProviderFactory(Protocol):
+    def __call__(self) -> ExtractionProvider: ...
+
+
+def load_golden_samples(path: Path) -> tuple[GoldenSample, ...]:
+    """Load a committed extraction golden set from JSON."""
+
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    samples: list[GoldenSample] = []
+    for item in payload["samples"]:
+        expected_payload = item["expected_fields"]
+        if isinstance(expected_payload, Mapping):
+            expected_fields = tuple(
+                GoldenField(key=str(key), value=str(value))
+                for key, value in expected_payload.items()
+            )
+        else:
+            expected_fields = tuple(
+                GoldenField(key=str(field["key"]), value=str(field["value"]))
+                for field in expected_payload
+            )
+        samples.append(
+            GoldenSample(
+                source_doc_id=str(item["source_doc_id"]),
+                content=str(item["content"]).encode("utf-8"),
+                expected_fields=expected_fields,
+            )
+        )
+    return tuple(samples)
+
+
+def evaluate_extraction_regression(
+    *,
+    provider_factory: _ProviderFactory,
+    samples: tuple[GoldenSample, ...],
+    minimum_f1: float,
+) -> ExtractionRegressionReport:
+    """Run a provider over a golden set and compute field-level precision/recall/F1."""
+
+    if not 0.0 <= minimum_f1 <= 1.0:
+        raise ValueError("minimum_f1 must be between 0 and 1")
+
+    provider = provider_factory()
+    actual_by_source: dict[str, dict[str, str]] = {}
+
+    for sample in samples:
+        result = provider.extract(source_doc_id=sample.source_doc_id, content=sample.content)
+        actual_by_source[sample.source_doc_id] = {
+            _normalize(field.key): _normalize(field.value) for field in result.fields
+        }
+
+    report = _score_fields(
+        provider_name=provider.name,
+        samples=samples,
+        actual_by_source=actual_by_source,
+        minimum_f1=minimum_f1,
+    )
+    return report
+
+
+def assert_regression_gate(report: ExtractionRegressionReport) -> None:
+    """Fail closed when a regression report falls below its configured F1 floor."""
+
+    if report.passes:
+        return
+
+    raise AssertionError(
+        "extraction regression F1 "
+        f"{report.f1:.4f} is below minimum {report.minimum_f1:.4f}; "
+        f"missing={list(report.missing_fields)} "
+        f"mismatched={list(report.mismatched_fields)} "
+        f"unexpected={list(report.unexpected_fields)}"
+    )
+
+
+def score_trace_drift(
+    *,
+    samples: tuple[GoldenSample, ...],
+    trace_events: Iterable[TraceEvent],
+    minimum_f1: float,
+    provider_name: str = "trace-sample",
+) -> DriftScore:
+    """Score sampled trace metadata against the same golden-set field contract.
+
+    The helper accepts in-memory trace events or exported LangSmith trace metadata. It
+    expects span metadata shaped as ``source_doc_id`` plus a ``fields`` mapping.
+    """
+
+    actual_by_source: dict[str, dict[str, str]] = {}
+    trace_event_count = 0
+    matched_trace_count = 0
+    sample_ids = {sample.source_doc_id for sample in samples}
+
+    for event in trace_events:
+        trace_event_count += 1
+        source_doc_id = event.metadata.get("source_doc_id")
+        fields = event.metadata.get("fields")
+        if not isinstance(source_doc_id, str) or not isinstance(fields, Mapping):
+            continue
+        if source_doc_id not in sample_ids:
+            continue
+        matched_trace_count += 1
+        actual_by_source[source_doc_id] = {
+            _normalize(str(key)): _normalize(str(value)) for key, value in fields.items()
+        }
+
+    report = _score_fields(
+        provider_name=provider_name,
+        samples=samples,
+        actual_by_source=actual_by_source,
+        minimum_f1=minimum_f1,
+    )
+    return DriftScore(
+        trace_event_count=trace_event_count,
+        matched_trace_count=matched_trace_count,
+        report=report,
+    )
+
+
+def _score_fields(
+    *,
+    provider_name: str,
+    samples: tuple[GoldenSample, ...],
+    actual_by_source: Mapping[str, Mapping[str, str]],
+    minimum_f1: float,
+) -> ExtractionRegressionReport:
+    expected_total = 0
+    predicted_total = 0
+    true_positive = 0
+    missing: list[str] = []
+    mismatched: list[str] = []
+    unexpected: list[str] = []
+
+    for sample in samples:
+        expected = {
+            _normalize(field.key): _normalize(field.value) for field in sample.expected_fields
+        }
+        actual = actual_by_source.get(sample.source_doc_id, {})
+        expected_total += len(expected)
+        predicted_total += len(actual)
+
+        for key, expected_value in expected.items():
+            field_ref = f"{sample.source_doc_id}:{key}"
+            actual_value = actual.get(key)
+            if actual_value is None:
+                missing.append(field_ref)
+            elif actual_value == expected_value:
+                true_positive += 1
+            else:
+                mismatched.append(field_ref)
+
+        for key in sorted(set(actual) - set(expected)):
+            unexpected.append(f"{sample.source_doc_id}:{key}")
+
+    return ExtractionRegressionReport(
+        provider_name=provider_name,
+        evaluated_fields=expected_total,
+        predicted_fields=predicted_total,
+        true_positive_fields=true_positive,
+        missing_fields=tuple(missing),
+        mismatched_fields=tuple(mismatched),
+        unexpected_fields=tuple(unexpected),
+        minimum_f1=minimum_f1,
+    )
+
+
+def _normalize(value: str) -> str:
+    return " ".join(value.strip().casefold().split())

--- a/tests/extraction/golden/extraction_regression_golden.json
+++ b/tests/extraction/golden/extraction_regression_golden.json
@@ -1,0 +1,34 @@
+{
+  "samples": [
+    {
+      "source_doc_id": "golden-manager-report",
+      "content": "Strategy: Global Multi-Asset Income\nBenchmark: Bloomberg US Aggregate\nManagement Fee: 1.50%\nPerformance Fee: 15%\nTable Snapshot\nYear Return AUM\n2023 8.1 100",
+      "expected_fields": {
+        "strategy.name": "Global Multi-Asset Income",
+        "benchmark.name": "Bloomberg US Aggregate",
+        "terms.management_fee": "1.50%",
+        "terms.performance_fee": "15%"
+      }
+    },
+    {
+      "source_doc_id": "golden-credit-review",
+      "content": "STRATEGY - Defensive Credit Alpha\nBENCHMARK - ICE BofA US Corp\nmanagement fee : 0.95%\nPerformance Fee: 12%\n(ocr artifacts and line breaks)",
+      "expected_fields": {
+        "strategy.name": "Defensive Credit Alpha",
+        "benchmark.name": "ICE BofA US Corp",
+        "terms.management_fee": "0.95%",
+        "terms.performance_fee": "12%"
+      }
+    },
+    {
+      "source_doc_id": "golden-slide-update",
+      "content": "Fund update slide\nBenchmark: MSCI ACWI\nStrategy: Global Equity Long Short\nManagement Fee-2.00%\nPerformance Fee-20%\nImage callout: portfolio contributors",
+      "expected_fields": {
+        "strategy.name": "Global Equity Long Short",
+        "benchmark.name": "MSCI ACWI",
+        "terms.management_fee": "2.00%",
+        "terms.performance_fee": "20%"
+      }
+    }
+  ]
+}

--- a/tests/extraction/test_extraction_regression.py
+++ b/tests/extraction/test_extraction_regression.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import NoReturn
 
 import pytest
 
@@ -64,8 +65,38 @@ def test_extraction_regression_gate_fails_on_perturbed_golden_value() -> None:
         assert_regression_gate(report)
 
 
+def test_extraction_regression_reports_provider_failures_as_missing_fields() -> None:
+    samples = load_golden_samples(_GOLDEN_PATH)
+
+    report = evaluate_extraction_regression(
+        provider_factory=_FailingProvider,
+        samples=samples[:1],
+        minimum_f1=0.95,
+    )
+
+    assert report.provider_name == "failing-provider"
+    assert report.evaluated_fields == 4
+    assert report.predicted_fields == 0
+    assert report.true_positive_fields == 0
+    assert report.missing_fields == (
+        "golden-manager-report:strategy.name",
+        "golden-manager-report:benchmark.name",
+        "golden-manager-report:terms.management_fee",
+        "golden-manager-report:terms.performance_fee",
+    )
+    assert report.f1 == 0.0
+
+
 def test_trace_drift_scores_sampled_langsmith_metadata() -> None:
     samples = load_golden_samples(_GOLDEN_PATH)
+    date_numeric_sample = GoldenSample(
+        source_doc_id="golden-date-fee",
+        content=b"not used by trace drift",
+        expected_fields=(
+            GoldenField(key="terms.management_fee", value="1.50 %"),
+            GoldenField(key="document.received_at", value="2026-07-07"),
+        ),
+    )
     trace_events = (
         _trace_event(
             source_doc_id="golden-manager-report",
@@ -75,6 +106,17 @@ def test_trace_drift_scores_sampled_langsmith_metadata() -> None:
                 "terms.management_fee": "1.50%",
                 "terms.performance_fee": "15%",
             },
+            ended=False,
+        ),
+        _trace_event(
+            source_doc_id="golden-manager-report",
+            fields={
+                "strategy.name": "Global Multi-Asset Income",
+                "benchmark.name": "Bloomberg US Aggregate",
+                "terms.management_fee": "1.50%",
+                "terms.performance_fee": "15%",
+            },
+            ended=True,
         ),
         _trace_event(
             source_doc_id="golden-credit-review",
@@ -85,23 +127,50 @@ def test_trace_drift_scores_sampled_langsmith_metadata() -> None:
                 "terms.performance_fee": "99%",
             },
         ),
+        _trace_event(
+            source_doc_id="golden-date-fee",
+            fields={
+                "terms.management_fee": "1.5%",
+                "document.received_at": "2026-07-07T13:45:00+00:00",
+            },
+        ),
+        _trace_event(
+            source_doc_id="golden-date-fee",
+            fields={
+                "terms.management_fee": "9.9%",
+                "document.received_at": "2026-07-08",
+            },
+        ),
         _trace_event(source_doc_id="unrelated-doc", fields={"strategy.name": "Ignored"}),
     )
 
     drift = score_trace_drift(
-        samples=samples[:2],
+        samples=(*samples[:2], date_numeric_sample),
         trace_events=trace_events,
         minimum_f1=0.95,
     )
 
-    assert drift.trace_event_count == 3
-    assert drift.matched_trace_count == 2
-    assert drift.report.evaluated_fields == 8
+    assert drift.trace_event_count == 6
+    assert drift.matched_trace_count == 3
+    assert drift.report.evaluated_fields == 10
+    assert drift.report.true_positive_fields == 9
     assert drift.report.mismatched_fields == ("golden-credit-review:terms.performance_fee",)
     assert drift.drift_score > 0.0
 
 
-def _trace_event(*, source_doc_id: str, fields: dict[str, str]) -> TraceEvent:
+class _FailingProvider:
+    name = "failing-provider"
+
+    def extract(self, *, source_doc_id: str, content: bytes) -> NoReturn:
+        raise RuntimeError(f"failed {source_doc_id} with {len(content)} bytes")
+
+
+def _trace_event(
+    *,
+    source_doc_id: str,
+    fields: dict[str, object],
+    ended: bool = True,
+) -> TraceEvent:
     return TraceEvent(
         kind="span",
         span_id=f"span-{source_doc_id}",
@@ -112,5 +181,5 @@ def _trace_event(*, source_doc_id: str, fields: dict[str, str]) -> TraceEvent:
         parent_span_id=None,
         metadata={"source_doc_id": source_doc_id, "fields": fields},
         started_at="2026-07-07T00:00:00+00:00",
-        ended_at="2026-07-07T00:00:01+00:00",
+        ended_at="2026-07-07T00:00:01+00:00" if ended else None,
     )

--- a/tests/extraction/test_extraction_regression.py
+++ b/tests/extraction/test_extraction_regression.py
@@ -1,0 +1,116 @@
+"""Golden-set extraction regression gate and drift metric tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from inv_man_intake.extraction.providers.primary import PrimaryRegexExtractionProvider
+from inv_man_intake.extraction.regression import (
+    GoldenField,
+    GoldenSample,
+    assert_regression_gate,
+    evaluate_extraction_regression,
+    load_golden_samples,
+    score_trace_drift,
+)
+from inv_man_intake.observability.tracing import TraceEvent
+
+_GOLDEN_PATH = Path(__file__).resolve().parent / "golden" / "extraction_regression_golden.json"
+
+
+def test_extraction_matches_golden() -> None:
+    samples = load_golden_samples(_GOLDEN_PATH)
+
+    report = evaluate_extraction_regression(
+        provider_factory=PrimaryRegexExtractionProvider,
+        samples=samples,
+        minimum_f1=0.95,
+    )
+
+    assert report.provider_name == "primary-regex"
+    assert report.evaluated_fields == 12
+    assert report.predicted_fields == 12
+    assert report.true_positive_fields == 12
+    assert report.f1 == 1.0
+    assert report.passes is True
+    assert_regression_gate(report)
+
+
+def test_extraction_regression_gate_fails_on_perturbed_golden_value() -> None:
+    samples = load_golden_samples(_GOLDEN_PATH)
+    perturbed = (
+        GoldenSample(
+            source_doc_id=samples[0].source_doc_id,
+            content=samples[0].content,
+            expected_fields=(
+                GoldenField(key="strategy.name", value="Different Strategy"),
+                *samples[0].expected_fields[1:],
+            ),
+        ),
+        *samples[1:],
+    )
+
+    report = evaluate_extraction_regression(
+        provider_factory=PrimaryRegexExtractionProvider,
+        samples=perturbed,
+        minimum_f1=0.95,
+    )
+
+    assert report.f1 < 0.95
+    assert report.mismatched_fields == ("golden-manager-report:strategy.name",)
+    with pytest.raises(AssertionError, match="extraction regression F1"):
+        assert_regression_gate(report)
+
+
+def test_trace_drift_scores_sampled_langsmith_metadata() -> None:
+    samples = load_golden_samples(_GOLDEN_PATH)
+    trace_events = (
+        _trace_event(
+            source_doc_id="golden-manager-report",
+            fields={
+                "strategy.name": "Global Multi-Asset Income",
+                "benchmark.name": "Bloomberg US Aggregate",
+                "terms.management_fee": "1.50%",
+                "terms.performance_fee": "15%",
+            },
+        ),
+        _trace_event(
+            source_doc_id="golden-credit-review",
+            fields={
+                "strategy.name": "Defensive Credit Alpha",
+                "benchmark.name": "ICE BofA US Corp",
+                "terms.management_fee": "0.95%",
+                "terms.performance_fee": "99%",
+            },
+        ),
+        _trace_event(source_doc_id="unrelated-doc", fields={"strategy.name": "Ignored"}),
+    )
+
+    drift = score_trace_drift(
+        samples=samples[:2],
+        trace_events=trace_events,
+        minimum_f1=0.95,
+    )
+
+    assert drift.trace_event_count == 3
+    assert drift.matched_trace_count == 2
+    assert drift.report.evaluated_fields == 8
+    assert drift.report.mismatched_fields == ("golden-credit-review:terms.performance_fee",)
+    assert drift.drift_score > 0.0
+
+
+def _trace_event(*, source_doc_id: str, fields: dict[str, str]) -> TraceEvent:
+    return TraceEvent(
+        kind="span",
+        span_id=f"span-{source_doc_id}",
+        trace_id="trace-golden",
+        run_id=None,
+        name="extract.fields",
+        parent_run_id=None,
+        parent_span_id=None,
+        metadata={"source_doc_id": source_doc_id, "fields": fields},
+        started_at="2026-07-07T00:00:00+00:00",
+        ended_at="2026-07-07T00:00:01+00:00",
+    )


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:714 -->
> **Source:** Issue #714

Closes #714

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The scoring side has regression fixtures (`src/inv_man_intake/scoring/regression.py`) but there is **no
extraction-accuracy regression gate** and **no drift monitor**, even though the orchestrator already traces
every run and the repo exports to LangSmith (`src/inv_man_intake/observability/langsmith_sink.py`,
`observability/tracing.py`). The field's converged pattern is a CI/PR-time gate (catch regressions before
merge) PAIRED with a production drift monitor (catch new-layout drift) — both fed by a golden set built from
human corrections (`data/provenance.py:23` `CorrectionRecord`). Without it, a provider/model/prompt change can
silently degrade extraction and only surface as analyst pain. Latent gap (not a current break).

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#699](https://github.com/stranske/Inv-Man-Intake/issues/699)
- [#711](https://github.com/stranske/Inv-Man-Intake/issues/711)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] Add `tests/extraction/test_extraction_regression.py` that runs the extraction path over a small committed
  golden set (expected field/value/confidence) and computes per-field precision/recall with numeric/date
  normalization; fail under a threshold.
- [ ] Add a golden fixture dir `tests/extraction/golden/` (seeded from `CorrectionRecord`-style expected values).
- [ ] Add a sampled online drift helper under `observability/` that scores a sample of LangSmith-traced runs
  against the golden set and emits a drift metric (no hard fail; report).

#### Acceptance criteria
- [ ] Named test `tests/extraction/test_extraction_regression.py::test_extraction_matches_golden` passes:
  per-field F1 over the golden set is ≥ the configured threshold.
- [ ] **Deliberate-break gate:** perturb one golden expected value (or inject a known extraction regression);
  the named test **must FAIL** (F1 drops below threshold); revert → passes. Capture both.
- [ ] The drift helper produces a numeric drift score on a sample run (captured in the PR); the PR gate stays
  deterministic (no live network in the unit test).

<!-- auto-status-summary:end -->