### PR TITLE
Add observability extraction drift record

### DIFF
--- a/src/inv_man_intake/extraction/regression.py
+++ b/src/inv_man_intake/extraction/regression.py
@@ -318,6 +318,8 @@ def _normalize_decimal(value: Decimal) -> str:
 def _optional_confidence(value: Any) -> float | None:
     if value is None:
         return None
+    if isinstance(value, bool):
+        raise ValueError("golden field confidence must be numeric")
     confidence = float(value)
     if not 0.0 <= confidence <= 1.0:
         raise ValueError("golden field confidence must be between 0 and 1")

--- a/src/inv_man_intake/extraction/regression.py
+++ b/src/inv_man_intake/extraction/regression.py
@@ -21,6 +21,7 @@ class GoldenField:
 
     key: str
     value: str
+    confidence: float | None = None
 
 
 @dataclass(frozen=True)
@@ -101,7 +102,11 @@ def load_golden_samples(path: Path) -> tuple[GoldenSample, ...]:
             )
         else:
             expected_fields = tuple(
-                GoldenField(key=str(field["key"]), value=str(field["value"]))
+                GoldenField(
+                    key=str(field["key"]),
+                    value=str(field["value"]),
+                    confidence=_optional_confidence(field.get("confidence")),
+                )
                 for field in expected_payload
             )
         samples.append(
@@ -308,3 +313,12 @@ def _normalize_decimal(value: Decimal) -> str:
     if normalized == normalized.to_integral():
         return str(normalized.quantize(Decimal("1")))
     return format(normalized, "f")
+
+
+def _optional_confidence(value: Any) -> float | None:
+    if value is None:
+        return None
+    confidence = float(value)
+    if not 0.0 <= confidence <= 1.0:
+        raise ValueError("golden field confidence must be between 0 and 1")
+    return confidence

--- a/src/inv_man_intake/observability/__init__.py
+++ b/src/inv_man_intake/observability/__init__.py
@@ -1,6 +1,7 @@
 """Observability utilities for trace and metric instrumentation."""
 
 from .entrypoints import PipelineEntrypoint, audit_intake_extraction_entrypoints
+from .extraction_drift import ExtractionDriftRecord, score_extraction_trace_drift
 from .langsmith_fleet import (
     ARTIFACT_NAME,
     DEFAULT_PROJECT,
@@ -58,6 +59,7 @@ from .tracing import (
 __all__ = [
     "CORRELATION_ID_KEY",
     "ESCALATION_COUNT",
+    "ExtractionDriftRecord",
     "FAILURE_COUNT",
     "FALLBACK_COUNT",
     "InMemoryMetrics",
@@ -98,6 +100,7 @@ __all__ = [
     "inject_trace_context",
     "new_correlation_id",
     "new_trace_context",
+    "score_extraction_trace_drift",
     "traced_run",
     "traced_span",
     "tracing_enabled_from_env",

--- a/src/inv_man_intake/observability/__init__.py
+++ b/src/inv_man_intake/observability/__init__.py
@@ -1,7 +1,8 @@
 """Observability utilities for trace and metric instrumentation."""
 
+from typing import TYPE_CHECKING
+
 from .entrypoints import PipelineEntrypoint, audit_intake_extraction_entrypoints
-from .extraction_drift import ExtractionDriftRecord, score_extraction_trace_drift
 from .langsmith_fleet import (
     ARTIFACT_NAME,
     DEFAULT_PROJECT,
@@ -55,6 +56,22 @@ from .tracing import (
     traced_span,
     tracing_enabled_from_env,
 )
+
+if TYPE_CHECKING:
+    from .extraction_drift import ExtractionDriftRecord
+
+
+def __getattr__(name: str) -> object:
+    if name in {"ExtractionDriftRecord", "score_extraction_trace_drift"}:
+        from .extraction_drift import ExtractionDriftRecord, score_extraction_trace_drift
+
+        exports = {
+            "ExtractionDriftRecord": ExtractionDriftRecord,
+            "score_extraction_trace_drift": score_extraction_trace_drift,
+        }
+        return exports[name]
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 __all__ = [
     "CORRELATION_ID_KEY",

--- a/src/inv_man_intake/observability/extraction_drift.py
+++ b/src/inv_man_intake/observability/extraction_drift.py
@@ -1,0 +1,78 @@
+"""Observability-facing extraction drift reports over traced extraction metadata."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+from inv_man_intake.extraction.regression import (
+    DriftScore,
+    GoldenSample,
+    score_trace_drift,
+)
+from inv_man_intake.observability.tracing import TraceEvent
+
+
+@dataclass(frozen=True)
+class ExtractionDriftRecord:
+    """Numeric drift report safe to emit as an observability artifact."""
+
+    provider_name: str
+    trace_event_count: int
+    matched_trace_count: int
+    evaluated_fields: int
+    true_positive_fields: int
+    f1: float
+    drift_score: float
+    mismatched_fields: tuple[str, ...]
+    missing_fields: tuple[str, ...]
+
+    @property
+    def status(self) -> str:
+        return "pass" if self.drift_score == 0.0 else "drift"
+
+    def as_metric_fields(self) -> dict[str, int | float | str]:
+        """Return stable scalar fields for metrics, logs, and PR evidence comments."""
+
+        return {
+            "provider_name": self.provider_name,
+            "trace_event_count": self.trace_event_count,
+            "matched_trace_count": self.matched_trace_count,
+            "evaluated_fields": self.evaluated_fields,
+            "true_positive_fields": self.true_positive_fields,
+            "f1": self.f1,
+            "drift_score": self.drift_score,
+            "status": self.status,
+        }
+
+
+def score_extraction_trace_drift(
+    *,
+    samples: tuple[GoldenSample, ...],
+    trace_events: Iterable[TraceEvent],
+    minimum_f1: float,
+    provider_name: str = "langsmith-trace-sample",
+) -> ExtractionDriftRecord:
+    """Score sampled LangSmith trace metadata and return a numeric drift record."""
+
+    score = score_trace_drift(
+        samples=samples,
+        trace_events=trace_events,
+        minimum_f1=minimum_f1,
+        provider_name=provider_name,
+    )
+    return _record_from_score(score)
+
+
+def _record_from_score(score: DriftScore) -> ExtractionDriftRecord:
+    return ExtractionDriftRecord(
+        provider_name=score.report.provider_name,
+        trace_event_count=score.trace_event_count,
+        matched_trace_count=score.matched_trace_count,
+        evaluated_fields=score.report.evaluated_fields,
+        true_positive_fields=score.report.true_positive_fields,
+        f1=score.report.f1,
+        drift_score=score.drift_score,
+        mismatched_fields=score.report.mismatched_fields,
+        missing_fields=score.report.missing_fields,
+    )

--- a/src/inv_man_intake/observability/extraction_drift.py
+++ b/src/inv_man_intake/observability/extraction_drift.py
@@ -55,6 +55,9 @@ def score_extraction_trace_drift(
 ) -> ExtractionDriftRecord:
     """Score sampled LangSmith trace metadata and return a numeric drift record."""
 
+    if not 0.0 <= minimum_f1 <= 1.0:
+        raise ValueError("minimum_f1 must be between 0 and 1")
+
     score = score_trace_drift(
         samples=samples,
         trace_events=trace_events,

--- a/tests/extraction/golden/extraction_regression_golden.json
+++ b/tests/extraction/golden/extraction_regression_golden.json
@@ -3,32 +3,32 @@
     {
       "source_doc_id": "golden-manager-report",
       "content": "Strategy: Global Multi-Asset Income\nBenchmark: Bloomberg US Aggregate\nManagement Fee: 1.50%\nPerformance Fee: 15%\nTable Snapshot\nYear Return AUM\n2023 8.1 100",
-      "expected_fields": {
-        "strategy.name": "Global Multi-Asset Income",
-        "benchmark.name": "Bloomberg US Aggregate",
-        "terms.management_fee": "1.50%",
-        "terms.performance_fee": "15%"
-      }
+      "expected_fields": [
+        {"key": "strategy.name", "value": "Global Multi-Asset Income", "confidence": 0.93},
+        {"key": "benchmark.name", "value": "Bloomberg US Aggregate", "confidence": 0.91},
+        {"key": "terms.management_fee", "value": "1.50%", "confidence": 0.89},
+        {"key": "terms.performance_fee", "value": "15%", "confidence": 0.86}
+      ]
     },
     {
       "source_doc_id": "golden-credit-review",
       "content": "STRATEGY - Defensive Credit Alpha\nBENCHMARK - ICE BofA US Corp\nmanagement fee : 0.95%\nPerformance Fee: 12%\n(ocr artifacts and line breaks)",
-      "expected_fields": {
-        "strategy.name": "Defensive Credit Alpha",
-        "benchmark.name": "ICE BofA US Corp",
-        "terms.management_fee": "0.95%",
-        "terms.performance_fee": "12%"
-      }
+      "expected_fields": [
+        {"key": "strategy.name", "value": "Defensive Credit Alpha", "confidence": 0.94},
+        {"key": "benchmark.name", "value": "ICE BofA US Corp", "confidence": 0.88},
+        {"key": "terms.management_fee", "value": "0.95%", "confidence": 0.87},
+        {"key": "terms.performance_fee", "value": "12%", "confidence": 0.84}
+      ]
     },
     {
       "source_doc_id": "golden-slide-update",
       "content": "Fund update slide\nBenchmark: MSCI ACWI\nStrategy: Global Equity Long Short\nManagement Fee-2.00%\nPerformance Fee-20%\nImage callout: portfolio contributors",
-      "expected_fields": {
-        "strategy.name": "Global Equity Long Short",
-        "benchmark.name": "MSCI ACWI",
-        "terms.management_fee": "2.00%",
-        "terms.performance_fee": "20%"
-      }
+      "expected_fields": [
+        {"key": "strategy.name", "value": "Global Equity Long Short", "confidence": 0.92},
+        {"key": "benchmark.name", "value": "MSCI ACWI", "confidence": 0.9},
+        {"key": "terms.management_fee", "value": "2.00%", "confidence": 0.88},
+        {"key": "terms.performance_fee", "value": "20%", "confidence": 0.85}
+      ]
     }
   ]
 }

--- a/tests/extraction/test_extraction_regression.py
+++ b/tests/extraction/test_extraction_regression.py
@@ -24,7 +24,13 @@ _GOLDEN_PATH = Path(__file__).resolve().parent / "golden" / "extraction_regressi
 def test_extraction_matches_golden() -> None:
     samples = load_golden_samples(_GOLDEN_PATH)
 
-    assert samples[0].expected_fields[0].confidence == 0.93
+    manager_report = next(
+        sample for sample in samples if sample.source_doc_id == "golden-manager-report"
+    )
+    strategy_field = next(
+        field for field in manager_report.expected_fields if field.key == "strategy.name"
+    )
+    assert strategy_field.confidence == 0.93
 
     report = evaluate_extraction_regression(
         provider_factory=PrimaryRegexExtractionProvider,
@@ -87,6 +93,29 @@ def test_extraction_regression_reports_provider_failures_as_missing_fields() -> 
         "golden-manager-report:terms.performance_fee",
     )
     assert report.f1 == 0.0
+
+
+def test_load_golden_samples_rejects_boolean_confidence(tmp_path: Path) -> None:
+    golden_path = tmp_path / "golden.json"
+    golden_path.write_text(
+        """
+        {
+          "samples": [
+            {
+              "source_doc_id": "bad-confidence",
+              "content": "sample",
+              "expected_fields": [
+                {"key": "strategy.name", "value": "Example", "confidence": true}
+              ]
+            }
+          ]
+        }
+        """,
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="confidence must be numeric"):
+        load_golden_samples(golden_path)
 
 
 def test_trace_drift_scores_sampled_langsmith_metadata() -> None:

--- a/tests/extraction/test_extraction_regression.py
+++ b/tests/extraction/test_extraction_regression.py
@@ -24,6 +24,8 @@ _GOLDEN_PATH = Path(__file__).resolve().parent / "golden" / "extraction_regressi
 def test_extraction_matches_golden() -> None:
     samples = load_golden_samples(_GOLDEN_PATH)
 
+    assert samples[0].expected_fields[0].confidence == 0.93
+
     report = evaluate_extraction_regression(
         provider_factory=PrimaryRegexExtractionProvider,
         samples=samples,

--- a/tests/observability/test_extraction_drift.py
+++ b/tests/observability/test_extraction_drift.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from inv_man_intake.extraction.regression import load_golden_samples
 from inv_man_intake.observability.extraction_drift import score_extraction_trace_drift
 from inv_man_intake.observability.tracing import TraceEvent
@@ -54,6 +56,17 @@ def test_score_extraction_trace_drift_returns_numeric_observability_record() -> 
     assert record.drift_score == 0.125
     assert record.status == "drift"
     assert record.as_metric_fields()["drift_score"] == 0.125
+
+
+def test_score_extraction_trace_drift_validates_minimum_f1() -> None:
+    samples = load_golden_samples(_GOLDEN_PATH)
+
+    with pytest.raises(ValueError, match="minimum_f1 must be between 0 and 1"):
+        score_extraction_trace_drift(
+            samples=samples[:1],
+            trace_events=(),
+            minimum_f1=1.1,
+        )
 
 
 def _trace_event(*, source_doc_id: str, fields: dict[str, object]) -> TraceEvent:

--- a/tests/observability/test_extraction_drift.py
+++ b/tests/observability/test_extraction_drift.py
@@ -1,0 +1,71 @@
+"""Tests for observability-owned extraction drift records."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from inv_man_intake.extraction.regression import load_golden_samples
+from inv_man_intake.observability.extraction_drift import score_extraction_trace_drift
+from inv_man_intake.observability.tracing import TraceEvent
+
+_GOLDEN_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "extraction"
+    / "golden"
+    / "extraction_regression_golden.json"
+)
+
+
+def test_score_extraction_trace_drift_returns_numeric_observability_record() -> None:
+    samples = load_golden_samples(_GOLDEN_PATH)
+    trace_events = (
+        _trace_event(
+            source_doc_id="golden-manager-report",
+            fields={
+                "strategy.name": "Global Multi-Asset Income",
+                "benchmark.name": "Bloomberg US Aggregate",
+                "terms.management_fee": "1.50%",
+                "terms.performance_fee": "15%",
+            },
+        ),
+        _trace_event(
+            source_doc_id="golden-credit-review",
+            fields={
+                "strategy.name": "Defensive Credit Alpha",
+                "benchmark.name": "ICE BofA US Corp",
+                "terms.management_fee": "0.95%",
+                "terms.performance_fee": "99%",
+            },
+        ),
+    )
+
+    record = score_extraction_trace_drift(
+        samples=samples[:2],
+        trace_events=trace_events,
+        minimum_f1=0.95,
+    )
+
+    assert record.provider_name == "langsmith-trace-sample"
+    assert record.trace_event_count == 2
+    assert record.matched_trace_count == 2
+    assert record.evaluated_fields == 8
+    assert record.true_positive_fields == 7
+    assert record.mismatched_fields == ("golden-credit-review:terms.performance_fee",)
+    assert record.drift_score == 0.125
+    assert record.status == "drift"
+    assert record.as_metric_fields()["drift_score"] == 0.125
+
+
+def _trace_event(*, source_doc_id: str, fields: dict[str, object]) -> TraceEvent:
+    return TraceEvent(
+        kind="span",
+        span_id=f"span-{source_doc_id}",
+        trace_id="trace-golden",
+        run_id=None,
+        name="extract.fields",
+        parent_run_id=None,
+        parent_span_id=None,
+        metadata={"source_doc_id": source_doc_id, "fields": fields},
+        started_at="2026-07-07T00:00:00+00:00",
+        ended_at="2026-07-07T00:00:01+00:00",
+    )


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:714 -->
> **Source:** Issue #714

Closes #714

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The scoring side has regression fixtures (`src/inv_man_intake/scoring/regression.py`) but there is **no
extraction-accuracy regression gate** and **no drift monitor**, even though the orchestrator already traces
every run and the repo exports to LangSmith (`src/inv_man_intake/observability/langsmith_sink.py`,
`observability/tracing.py`). The field's converged pattern is a CI/PR-time gate (catch regressions before
merge) PAIRED with a production drift monitor (catch new-layout drift) — both fed by a golden set built from
human corrections (`data/provenance.py:23` `CorrectionRecord`). Without it, a provider/model/prompt change can
silently degrade extraction and only surface as analyst pain. Latent gap (not a current break).

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#699](https://github.com/stranske/Inv-Man-Intake/issues/699)
- [#711](https://github.com/stranske/Inv-Man-Intake/issues/711)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] Add `tests/extraction/test_extraction_regression.py` that runs the extraction path over a small committed
  golden set (expected field/value/confidence) and computes per-field precision/recall with numeric/date
  normalization; fail under a threshold.
- [ ] Add a golden fixture dir `tests/extraction/golden/` (seeded from `CorrectionRecord`-style expected values).
- [ ] Add a sampled online drift helper under `observability/` that scores a sample of LangSmith-traced runs
  against the golden set and emits a drift metric (no hard fail; report).

#### Acceptance criteria
- [ ] Named test `tests/extraction/test_extraction_regression.py::test_extraction_matches_golden` passes:
  per-field F1 over the golden set is ≥ the configured threshold.
- [ ] **Deliberate-break gate:** perturb one golden expected value (or inject a known extraction regression);
  the named test **must FAIL** (F1 drops below threshold); revert → passes. Capture both.
- [ ] The drift helper produces a numeric drift score on a sample run (captured in the PR); the PR gate stays
  deterministic (no live network in the unit test).

<!-- auto-status-summary:end -->