### PR TITLE
Add LLM egress guard boundary

### DIFF
--- a/src/inv_man_intake/assist/__init__.py
+++ b/src/inv_man_intake/assist/__init__.py
@@ -1,0 +1,19 @@
+"""Operator assistant guardrails."""
+
+from inv_man_intake.assist.egress_guard import (
+    EgressConsent,
+    EgressLogRecord,
+    EgressResponse,
+    ProviderConfig,
+    redact_payload,
+    send_to_llm,
+)
+
+__all__ = [
+    "EgressConsent",
+    "EgressLogRecord",
+    "EgressResponse",
+    "ProviderConfig",
+    "redact_payload",
+    "send_to_llm",
+]

--- a/src/inv_man_intake/assist/egress_guard.py
+++ b/src/inv_man_intake/assist/egress_guard.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import json
 import re
+import threading
 from collections.abc import Callable, Mapping, Sequence
+from copy import deepcopy
 from dataclasses import asdict, dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -25,6 +27,7 @@ _PROPRIETARY_PATTERNS = (
     re.compile(r"\bCONFIDENTIAL[:\-_ ][A-Za-z0-9_.:/-]+", re.IGNORECASE),
 )
 _REDACTED = "[REDACTED]"
+_LOG_WRITE_LOCK = threading.Lock()
 
 
 @dataclass(frozen=True)
@@ -54,6 +57,7 @@ class EgressLogRecord:
     provider: str
     model: str
     consent_granted_by: str
+    consent_granted_at: str
     purpose: str
     redaction_applied: bool
     outbound_payload: dict[str, JsonValue]
@@ -86,19 +90,25 @@ def send_to_llm(
 
     if consent is None:
         raise PermissionError("LLM egress requires per-call operator consent")
-    if not consent.granted_by.strip() or not consent.purpose.strip():
-        raise ValueError("LLM egress consent must include actor and purpose")
+    if (
+        not consent.granted_by.strip()
+        or not consent.purpose.strip()
+        or not consent.granted_at.strip()
+    ):
+        raise ValueError("LLM egress consent must include actor, purpose, and grant timestamp")
+    consent_granted_at = _parse_consent_granted_at(consent.granted_at)
     if not provider_config.zero_retention or not provider_config.baa_eligible:
         raise ValueError("LLM egress provider must be zero-retention and BAA eligible")
 
     outbound_payload = redact_payload(payload)
-    response = dict(client(outbound_payload, provider_config))
+    response = dict(client(deepcopy(outbound_payload), provider_config))
     timestamp = (now or _utc_now)().astimezone(UTC).isoformat()
     log_record = EgressLogRecord(
         timestamp=timestamp,
         provider=provider_config.provider,
         model=provider_config.model,
         consent_granted_by=consent.granted_by,
+        consent_granted_at=consent_granted_at,
         purpose=consent.purpose,
         redaction_applied=outbound_payload != _json_payload(payload),
         outbound_payload=outbound_payload,
@@ -140,7 +150,7 @@ def _redact_value(*, key: str, value: Any) -> JsonValue:
         return [_redact_value(key=key, value=item) for item in value]
     if isinstance(value, bool | int | float) or value is None:
         return cast(JsonValue, value)
-    return str(value)
+    return _REDACTED
 
 
 def _json_payload(payload: Mapping[str, Any]) -> dict[str, JsonValue]:
@@ -163,9 +173,16 @@ def _json_value(value: Any) -> JsonValue:
 
 def _append_log_record(log_path: Path, record: EgressLogRecord) -> None:
     log_path.parent.mkdir(parents=True, exist_ok=True)
-    with log_path.open("a", encoding="utf-8") as handle:
+    with _LOG_WRITE_LOCK, log_path.open("a", encoding="utf-8") as handle:
         handle.write(json.dumps(asdict(record), sort_keys=True) + "\n")
 
 
 def _utc_now() -> datetime:
     return datetime.now(tz=UTC)
+
+
+def _parse_consent_granted_at(value: str) -> str:
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ValueError("LLM egress consent granted_at must include a timezone")
+    return parsed.astimezone(UTC).isoformat()

--- a/src/inv_man_intake/assist/egress_guard.py
+++ b/src/inv_man_intake/assist/egress_guard.py
@@ -1,0 +1,171 @@
+"""Redaction and audit boundary for approved LLM-lane egress."""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, cast
+
+type JsonValue = str | int | float | bool | None | dict[str, JsonValue] | list[JsonValue]
+type LlmClient = Callable[[dict[str, JsonValue], "ProviderConfig"], Mapping[str, Any]]
+
+_SENSITIVE_KEYS = {
+    "document_text",
+    "full_text",
+    "raw_document",
+    "raw_text",
+    "source_text",
+}
+_PROPRIETARY_PATTERNS = (
+    re.compile(r"\bPROPRIETARY[:\-_ ][A-Za-z0-9_.:/-]+", re.IGNORECASE),
+    re.compile(r"\bCONFIDENTIAL[:\-_ ][A-Za-z0-9_.:/-]+", re.IGNORECASE),
+)
+_REDACTED = "[REDACTED]"
+
+
+@dataclass(frozen=True)
+class EgressConsent:
+    """Per-call human authorization for LLM-lane egress."""
+
+    granted_by: str
+    purpose: str
+    granted_at: str
+
+
+@dataclass(frozen=True)
+class ProviderConfig:
+    """Provider policy required before any payload may leave the local process."""
+
+    provider: str
+    model: str
+    zero_retention: bool
+    baa_eligible: bool
+
+
+@dataclass(frozen=True)
+class EgressLogRecord:
+    """Append-only audit entry for one guarded outbound request."""
+
+    timestamp: str
+    provider: str
+    model: str
+    consent_granted_by: str
+    purpose: str
+    redaction_applied: bool
+    outbound_payload: dict[str, JsonValue]
+
+
+@dataclass(frozen=True)
+class EgressResponse:
+    """Guarded LLM-lane response plus the audit record that was written."""
+
+    provider_response: dict[str, Any]
+    outbound_payload: dict[str, JsonValue]
+    log_record: EgressLogRecord
+
+
+def send_to_llm(
+    payload: Mapping[str, Any],
+    *,
+    consent: EgressConsent | None,
+    provider_config: ProviderConfig,
+    log_path: Path,
+    client: LlmClient,
+    now: Callable[[], datetime] | None = None,
+) -> EgressResponse:
+    """Redact, require consent/provider policy, call an injected client, and log.
+
+    The guard accepts only an injected ``client`` callable so production wiring has
+    to cross this boundary explicitly. Tests can assert the exact outbound payload
+    without any network dependency.
+    """
+
+    if consent is None:
+        raise PermissionError("LLM egress requires per-call operator consent")
+    if not consent.granted_by.strip() or not consent.purpose.strip():
+        raise ValueError("LLM egress consent must include actor and purpose")
+    if not provider_config.zero_retention or not provider_config.baa_eligible:
+        raise ValueError("LLM egress provider must be zero-retention and BAA eligible")
+
+    outbound_payload = redact_payload(payload)
+    response = dict(client(outbound_payload, provider_config))
+    timestamp = (now or _utc_now)().astimezone(UTC).isoformat()
+    log_record = EgressLogRecord(
+        timestamp=timestamp,
+        provider=provider_config.provider,
+        model=provider_config.model,
+        consent_granted_by=consent.granted_by,
+        purpose=consent.purpose,
+        redaction_applied=outbound_payload != _json_payload(payload),
+        outbound_payload=outbound_payload,
+    )
+    _append_log_record(log_path, log_record)
+    return EgressResponse(
+        provider_response=response,
+        outbound_payload=outbound_payload,
+        log_record=log_record,
+    )
+
+
+def redact_payload(payload: Mapping[str, Any]) -> dict[str, JsonValue]:
+    """Return the minimal redacted JSON payload permitted for LLM egress."""
+
+    return {
+        str(key): _redact_value(key=str(key), value=value)
+        for key, value in payload.items()
+        if not str(key).startswith("_")
+    }
+
+
+def _redact_value(*, key: str, value: Any) -> JsonValue:
+    normalized_key = key.lower()
+    if normalized_key in _SENSITIVE_KEYS:
+        return _REDACTED
+    if isinstance(value, Mapping):
+        return {
+            str(child_key): _redact_value(key=str(child_key), value=child_value)
+            for child_key, child_value in value.items()
+            if not str(child_key).startswith("_")
+        }
+    if isinstance(value, str):
+        redacted = value
+        for pattern in _PROPRIETARY_PATTERNS:
+            redacted = pattern.sub(_REDACTED, redacted)
+        return redacted
+    if isinstance(value, Sequence) and not isinstance(value, bytes | bytearray | str):
+        return [_redact_value(key=key, value=item) for item in value]
+    if isinstance(value, bool | int | float) or value is None:
+        return cast(JsonValue, value)
+    return str(value)
+
+
+def _json_payload(payload: Mapping[str, Any]) -> dict[str, JsonValue]:
+    return {
+        str(key): _json_value(value)
+        for key, value in payload.items()
+        if not str(key).startswith("_")
+    }
+
+
+def _json_value(value: Any) -> JsonValue:
+    if isinstance(value, Mapping):
+        return {str(key): _json_value(child) for key, child in value.items()}
+    if isinstance(value, Sequence) and not isinstance(value, bytes | bytearray | str):
+        return [_json_value(item) for item in value]
+    if isinstance(value, str | bool | int | float) or value is None:
+        return cast(JsonValue, value)
+    return str(value)
+
+
+def _append_log_record(log_path: Path, record: EgressLogRecord) -> None:
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    with log_path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(asdict(record), sort_keys=True) + "\n")
+
+
+def _utc_now() -> datetime:
+    return datetime.now(tz=UTC)

--- a/tests/assist/test_egress_guard.py
+++ b/tests/assist/test_egress_guard.py
@@ -1,0 +1,106 @@
+"""Tests for the assistant egress guard."""
+
+from __future__ import annotations
+
+import inspect
+import json
+from collections.abc import Mapping
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import inv_man_intake.run as deterministic_run
+from inv_man_intake.assist.egress_guard import EgressConsent, ProviderConfig, send_to_llm
+
+
+def test_guard_redacts_requires_consent_and_logs(tmp_path: Path) -> None:
+    outbound_calls: list[dict[str, Any]] = []
+
+    def fake_client(payload: dict[str, Any], provider_config: ProviderConfig) -> Mapping[str, Any]:
+        outbound_calls.append({"payload": payload, "provider": provider_config.provider})
+        return {"recommendations": ["review threshold drift"]}
+
+    log_path = tmp_path / "egress.jsonl"
+    provider_config = ProviderConfig(
+        provider="frontier-zero-retention",
+        model="secure-model",
+        zero_retention=True,
+        baa_eligible=True,
+    )
+    payload = {
+        "task": "recommend intake improvements",
+        "document_text": "PROPRIETARY:AlphaFund raw document text",
+        "signals": [
+            {
+                "field": "aum",
+                "snippet": "AUM changed for PROPRIETARY:AlphaFund",
+                "derived_score": 0.42,
+            }
+        ],
+    }
+
+    with pytest.raises(PermissionError):
+        send_to_llm(
+            payload,
+            consent=None,
+            provider_config=provider_config,
+            log_path=log_path,
+            client=fake_client,
+        )
+
+    result = send_to_llm(
+        payload,
+        consent=EgressConsent(
+            granted_by="operator",
+            purpose="rank intake-improvement recommendations",
+            granted_at="2026-07-07T09:00:00+00:00",
+        ),
+        provider_config=provider_config,
+        log_path=log_path,
+        client=fake_client,
+        now=lambda: datetime(2026, 7, 7, 9, 0, tzinfo=UTC),
+    )
+
+    assert outbound_calls
+    outbound_payload = outbound_calls[-1]["payload"]
+    assert outbound_payload["document_text"] == "[REDACTED]"
+    assert "PROPRIETARY:AlphaFund" not in json.dumps(outbound_payload)
+    assert result.provider_response == {"recommendations": ["review threshold drift"]}
+
+    records = [json.loads(line) for line in log_path.read_text(encoding="utf-8").splitlines()]
+    assert len(records) == 1
+    assert records[0]["consent_granted_by"] == "operator"
+    assert records[0]["redaction_applied"] is True
+    assert "PROPRIETARY:AlphaFund" not in json.dumps(records[0])
+
+
+def test_guard_rejects_non_zero_retention_provider(tmp_path: Path) -> None:
+    def fake_client(payload: dict[str, Any], provider_config: ProviderConfig) -> Mapping[str, Any]:
+        raise AssertionError("provider must not be called when policy is invalid")
+
+    with pytest.raises(ValueError, match="zero-retention"):
+        send_to_llm(
+            {"task": "summarize", "document_text": "PROPRIETARY:AlphaFund"},
+            consent=EgressConsent(
+                granted_by="operator",
+                purpose="test",
+                granted_at="2026-07-07T09:00:00+00:00",
+            ),
+            provider_config=ProviderConfig(
+                provider="unsafe-provider",
+                model="model",
+                zero_retention=False,
+                baa_eligible=True,
+            ),
+            log_path=tmp_path / "egress.jsonl",
+            client=fake_client,
+        )
+
+
+def test_deterministic_packet_path_does_not_import_egress_guard() -> None:
+    source = inspect.getsource(deterministic_run)
+
+    assert "egress_guard" not in source
+    assert "send_to_llm" not in source

--- a/tests/assist/test_egress_guard.py
+++ b/tests/assist/test_egress_guard.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import inspect
+import ast
 import json
 from collections.abc import Mapping
 from datetime import UTC, datetime
@@ -32,6 +32,7 @@ def test_guard_redacts_requires_consent_and_logs(tmp_path: Path) -> None:
     payload = {
         "task": "recommend intake improvements",
         "document_text": "PROPRIETARY:AlphaFund raw document text",
+        "attachment": b"PROPRIETARY:AlphaFund bytes",
         "signals": [
             {
                 "field": "aum",
@@ -66,14 +67,53 @@ def test_guard_redacts_requires_consent_and_logs(tmp_path: Path) -> None:
     assert outbound_calls
     outbound_payload = outbound_calls[-1]["payload"]
     assert outbound_payload["document_text"] == "[REDACTED]"
+    assert outbound_payload["attachment"] == "[REDACTED]"
     assert "PROPRIETARY:AlphaFund" not in json.dumps(outbound_payload)
     assert result.provider_response == {"recommendations": ["review threshold drift"]}
 
     records = [json.loads(line) for line in log_path.read_text(encoding="utf-8").splitlines()]
     assert len(records) == 1
     assert records[0]["consent_granted_by"] == "operator"
+    assert records[0]["consent_granted_at"] == "2026-07-07T09:00:00+00:00"
     assert records[0]["redaction_applied"] is True
     assert "PROPRIETARY:AlphaFund" not in json.dumps(records[0])
+
+
+def test_guard_isolated_from_client_payload_mutation(tmp_path: Path) -> None:
+    def mutating_client(
+        payload: dict[str, Any], provider_config: ProviderConfig
+    ) -> Mapping[str, Any]:
+        payload["document_text"] = "PROPRIETARY:AlphaFund restored"
+        payload["nested"]["raw_document"] = "PROPRIETARY:AlphaFund restored"
+        return {"ok": True}
+
+    result = send_to_llm(
+        {
+            "document_text": "PROPRIETARY:AlphaFund",
+            "nested": {"raw_document": "CONFIDENTIAL:LPData"},
+        },
+        consent=EgressConsent(
+            granted_by="operator",
+            purpose="test mutation isolation",
+            granted_at="2026-07-07T09:00:00Z",
+        ),
+        provider_config=ProviderConfig(
+            provider="frontier-zero-retention",
+            model="secure-model",
+            zero_retention=True,
+            baa_eligible=True,
+        ),
+        log_path=tmp_path / "egress.jsonl",
+        client=mutating_client,
+        now=lambda: datetime(2026, 7, 7, 9, 1, tzinfo=UTC),
+    )
+
+    assert result.outbound_payload["document_text"] == "[REDACTED]"
+    assert result.outbound_payload["nested"] == {"raw_document": "[REDACTED]"}
+    assert result.log_record.outbound_payload == result.outbound_payload
+    assert "PROPRIETARY:AlphaFund" not in json.dumps(
+        json.loads((tmp_path / "egress.jsonl").read_text(encoding="utf-8"))
+    )
 
 
 def test_guard_rejects_non_zero_retention_provider(tmp_path: Path) -> None:
@@ -99,8 +139,65 @@ def test_guard_rejects_non_zero_retention_provider(tmp_path: Path) -> None:
         )
 
 
-def test_deterministic_packet_path_does_not_import_egress_guard() -> None:
-    source = inspect.getsource(deterministic_run)
+def test_guard_rejects_non_baa_provider(tmp_path: Path) -> None:
+    def fake_client(payload: dict[str, Any], provider_config: ProviderConfig) -> Mapping[str, Any]:
+        raise AssertionError("provider must not be called when policy is invalid")
 
-    assert "egress_guard" not in source
-    assert "send_to_llm" not in source
+    with pytest.raises(ValueError, match="BAA eligible"):
+        send_to_llm(
+            {"task": "summarize"},
+            consent=EgressConsent(
+                granted_by="operator",
+                purpose="test",
+                granted_at="2026-07-07T09:00:00+00:00",
+            ),
+            provider_config=ProviderConfig(
+                provider="unsafe-provider",
+                model="model",
+                zero_retention=True,
+                baa_eligible=False,
+            ),
+            log_path=tmp_path / "egress.jsonl",
+            client=fake_client,
+        )
+
+
+def test_guard_rejects_consent_without_timezone(tmp_path: Path) -> None:
+    def fake_client(payload: dict[str, Any], provider_config: ProviderConfig) -> Mapping[str, Any]:
+        raise AssertionError("client must not be called when consent is invalid")
+
+    with pytest.raises(ValueError, match="granted_at must include a timezone"):
+        send_to_llm(
+            {"task": "summarize"},
+            consent=EgressConsent(
+                granted_by="operator",
+                purpose="test",
+                granted_at="2026-07-07T09:00:00",
+            ),
+            provider_config=ProviderConfig(
+                provider="frontier-zero-retention",
+                model="model",
+                zero_retention=True,
+                baa_eligible=True,
+            ),
+            log_path=tmp_path / "egress.jsonl",
+            client=fake_client,
+        )
+
+
+def test_deterministic_packet_path_does_not_import_egress_guard() -> None:
+    tree = ast.parse(Path(deterministic_run.__file__).read_text(encoding="utf-8"))
+    imported_modules = {
+        node.module
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom) and node.module is not None
+    }
+    imported_modules.update(
+        alias.name
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Import)
+        for alias in node.names
+    )
+
+    assert "inv_man_intake.assist" not in imported_modules
+    assert "inv_man_intake.assist.egress_guard" not in imported_modules


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:724 -->
> **Source:** Issue #724

Closes #724

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Inv-Man-Intake is Tier A (no egress). The owner approved a frontier API for the **LLM lane only**, as a fenced
exception. That exception is **safe only if a redaction/egress-guard enforces it**: proprietary document content
must be redacted to minimal snippets/derived features, sent only to a **zero-retention/BAA** provider, with
**per-call operator consent** and **full egress logging**. Without this guard, the LLM lane silently breaks the
Tier-A confidentiality guarantee. This is the security-critical boundary; build it before any assistant call.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#718](https://github.com/stranske/Inv-Man-Intake/issues/718)
- [#725](https://github.com/stranske/Inv-Man-Intake/issues/725)
- [#726](https://github.com/stranske/Inv-Man-Intake/issues/726)
- [#727](https://github.com/stranske/Inv-Man-Intake/issues/727)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] Add `src/inv_man_intake/assist/egress_guard.py`: `send_to_llm(payload, *, consent, provider_config)` that
  (a) runs a redaction pass over the payload, (b) refuses unless `consent` is present, (c) requires a
  zero-retention provider config, (d) appends an egress-log record (what was sent, redacted, when, by whom).
- [ ] A redaction policy module: strip/transform proprietary identifiers and raw document text down to the
  minimal snippet/feature set needed for the task.
- [ ] An egress-log contract (append-only) for audit.

#### Acceptance criteria
- [ ] Named test `tests/assist/test_egress_guard.py::test_guard_redacts_requires_consent_and_logs` passes: a
  payload containing a proprietary marker is **redacted** before send (assert the marker is absent from the
  outbound payload), a call without consent **raises**, and an egress-log record is written.
- [ ] **Deliberate-break gate:** disable the redaction step; the named test **must FAIL** (proprietary marker
  leaks into the outbound payload); revert → passes.
- [ ] A test asserts the deterministic packet path (M2) makes **no** call into `egress_guard`.

<!-- auto-status-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a guarded assistant flow for sending information to AI services, with built-in consent checks and provider-policy validation.
  * Added automatic redaction of sensitive content before data is sent out.
  * Added an audit log for outbound AI requests and responses.

* **Bug Fixes**
  * Prevents requests from being sent when required consent or provider safeguards are missing.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->