### PR TITLE
Add document-type threshold profiles

### DIFF
--- a/config/extraction_thresholds.yaml
+++ b/config/extraction_thresholds.yaml
@@ -7,3 +7,35 @@ mandatory_fields:
   - terms.management_fee
   - performance.net_return_1y
   - operations.aum
+document_profiles:
+  pitchbook:
+    key_fields:
+      - terms.management_fee
+      - performance.net_return_1y
+      - operations.aum
+    mandatory_fields:
+      - terms.management_fee
+      - performance.net_return_1y
+      - operations.aum
+  tear_sheet:
+    key_fields:
+      - performance.net_return_1y
+      - operations.aum
+    document_key_field_coverage_min: 1.0
+    mandatory_fields:
+      - operations.aum
+  monthly_letter:
+    key_fields:
+      - performance.net_return_1y
+      - commentary.market_update
+    document_key_field_coverage_min: 0.5
+    mandatory_fields:
+      - performance.net_return_1y
+  ddq:
+    key_fields:
+      - terms.management_fee
+      - operations.aum
+      - operations.inception_date
+    mandatory_fields:
+      - terms.management_fee
+      - operations.aum

--- a/src/inv_man_intake/extraction/__init__.py
+++ b/src/inv_man_intake/extraction/__init__.py
@@ -1,11 +1,13 @@
 """Extraction contracts and provider implementations."""
 
 from inv_man_intake.extraction.confidence import (
+    DocumentThresholdProfile,
     ThresholdConfig,
     ThresholdDecision,
     attach_threshold_summary,
     evaluate_thresholds,
     load_threshold_config,
+    select_threshold_profile,
 )
 from inv_man_intake.extraction.cross_check import (
     CrossCheckReport,
@@ -15,6 +17,7 @@ from inv_man_intake.extraction.cross_check import (
     cross_check_extraction_results,
     cross_check_observations,
 )
+from inv_man_intake.extraction.doc_type import DocumentType, classify_doc_type
 from inv_man_intake.extraction.orchestrator import (
     ExtractionFailedError,
     ExtractionOrchestrator,
@@ -30,12 +33,16 @@ __all__ = [
     "FieldObservation",
     "OrchestrationResult",
     "RetryPolicy",
+    "DocumentThresholdProfile",
+    "DocumentType",
     "ThresholdConfig",
     "ThresholdDecision",
     "attach_threshold_summary",
+    "classify_doc_type",
     "create_cross_check_queue_item",
     "cross_check_extraction_results",
     "cross_check_observations",
     "evaluate_thresholds",
     "load_threshold_config",
+    "select_threshold_profile",
 ]

--- a/src/inv_man_intake/extraction/confidence.py
+++ b/src/inv_man_intake/extraction/confidence.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import math
 from collections.abc import Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from dataclasses import field as dataclass_field
 from pathlib import Path
 
@@ -58,6 +58,7 @@ def load_threshold_config(path: str | Path) -> ThresholdConfig:
     profile_values: dict[str, dict[str, str]] = {}
     profile_key_fields: dict[str, list[str]] = {}
     profile_mandatory_fields: dict[str, list[str]] = {}
+    profile_lists_seen: dict[str, set[str]] = {}
 
     for raw_line in lines:
         line_without_comment = raw_line.split("#", 1)[0].rstrip()
@@ -83,11 +84,13 @@ def load_threshold_config(path: str | Path) -> ThresholdConfig:
                 profile_values.setdefault(profile_name, {})
                 profile_key_fields.setdefault(profile_name, [])
                 profile_mandatory_fields.setdefault(profile_name, [])
+                profile_lists_seen.setdefault(profile_name, set())
                 profile_list_name = None
                 continue
             elif indent == 4 and profile_name is not None:
                 if line in {"key_fields:", "mandatory_fields:"}:
                     profile_list_name = line.removesuffix(":")
+                    profile_lists_seen[profile_name].add(profile_list_name)
                     continue
                 if ":" in line:
                     profile_list_name = None
@@ -104,6 +107,7 @@ def load_threshold_config(path: str | Path) -> ThresholdConfig:
                         )
                     profile_values[profile_name][normalized_key] = value.strip().strip('"')
                     continue
+                raise ValueError(f"unexpected line in document profile {profile_name}: {line!r}")
             elif indent == 6 and line.startswith("-") and profile_name is not None:
                 value = line.removeprefix("-").strip().strip('"')
                 if profile_list_name == "key_fields":
@@ -113,6 +117,8 @@ def load_threshold_config(path: str | Path) -> ThresholdConfig:
                     profile_mandatory_fields[profile_name].append(value)
                     continue
                 raise ValueError(f"unexpected list item in document profile {profile_name}")
+            elif indent != 0:
+                raise ValueError(f"unexpected indentation in document_profiles: {raw_line!r}")
         if line == "mandatory_fields:":
             in_mandatory_list = True
             continue
@@ -159,18 +165,12 @@ def load_threshold_config(path: str | Path) -> ThresholdConfig:
             values=profile_values[name],
             key_fields=tuple(profile_key_fields[name]),
             mandatory_fields=tuple(profile_mandatory_fields[name]),
+            has_mandatory_fields="mandatory_fields" in profile_lists_seen.get(name, set()),
             base_config=base_config,
         )
         for name in profile_values
     }
-    return ThresholdConfig(
-        field_auto_accept_min=base_config.field_auto_accept_min,
-        key_field_confidence_min=base_config.key_field_confidence_min,
-        document_key_field_coverage_min=base_config.document_key_field_coverage_min,
-        mandatory_field_min=base_config.mandatory_field_min,
-        mandatory_fields=base_config.mandatory_fields,
-        document_profiles=profiles,
-    )
+    return replace(base_config, document_profiles=profiles)
 
 
 def _document_profile(
@@ -179,6 +179,7 @@ def _document_profile(
     values: dict[str, str],
     key_fields: tuple[str, ...],
     mandatory_fields: tuple[str, ...],
+    has_mandatory_fields: bool,
     base_config: ThresholdConfig,
 ) -> DocumentThresholdProfile:
     if not key_fields:
@@ -200,7 +201,9 @@ def _document_profile(
                 "document_key_field_coverage_min", merged_values
             ),
             mandatory_field_min=_threshold_value("mandatory_field_min", merged_values),
-            mandatory_fields=mandatory_fields,
+            mandatory_fields=(
+                mandatory_fields if has_mandatory_fields else base_config.mandatory_fields
+            ),
         ),
     )
 

--- a/src/inv_man_intake/extraction/confidence.py
+++ b/src/inv_man_intake/extraction/confidence.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 import math
+from collections.abc import Mapping
 from dataclasses import dataclass
+from dataclasses import field as dataclass_field
 from pathlib import Path
 
+from inv_man_intake.extraction.doc_type import DocumentType
 from inv_man_intake.extraction.providers.base import ExtractedDocumentResult, ExtractedField
 
 
@@ -18,6 +21,17 @@ class ThresholdConfig:
     document_key_field_coverage_min: float
     mandatory_field_min: float
     mandatory_fields: tuple[str, ...]
+    document_profiles: Mapping[str, DocumentThresholdProfile] = dataclass_field(
+        default_factory=dict
+    )
+
+
+@dataclass(frozen=True)
+class DocumentThresholdProfile:
+    """Document-type-specific expected-field and confidence policy overrides."""
+
+    key_fields: tuple[str, ...]
+    config: ThresholdConfig
 
 
 @dataclass(frozen=True)
@@ -38,11 +52,67 @@ def load_threshold_config(path: str | Path) -> ThresholdConfig:
     values: dict[str, str] = {}
     mandatory_fields: list[str] = []
     in_mandatory_list = False
+    profile_name: str | None = None
+    profile_list_name: str | None = None
+    in_document_profiles = False
+    profile_values: dict[str, dict[str, str]] = {}
+    profile_key_fields: dict[str, list[str]] = {}
+    profile_mandatory_fields: dict[str, list[str]] = {}
 
     for raw_line in lines:
-        line = raw_line.split("#", 1)[0].strip()
+        line_without_comment = raw_line.split("#", 1)[0].rstrip()
+        line = line_without_comment.strip()
         if not line:
             continue
+        indent = len(line_without_comment) - len(line_without_comment.lstrip(" "))
+        if line == "document_profiles:":
+            in_document_profiles = True
+            profile_name = None
+            profile_list_name = None
+            in_mandatory_list = False
+            continue
+        if in_document_profiles:
+            if indent == 0:
+                in_document_profiles = False
+                profile_name = None
+                profile_list_name = None
+            elif indent == 2 and line.endswith(":"):
+                profile_name = line.removesuffix(":").strip()
+                if not profile_name:
+                    raise ValueError("document profile name must be non-empty")
+                profile_values.setdefault(profile_name, {})
+                profile_key_fields.setdefault(profile_name, [])
+                profile_mandatory_fields.setdefault(profile_name, [])
+                profile_list_name = None
+                continue
+            elif indent == 4 and profile_name is not None:
+                if line in {"key_fields:", "mandatory_fields:"}:
+                    profile_list_name = line.removesuffix(":")
+                    continue
+                if ":" in line:
+                    profile_list_name = None
+                    key, value = line.split(":", 1)
+                    normalized_key = key.strip()
+                    if normalized_key not in {
+                        "field_auto_accept_min",
+                        "key_field_confidence_min",
+                        "document_key_field_coverage_min",
+                        "mandatory_field_min",
+                    }:
+                        raise ValueError(
+                            f"unknown threshold config key in profile {profile_name}: {normalized_key}"
+                        )
+                    profile_values[profile_name][normalized_key] = value.strip().strip('"')
+                    continue
+            elif indent == 6 and line.startswith("-") and profile_name is not None:
+                value = line.removeprefix("-").strip().strip('"')
+                if profile_list_name == "key_fields":
+                    profile_key_fields[profile_name].append(value)
+                    continue
+                if profile_list_name == "mandatory_fields":
+                    profile_mandatory_fields[profile_name].append(value)
+                    continue
+                raise ValueError(f"unexpected list item in document profile {profile_name}")
         if line == "mandatory_fields:":
             in_mandatory_list = True
             continue
@@ -76,12 +146,62 @@ def load_threshold_config(path: str | Path) -> ThresholdConfig:
     if missing:
         raise ValueError(f"missing threshold config keys: {', '.join(missing)}")
 
-    return ThresholdConfig(
+    base_config = ThresholdConfig(
         field_auto_accept_min=_threshold_value("field_auto_accept_min", values),
         key_field_confidence_min=_threshold_value("key_field_confidence_min", values),
         document_key_field_coverage_min=_threshold_value("document_key_field_coverage_min", values),
         mandatory_field_min=_threshold_value("mandatory_field_min", values),
         mandatory_fields=tuple(mandatory_fields),
+    )
+    profiles = {
+        name: _document_profile(
+            name=name,
+            values=profile_values[name],
+            key_fields=tuple(profile_key_fields[name]),
+            mandatory_fields=tuple(profile_mandatory_fields[name]),
+            base_config=base_config,
+        )
+        for name in profile_values
+    }
+    return ThresholdConfig(
+        field_auto_accept_min=base_config.field_auto_accept_min,
+        key_field_confidence_min=base_config.key_field_confidence_min,
+        document_key_field_coverage_min=base_config.document_key_field_coverage_min,
+        mandatory_field_min=base_config.mandatory_field_min,
+        mandatory_fields=base_config.mandatory_fields,
+        document_profiles=profiles,
+    )
+
+
+def _document_profile(
+    *,
+    name: str,
+    values: dict[str, str],
+    key_fields: tuple[str, ...],
+    mandatory_fields: tuple[str, ...],
+    base_config: ThresholdConfig,
+) -> DocumentThresholdProfile:
+    if not key_fields:
+        raise ValueError(f"document profile {name} missing key_fields")
+
+    merged_values = {
+        "field_auto_accept_min": str(base_config.field_auto_accept_min),
+        "key_field_confidence_min": str(base_config.key_field_confidence_min),
+        "document_key_field_coverage_min": str(base_config.document_key_field_coverage_min),
+        "mandatory_field_min": str(base_config.mandatory_field_min),
+        **values,
+    }
+    return DocumentThresholdProfile(
+        key_fields=key_fields,
+        config=ThresholdConfig(
+            field_auto_accept_min=_threshold_value("field_auto_accept_min", merged_values),
+            key_field_confidence_min=_threshold_value("key_field_confidence_min", merged_values),
+            document_key_field_coverage_min=_threshold_value(
+                "document_key_field_coverage_min", merged_values
+            ),
+            mandatory_field_min=_threshold_value("mandatory_field_min", merged_values),
+            mandatory_fields=mandatory_fields,
+        ),
     )
 
 
@@ -163,6 +283,21 @@ def evaluate_thresholds(
         escalate=escalate,
         escalation_reason=reason,
     )
+
+
+def select_threshold_profile(
+    *,
+    document_type: DocumentType | str,
+    key_fields: tuple[str, ...],
+    config: ThresholdConfig,
+) -> tuple[tuple[str, ...], ThresholdConfig]:
+    """Return expected fields and thresholds for a document type, preserving unknown fallback."""
+
+    profile_key = document_type.value if isinstance(document_type, DocumentType) else document_type
+    profile = config.document_profiles.get(profile_key)
+    if profile is None:
+        return key_fields, config
+    return profile.key_fields, profile.config
 
 
 def attach_threshold_summary(

--- a/src/inv_man_intake/extraction/doc_type.py
+++ b/src/inv_man_intake/extraction/doc_type.py
@@ -22,16 +22,16 @@ _DOCUMENT_TYPE_KEYWORDS: tuple[tuple[DocumentType, tuple[str, ...]], ...] = (
         ("ddq", "due diligence questionnaire", "questionnaire"),
     ),
     (
-        DocumentType.MONTHLY_LETTER,
-        ("monthly letter", "investor letter", "monthly commentary", "month-end"),
-    ),
-    (
         DocumentType.TEAR_SHEET,
         ("tear sheet", "tearsheet", "factsheet", "fact sheet", "one pager"),
     ),
     (
+        DocumentType.MONTHLY_LETTER,
+        ("monthly letter", "investor letter", "monthly commentary"),
+    ),
+    (
         DocumentType.PITCHBOOK,
-        ("pitchbook", "pitch book", "private placement memorandum", "ppm"),
+        ("pitchbook", "pitch book", "private placement memorandum"),
     ),
 )
 

--- a/src/inv_man_intake/extraction/doc_type.py
+++ b/src/inv_man_intake/extraction/doc_type.py
@@ -1,0 +1,58 @@
+"""Deterministic document-type classification for extraction threshold routing."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from enum import StrEnum
+
+
+class DocumentType(StrEnum):
+    """Known screening document types used to select expected-field profiles."""
+
+    PITCHBOOK = "pitchbook"
+    TEAR_SHEET = "tear_sheet"
+    MONTHLY_LETTER = "monthly_letter"
+    DDQ = "ddq"
+    UNKNOWN = "unknown"
+
+
+_DOCUMENT_TYPE_KEYWORDS: tuple[tuple[DocumentType, tuple[str, ...]], ...] = (
+    (
+        DocumentType.DDQ,
+        ("ddq", "due diligence questionnaire", "questionnaire"),
+    ),
+    (
+        DocumentType.MONTHLY_LETTER,
+        ("monthly letter", "investor letter", "monthly commentary", "month-end"),
+    ),
+    (
+        DocumentType.TEAR_SHEET,
+        ("tear sheet", "tearsheet", "factsheet", "fact sheet", "one pager"),
+    ),
+    (
+        DocumentType.PITCHBOOK,
+        ("pitchbook", "pitch book", "private placement memorandum", "ppm"),
+    ),
+)
+
+
+def classify_doc_type(content: str | bytes | Iterable[str]) -> DocumentType:
+    """Classify a document from deterministic text cues, falling back to unknown."""
+
+    text = _normalize_content(content)
+    if not text:
+        return DocumentType.UNKNOWN
+
+    for document_type, keywords in _DOCUMENT_TYPE_KEYWORDS:
+        if any(keyword in text for keyword in keywords):
+            return document_type
+
+    return DocumentType.UNKNOWN
+
+
+def _normalize_content(content: str | bytes | Iterable[str]) -> str:
+    if isinstance(content, bytes):
+        return content.decode("utf-8", errors="ignore").casefold()
+    if isinstance(content, str):
+        return content.casefold()
+    return "\n".join(content).casefold()

--- a/src/inv_man_intake/v1_smoke.py
+++ b/src/inv_man_intake/v1_smoke.py
@@ -18,7 +18,9 @@ from inv_man_intake.extraction.confidence import (
     attach_threshold_summary,
     evaluate_thresholds,
     load_threshold_config,
+    select_threshold_profile,
 )
+from inv_man_intake.extraction.doc_type import classify_doc_type
 from inv_man_intake.extraction.orchestrator import ExtractionOrchestrator
 from inv_man_intake.extraction.providers.base import ExtractedDocumentResult, ExtractionProvider
 from inv_man_intake.extraction.providers.pdf_primary import PdfPrimaryExtractionProvider
@@ -207,12 +209,13 @@ def _run_pipeline_core(
     primary_document = core_repository.get_document(record.document_ids[0])
     assert primary_document is not None, "primary document must be registered"
     primary_file_name = primary_document.file_name
+    primary_content = _fixture_bytes(fixture_root=fixture_root, file_name=primary_file_name)
     extraction_result = _run_extraction_smoke(
         tracer=tracer,
         trace_context=extraction_context,
         source_doc_id=record.document_ids[0],
         primary_file_name=primary_file_name,
-        content=_fixture_bytes(fixture_root=fixture_root, file_name=primary_file_name),
+        content=primary_content,
         correlation_id=correlation_id,
     )
     secondary_extraction_result = _run_secondary_extraction_boundary_smoke(
@@ -230,8 +233,8 @@ def _run_pipeline_core(
         effective_threshold_config = threshold_config or load_threshold_config(
             DEFAULT_THRESHOLD_CONFIG_PATH
         )
-        threshold_decision = evaluate_thresholds(
-            result=extraction_result,
+        threshold_key_fields, threshold_profile_config = select_threshold_profile(
+            document_type=classify_doc_type(primary_content),
             key_fields=(
                 "strategy.asset_class",
                 "terms.management_fee",
@@ -240,6 +243,11 @@ def _run_pipeline_core(
                 "team.key_person_risk",
             ),
             config=effective_threshold_config,
+        )
+        threshold_decision = evaluate_thresholds(
+            result=extraction_result,
+            key_fields=threshold_key_fields,
+            config=threshold_profile_config,
         )
         extraction_with_thresholds = attach_threshold_summary(
             result=extraction_result,

--- a/tests/extraction/test_doc_type.py
+++ b/tests/extraction/test_doc_type.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from inv_man_intake.extraction.confidence import (
     evaluate_thresholds,
     load_threshold_config,
@@ -78,3 +80,160 @@ def test_doctype_selects_expected_field_profile() -> None:
     assert unknown_key_fields == _GLOBAL_KEY_FIELDS
     assert unknown_decision.escalate is True
     assert unknown_decision.escalation_reason == "missing_mandatory_field:terms.management_fee"
+
+
+def test_classifier_handles_specific_document_types_without_ambiguous_matches() -> None:
+    assert classify_doc_type("Completed due diligence questionnaire") is DocumentType.DDQ
+    assert classify_doc_type("Factsheet with month-end returns and AUM") is DocumentType.TEAR_SHEET
+    assert classify_doc_type("Monthly commentary for investors") is DocumentType.MONTHLY_LETTER
+    assert classify_doc_type("Private placement memorandum for Fund VI") is DocumentType.PITCHBOOK
+    assert classify_doc_type("ESG parts per million emissions appendix") is DocumentType.UNKNOWN
+
+
+def test_profile_overrides_are_merged_for_each_document_type() -> None:
+    config = load_threshold_config(_CONFIG_PATH)
+
+    monthly_fields, monthly_config = select_threshold_profile(
+        document_type=DocumentType.MONTHLY_LETTER,
+        key_fields=_GLOBAL_KEY_FIELDS,
+        config=config,
+    )
+    monthly_decision = evaluate_thresholds(
+        result=_result(("performance.net_return_1y", 0.91)),
+        key_fields=monthly_fields,
+        config=monthly_config,
+    )
+    assert monthly_fields == ("performance.net_return_1y", "commentary.market_update")
+    assert monthly_config.document_key_field_coverage_min == 0.5
+    assert monthly_decision.auto_pass_document is True
+    assert monthly_decision.escalate is False
+
+    ddq_fields, ddq_config = select_threshold_profile(
+        document_type=DocumentType.DDQ,
+        key_fields=_GLOBAL_KEY_FIELDS,
+        config=config,
+    )
+    ddq_decision = evaluate_thresholds(
+        result=_result(("terms.management_fee", 0.91), ("operations.aum", 0.89)),
+        key_fields=ddq_fields,
+        config=ddq_config,
+    )
+    assert ddq_fields == (
+        "terms.management_fee",
+        "operations.aum",
+        "operations.inception_date",
+    )
+    assert ddq_decision.escalate is True
+    assert ddq_decision.escalation_reason == "low_key_field_coverage"
+
+    pitchbook_fields, pitchbook_config = select_threshold_profile(
+        document_type=DocumentType.PITCHBOOK,
+        key_fields=_GLOBAL_KEY_FIELDS,
+        config=config,
+    )
+    pitchbook_decision = evaluate_thresholds(
+        result=_result(
+            ("terms.management_fee", 0.91),
+            ("performance.net_return_1y", 0.90),
+            ("operations.aum", 0.89),
+        ),
+        key_fields=pitchbook_fields,
+        config=pitchbook_config,
+    )
+    assert pitchbook_fields == _GLOBAL_KEY_FIELDS
+    assert pitchbook_decision.escalate is False
+
+
+def test_profile_without_mandatory_fields_inherits_global_policy(tmp_path: Path) -> None:
+    config_path = tmp_path / "thresholds.yaml"
+    config_path.write_text(
+        """
+field_auto_accept_min: 0.85
+key_field_confidence_min: 0.75
+document_key_field_coverage_min: 0.80
+mandatory_field_min: 0.60
+mandatory_fields:
+  - terms.management_fee
+document_profiles:
+  tear_sheet:
+    key_fields:
+      - performance.net_return_1y
+    document_key_field_coverage_min: 1.0
+""".strip(),
+        encoding="utf-8",
+    )
+
+    config = load_threshold_config(config_path)
+    key_fields, profile_config = select_threshold_profile(
+        document_type=DocumentType.TEAR_SHEET,
+        key_fields=_GLOBAL_KEY_FIELDS,
+        config=config,
+    )
+    decision = evaluate_thresholds(
+        result=_result(("performance.net_return_1y", 0.91)),
+        key_fields=key_fields,
+        config=profile_config,
+    )
+
+    assert profile_config.mandatory_fields == ("terms.management_fee",)
+    assert decision.escalate is True
+    assert decision.escalation_reason == "missing_mandatory_field:terms.management_fee"
+
+
+@pytest.mark.parametrize(
+    ("config_body", "error"),
+    (
+        (
+            """
+field_auto_accept_min: 0.85
+key_field_confidence_min: 0.75
+document_key_field_coverage_min: 0.80
+mandatory_field_min: 0.60
+mandatory_fields:
+  - terms.management_fee
+document_profiles:
+  tear_sheet:
+    key_fields:
+      - performance.net_return_1y
+    malformed_profile_line
+""",
+            "unexpected line in document profile tear_sheet",
+        ),
+        (
+            """
+field_auto_accept_min: 0.85
+key_field_confidence_min: 0.75
+document_key_field_coverage_min: 0.80
+mandatory_field_min: 0.60
+mandatory_fields:
+  - terms.management_fee
+document_profiles:
+  tear_sheet:
+    key_fields:
+      performance.net_return_1y
+""",
+            "unexpected indentation in document_profiles",
+        ),
+        (
+            """
+field_auto_accept_min: 0.85
+key_field_confidence_min: 0.75
+document_key_field_coverage_min: 0.80
+mandatory_field_min: 0.60
+mandatory_fields:
+  - terms.management_fee
+document_profiles:
+   tear_sheet:
+    key_fields:
+      - performance.net_return_1y
+""",
+            "unexpected indentation in document_profiles",
+        ),
+    ),
+)
+def test_document_profile_parser_fails_closed(tmp_path: Path, config_body: str, error: str) -> None:
+    config_path = tmp_path / "thresholds.yaml"
+    config_path.write_text(config_body.strip(), encoding="utf-8")
+
+    with pytest.raises(ValueError, match=error):
+        load_threshold_config(config_path)

--- a/tests/extraction/test_doc_type.py
+++ b/tests/extraction/test_doc_type.py
@@ -1,0 +1,80 @@
+"""Tests for document-type-specific extraction threshold profiles."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from inv_man_intake.extraction.confidence import (
+    evaluate_thresholds,
+    load_threshold_config,
+    select_threshold_profile,
+)
+from inv_man_intake.extraction.doc_type import DocumentType, classify_doc_type
+from inv_man_intake.extraction.providers.base import ExtractedDocumentResult, ExtractedField
+
+_CONFIG_PATH = Path(__file__).resolve().parents[2] / "config" / "extraction_thresholds.yaml"
+_GLOBAL_KEY_FIELDS = (
+    "terms.management_fee",
+    "performance.net_return_1y",
+    "operations.aum",
+)
+
+
+def _result(*fields: tuple[str, float]) -> ExtractedDocumentResult:
+    return ExtractedDocumentResult(
+        source_doc_id="doc_1",
+        provider_name="primary",
+        fields=tuple(
+            ExtractedField(
+                key=key,
+                value="value",
+                confidence=confidence,
+                source_doc_id="doc_1",
+                source_page=1,
+                method="primary",
+            )
+            for key, confidence in fields
+        ),
+    )
+
+
+def test_doctype_selects_expected_field_profile() -> None:
+    config = load_threshold_config(_CONFIG_PATH)
+    document_type = classify_doc_type("Q2 manager tear sheet with returns and AUM")
+    key_fields, profile_config = select_threshold_profile(
+        document_type=document_type,
+        key_fields=_GLOBAL_KEY_FIELDS,
+        config=config,
+    )
+
+    tear_sheet_decision = evaluate_thresholds(
+        result=_result(
+            ("performance.net_return_1y", 0.91),
+            ("operations.aum", 0.89),
+        ),
+        key_fields=key_fields,
+        config=profile_config,
+    )
+
+    assert document_type is DocumentType.TEAR_SHEET
+    assert key_fields == ("performance.net_return_1y", "operations.aum")
+    assert tear_sheet_decision.auto_pass_document is True
+    assert tear_sheet_decision.escalate is False
+
+    unknown_key_fields, unknown_config = select_threshold_profile(
+        document_type=classify_doc_type("unlabeled manager packet"),
+        key_fields=_GLOBAL_KEY_FIELDS,
+        config=config,
+    )
+    unknown_decision = evaluate_thresholds(
+        result=_result(
+            ("performance.net_return_1y", 0.91),
+            ("operations.aum", 0.89),
+        ),
+        key_fields=unknown_key_fields,
+        config=unknown_config,
+    )
+
+    assert unknown_key_fields == _GLOBAL_KEY_FIELDS
+    assert unknown_decision.escalate is True
+    assert unknown_decision.escalation_reason == "missing_mandatory_field:terms.management_fee"


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:717 -->
> **Source:** Issue #717

Closes #717

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The extraction orchestrator routes by **format** (PDF/PPTX/XLSX) — `src/inv_man_intake/extraction/orchestrator.py` —
not by **document semantics** (pitchbook vs DDQ vs tear-sheet vs monthly letter). The mandatory/key-field gate
in `src/inv_man_intake/extraction/confidence.py` is currently **one global config** (`config/extraction_thresholds.yaml`),
so a monthly letter is held to a pitchbook's field expectations. The IDP field treats doc-type classification
as a first-class, accuracy-measured stage because *what kind of document this is* drives which fields to expect.
Lower priority than the other children (the screening doc mix is narrow), but it sharpens the expected-field
set and per-type thresholds. Latent gap.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#699](https://github.com/stranske/Inv-Man-Intake/issues/699)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] Add `src/inv_man_intake/extraction/doc_type.py::classify_doc_type(...)` returning one of a small enum
  (e.g. pitchbook / tear_sheet / monthly_letter / ddq / unknown), with an explicit `unknown` fallback.
- [ ] Add per-type expected-field/threshold profiles and have `evaluate_thresholds` (or its caller) select the
  profile by classified type, defaulting to the current global config for `unknown`.
- [ ] Add `tests/extraction/test_doc_type.py::test_doctype_selects_expected_field_profile`.

#### Acceptance criteria
- [ ] Named test `test_doctype_selects_expected_field_profile` passes: a tear-sheet-classified doc is gated on
  the tear-sheet field profile (not the pitchbook profile), and an `unknown` doc falls back to the global config.
- [ ] **Deliberate-break gate:** force `classify_doc_type` to always return `unknown`; the named test **must
  FAIL** (per-type profile no longer applied); revert → passes. Capture both.
- [ ] `pytest tests/extraction/ -q` green; default/unknown behavior unchanged from today.

<!-- auto-status-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added document-type-aware extraction threshold profiles for pitch books, tear sheets, monthly letters, and DDQs.
  * Introduced automatic document type classification to route documents to the right threshold rules.
  * Supported profile-specific field requirements and threshold overrides for different document types.

* **Tests**
  * Added coverage for profile selection and fallback behavior for unlabeled documents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->