### PR TITLE
Add scoring weight sensitivity report

### DIFF
--- a/config/scoring_weights/CHANGELOG.md
+++ b/config/scoring_weights/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Scoring Weight Approval Changelog
+
+Weight files are policy inputs. Any proposed change to `*.toml` weights must add
+an entry here before merge.
+
+## Entry Format
+
+- Date:
+- Asset class:
+- Version:
+- Approved by:
+- Rationale:
+- Sensitivity report:
+- Ranking impact:
+
+## 2026-07-07 - v1 Baseline
+
+- Date: 2026-07-07
+- Asset class: all launch asset classes
+- Version: v1
+- Approved by: initial repo-review baseline
+- Rationale: record the existing deterministic scoring-weight set as the governance baseline.
+- Sensitivity report: not applicable; no weight values changed.
+- Ranking impact: none.

--- a/src/inv_man_intake/scoring/__init__.py
+++ b/src/inv_man_intake/scoring/__init__.py
@@ -33,6 +33,11 @@ from inv_man_intake.scoring.regression import (
     detect_score_drift,
     rank_by_asset_class,
 )
+from inv_man_intake.scoring.weight_sensitivity import (
+    WeightSensitivityReport,
+    WeightSensitivityRow,
+    weight_sensitivity_report,
+)
 from inv_man_intake.scoring.weights import (
     ASSET_CLASS_ALIASES,
     COMPONENT_NAMES,
@@ -64,6 +69,8 @@ __all__ = [
     "ScoreEntry",
     "ScoreResult",
     "ScoreSubmission",
+    "WeightSensitivityReport",
+    "WeightSensitivityRow",
     "build_explainability_payload",
     "build_calibration_stats",
     "compute_score",
@@ -76,4 +83,5 @@ __all__ = [
     "percentile_rank",
     "rank_by_asset_class",
     "weights_by_asset_class_for",
+    "weight_sensitivity_report",
 ]

--- a/src/inv_man_intake/scoring/weight_sensitivity.py
+++ b/src/inv_man_intake/scoring/weight_sensitivity.py
@@ -1,0 +1,147 @@
+"""Weight-sensitivity reporting for deterministic manager scoring."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from types import MappingProxyType
+
+from inv_man_intake.scoring.contracts import ScoreSubmission
+from inv_man_intake.scoring.engine import compute_score
+from inv_man_intake.scoring.weights import (
+    COMPONENT_NAMES,
+    normalize_asset_class,
+    weights_for_registry,
+)
+
+
+@dataclass(frozen=True)
+class WeightSensitivityRow:
+    """One manager's baseline and perturbed rank/score movement."""
+
+    manager_id: str
+    baseline_score: float
+    perturbed_score: float
+    baseline_rank: int
+    perturbed_rank: int
+    rank_delta: int
+    score_delta: float
+
+
+@dataclass(frozen=True)
+class WeightSensitivityReport:
+    """Deterministic report for one asset-class weight perturbation."""
+
+    asset_class: str
+    baseline_weights: Mapping[str, float]
+    perturbed_weights: Mapping[str, float]
+    rows: tuple[WeightSensitivityRow, ...]
+
+
+def weight_sensitivity_report(
+    cohort: Sequence[ScoreSubmission],
+    asset_class: str,
+    perturbation: Mapping[str, float],
+) -> WeightSensitivityReport:
+    """Re-score a cohort under perturbed weights and report ranking deltas.
+
+    ``perturbation`` values are additive deltas applied to the canonical registry weight set.
+    The resulting positive weights are then renormalized to sum to 1. Runtime scoring weights
+    are not changed.
+    """
+
+    canonical_asset_class = normalize_asset_class(asset_class)
+    if not cohort:
+        raise ValueError("cohort must contain at least one submission")
+    if not perturbation:
+        raise ValueError("perturbation must contain at least one component delta")
+
+    registry_weights = weights_for_registry()
+    baseline_weights = dict(registry_weights[canonical_asset_class])
+    perturbed_weights = _perturbed_weight_set(baseline_weights, perturbation)
+
+    selected = _select_cohort(cohort, canonical_asset_class)
+    baseline_scores = {
+        submission.manager_id: compute_score(
+            submission, weights_by_asset_class=registry_weights
+        ).final_score
+        for submission in selected
+    }
+    perturbed_registry = dict(registry_weights)
+    perturbed_registry[canonical_asset_class] = perturbed_weights
+    perturbed_scores = {
+        submission.manager_id: compute_score(
+            submission, weights_by_asset_class=perturbed_registry
+        ).final_score
+        for submission in selected
+    }
+
+    baseline_ranks = _rank_scores(baseline_scores)
+    perturbed_ranks = _rank_scores(perturbed_scores)
+    rows = tuple(
+        WeightSensitivityRow(
+            manager_id=manager_id,
+            baseline_score=baseline_scores[manager_id],
+            perturbed_score=perturbed_scores[manager_id],
+            baseline_rank=baseline_ranks[manager_id],
+            perturbed_rank=perturbed_ranks[manager_id],
+            rank_delta=baseline_ranks[manager_id] - perturbed_ranks[manager_id],
+            score_delta=round(perturbed_scores[manager_id] - baseline_scores[manager_id], 6),
+        )
+        for manager_id in sorted(baseline_scores, key=lambda value: baseline_ranks[value])
+    )
+    return WeightSensitivityReport(
+        asset_class=canonical_asset_class,
+        baseline_weights=MappingProxyType(baseline_weights),
+        perturbed_weights=MappingProxyType(perturbed_weights),
+        rows=rows,
+    )
+
+
+def _select_cohort(
+    cohort: Sequence[ScoreSubmission], canonical_asset_class: str
+) -> tuple[ScoreSubmission, ...]:
+    selected = tuple(
+        submission
+        for submission in cohort
+        if normalize_asset_class(submission.asset_class) == canonical_asset_class
+    )
+    if not selected:
+        raise ValueError(
+            f"cohort contains no submissions for asset class {canonical_asset_class!r}"
+        )
+
+    manager_ids = [submission.manager_id for submission in selected]
+    duplicates = sorted(
+        {manager_id for manager_id in manager_ids if manager_ids.count(manager_id) > 1}
+    )
+    if duplicates:
+        raise ValueError(f"cohort contains duplicate manager_id(s): {', '.join(duplicates)}")
+    return selected
+
+
+def _perturbed_weight_set(
+    baseline_weights: Mapping[str, float], perturbation: Mapping[str, float]
+) -> dict[str, float]:
+    unknown = sorted(set(perturbation) - set(COMPONENT_NAMES))
+    if unknown:
+        raise ValueError(f"unknown perturbation component(s): {', '.join(unknown)}")
+
+    adjusted = dict(baseline_weights)
+    for component, delta in perturbation.items():
+        if not isinstance(delta, int | float) or not math.isfinite(delta):
+            raise ValueError(f"perturbation {component} must be finite numeric")
+        adjusted[component] += float(delta)
+        if adjusted[component] < 0.0:
+            raise ValueError(f"perturbation makes {component} negative")
+
+    total = sum(adjusted.values())
+    if total <= 0.0:
+        raise ValueError("perturbed weights must have a positive total")
+    return {component: round(adjusted[component] / total, 12) for component in COMPONENT_NAMES}
+
+
+def _rank_scores(scores: Mapping[str, float]) -> dict[str, int]:
+    ordered = sorted(scores.items(), key=lambda item: (-item[1], item[0]))
+    return {manager_id: index + 1 for index, (manager_id, _) in enumerate(ordered)}

--- a/src/inv_man_intake/scoring/weight_sensitivity.py
+++ b/src/inv_man_intake/scoring/weight_sensitivity.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import math
+from collections import Counter
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from types import MappingProxyType
@@ -112,10 +113,8 @@ def _select_cohort(
             f"cohort contains no submissions for asset class {canonical_asset_class!r}"
         )
 
-    manager_ids = [submission.manager_id for submission in selected]
-    duplicates = sorted(
-        {manager_id for manager_id in manager_ids if manager_ids.count(manager_id) > 1}
-    )
+    manager_counts = Counter(submission.manager_id for submission in selected)
+    duplicates = sorted(manager_id for manager_id, count in manager_counts.items() if count > 1)
     if duplicates:
         raise ValueError(f"cohort contains duplicate manager_id(s): {', '.join(duplicates)}")
     return selected

--- a/tests/scoring/test_weight_sensitivity.py
+++ b/tests/scoring/test_weight_sensitivity.py
@@ -1,0 +1,80 @@
+"""Tests for weight sensitivity reporting."""
+
+from __future__ import annotations
+
+import pytest
+
+from inv_man_intake.scoring.contracts import ScoreComponent, ScoreSubmission
+from inv_man_intake.scoring.weight_sensitivity import weight_sensitivity_report
+
+
+def _submission(
+    manager_id: str,
+    *,
+    performance_consistency: float,
+    risk_adjusted_returns: float,
+    operational_quality: float = 0.50,
+    transparency: float = 0.50,
+    team_experience: float = 0.50,
+) -> ScoreSubmission:
+    return ScoreSubmission(
+        manager_id=manager_id,
+        asset_class="equity_market_neutral",
+        components=(
+            ScoreComponent("performance_consistency", performance_consistency),
+            ScoreComponent("risk_adjusted_returns", risk_adjusted_returns),
+            ScoreComponent("operational_quality", operational_quality),
+            ScoreComponent("transparency", transparency),
+            ScoreComponent("team_experience", team_experience),
+        ),
+    )
+
+
+def test_perturbation_changes_ranking_deterministically() -> None:
+    cohort = (
+        _submission("steady_performer", performance_consistency=0.90, risk_adjusted_returns=0.40),
+        _submission("return_leader", performance_consistency=0.60, risk_adjusted_returns=0.75),
+        _submission("balanced_peer", performance_consistency=0.70, risk_adjusted_returns=0.55),
+    )
+
+    report = weight_sensitivity_report(
+        cohort,
+        "equity",
+        {"risk_adjusted_returns": 0.05},
+    )
+
+    assert report.asset_class == "equity_market_neutral"
+    assert sum(report.perturbed_weights.values()) == pytest.approx(1.0)
+    assert (
+        report.perturbed_weights["risk_adjusted_returns"]
+        > report.baseline_weights["risk_adjusted_returns"]
+    )
+
+    rows = {row.manager_id: row for row in report.rows}
+    assert rows["steady_performer"].baseline_rank == 1
+    assert rows["steady_performer"].perturbed_rank == 2
+    assert rows["steady_performer"].rank_delta == -1
+    assert rows["return_leader"].baseline_rank == 2
+    assert rows["return_leader"].perturbed_rank == 1
+    assert rows["return_leader"].rank_delta == 1
+    assert rows["return_leader"].score_delta > rows["steady_performer"].score_delta
+    assert [row.manager_id for row in report.rows] == [
+        "steady_performer",
+        "return_leader",
+        "balanced_peer",
+    ]
+
+
+def test_unknown_perturbation_component_is_rejected() -> None:
+    with pytest.raises(ValueError, match="unknown perturbation component"):
+        weight_sensitivity_report(
+            (
+                _submission(
+                    "steady_performer",
+                    performance_consistency=0.90,
+                    risk_adjusted_returns=0.45,
+                ),
+            ),
+            "equity_market_neutral",
+            {"unknown_component": 0.05},
+        )

--- a/tests/scoring/test_weight_sensitivity.py
+++ b/tests/scoring/test_weight_sensitivity.py
@@ -78,3 +78,19 @@ def test_unknown_perturbation_component_is_rejected() -> None:
             "equity_market_neutral",
             {"unknown_component": 0.05},
         )
+
+
+def test_duplicate_manager_ids_are_reported_deterministically() -> None:
+    cohort = (
+        _submission("zeta", performance_consistency=0.90, risk_adjusted_returns=0.45),
+        _submission("alpha", performance_consistency=0.85, risk_adjusted_returns=0.50),
+        _submission("zeta", performance_consistency=0.80, risk_adjusted_returns=0.55),
+        _submission("alpha", performance_consistency=0.75, risk_adjusted_returns=0.60),
+    )
+
+    with pytest.raises(ValueError, match=r"cohort contains duplicate manager_id\(s\): alpha, zeta"):
+        weight_sensitivity_report(
+            cohort,
+            "equity_market_neutral",
+            {"risk_adjusted_returns": 0.05},
+        )


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:716 -->
> **Source:** Issue #716

Closes #716

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Scoring weights are per-asset-class TOML with a `version` field and sum-to-1 validation
(`config/scoring_weights/*.toml`, `src/inv_man_intake/scoring/weights.py`) — good. But since the score IS the
decision artifact, **weight changes are policy changes**, and there is no tooling to (a) answer "how does the
ranking change if `risk_adjusted_returns` moves +0.05?" or (b) record who approved a weight change and what
re-ranked. This is only *possible* because scoring is deterministic (it reuses the engine over a cohort with
perturbed weights). Latent governance gap.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#699](https://github.com/stranske/Inv-Man-Intake/issues/699)
- [#710](https://github.com/stranske/Inv-Man-Intake/issues/710)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] Add `src/inv_man_intake/scoring/weight_sensitivity.py::weight_sensitivity_report(cohort, asset_class,
  perturbation)` that re-scores the cohort with perturbed weights (renormalized to sum 1) and returns ranking
  deltas vs the baseline weights.
- [ ] Add a `CHANGELOG`/`approved_by` convention to the weight TOMLs (or a sibling `scoring_weights/CHANGELOG.md`).
- [ ] Add `tests/scoring/test_weight_sensitivity.py::test_perturbation_changes_ranking_deterministically`.

#### Acceptance criteria
- [ ] Named test `test_perturbation_changes_ranking_deterministically` passes: a seeded 3-manager cohort
  re-scored with a +0.05 perturbation to one component yields the documented (deterministic) ranking delta.
- [ ] **Deliberate-break gate:** make the report ignore the perturbation (use baseline weights); the named test
  **must FAIL** (no ranking delta); revert → passes. Capture both.
- [ ] `pytest tests/scoring/ -q` green.

<!-- auto-status-summary:end -->