### PR TITLE
Plan operator app and intake assistant

### DIFF
--- a/docs/design/intake-improvement-assistant.md
+++ b/docs/design/intake-improvement-assistant.md
@@ -1,0 +1,112 @@
+# Intake Improvement Assistant Design
+
+Issue: [#718](https://github.com/stranske/Inv-Man-Intake/issues/718)
+
+## Decision
+
+The intake improvement assistant is a read-only analysis layer over local run,
+queue, correction, scoring, and readiness signals. It recommends improvements to
+thresholds, weights, parser coverage, document-type profiles, and operator
+workflow priorities. It never edits `config/*`, mutates artifacts, or applies a
+policy change automatically.
+
+The implementation child is
+[#725](https://github.com/stranske/Inv-Man-Intake/issues/725). The egress and
+privacy precondition is
+[#724](https://github.com/stranske/Inv-Man-Intake/issues/724).
+
+## Inputs
+
+The assistant reads structured local signals only:
+
+- `run.json`, `threshold-summary.json`, `explainability.json`, and
+  `manifest.json` from `src/inv_man_intake/run.py`.
+- Queue rows and escalation reasons from
+  `src/inv_man_intake/validation_queue_api.py`.
+- Correction history from `CorrectionRecord` in
+  `src/inv_man_intake/data/provenance.py`.
+- Score contributions and red-flag reasons from
+  `src/inv_man_intake/scoring/contracts.py`.
+- Calibration reports from
+  [#711](https://github.com/stranske/Inv-Man-Intake/issues/711).
+- Extraction drift reports from
+  [#714](https://github.com/stranske/Inv-Man-Intake/issues/714).
+- Weight sensitivity reports from
+  [#716](https://github.com/stranske/Inv-Man-Intake/issues/716).
+- Document-type threshold profiles from
+  [#717](https://github.com/stranske/Inv-Man-Intake/issues/717).
+
+## Recommendation Contract
+
+Each recommendation should be evidence-cited and structured:
+
+- `target`: threshold, scoring weight, parser/doc-type profile, queue workflow,
+  or documentation.
+- `evidence_refs`: run artifact ids, queue item ids, correction ids, score
+  contribution names, or report row ids.
+- `rationale`: why this change improves intake quality.
+- `risk`: expected false-positive, false-negative, review-load, or local data
+  zone risk.
+- `suggested_action`: a human-readable proposal, not a patch.
+- `requires_human_apply`: always `true`.
+
+The assistant output can later feed a HITL apply loop, but that loop must still
+require explicit human approval before any config file changes.
+
+## Local-First And Egress Rules
+
+Default mode is deterministic local analysis. It may use template rules or a
+local model over redacted summaries. Any frontier API call must route through
+`send_to_llm` from the egress guard and must satisfy:
+
+- explicit per-call consent;
+- zero-retention and BAA-eligible provider policy;
+- redaction of raw document text, proprietary identifiers, and unsupported
+  non-JSON values;
+- append-only JSONL audit logging;
+- no raw document payload egress.
+
+No child issue may bypass the egress guard by calling a provider SDK directly.
+
+## No Auto-Apply
+
+The assistant must never write `config/extraction_thresholds.yaml`,
+`config/scoring_weights/*`, or generated run artifacts. It may write a separate
+recommendation artifact under an operator-supplied output directory.
+
+Any future apply path must be a separate HITL command that:
+
+- reads a recommendation artifact;
+- shows the diff or generated candidate change to the operator;
+- requires explicit approval;
+- records approval metadata;
+- validates the named gate before saving a config change.
+
+## Dependency Order
+
+The assistant becomes useful only after its upstream analytics exist:
+
+1. [#711](https://github.com/stranske/Inv-Man-Intake/issues/711): correction
+   calibration closes the extraction feedback loop.
+2. [#714](https://github.com/stranske/Inv-Man-Intake/issues/714): drift reports
+   show stale extraction or source-quality regressions.
+3. [#716](https://github.com/stranske/Inv-Man-Intake/issues/716): weight
+   sensitivity reports show ranking instability and approval impact.
+4. [#717](https://github.com/stranske/Inv-Man-Intake/issues/717): document-type
+   profiles make threshold recommendations document-aware.
+5. [#724](https://github.com/stranske/Inv-Man-Intake/issues/724): LLM egress
+   guard provides the only approved outbound LLM boundary.
+6. [#725](https://github.com/stranske/Inv-Man-Intake/issues/725): read-only
+   assistant over the above signals.
+
+## Verification
+
+The assistant implementation should include a named gate that builds a
+recommendation from fixture artifacts and asserts:
+
+- each recommendation has at least one evidence ref;
+- `requires_human_apply` is true;
+- no `config/*` file is written;
+- no external document call is made by default;
+- any LLM-backed path is impossible without egress-guard consent and provider
+  policy.

--- a/docs/design/operator-application.md
+++ b/docs/design/operator-application.md
@@ -1,0 +1,105 @@
+# Operator Application Design
+
+Issue: [#718](https://github.com/stranske/Inv-Man-Intake/issues/718)
+
+## Decision
+
+Inv-Man-Intake remains a headless backend. The operator application is a local
+consumer of committed contracts and run artifacts, not a new production API
+inside `src/inv_man_intake`.
+
+The first application surface should be the Tier-A local operator app tracked by
+[#723](https://github.com/stranske/Inv-Man-Intake/issues/723). It can reuse the
+existing browser-demo/Pyodide posture while graduating from fixture inspection to
+operator workflow review. It must consume:
+
+- `src/inv_man_intake/validation_queue_api.py` for queue filtering, paging,
+  owner-role, state, SLA, and escalation views.
+- `src/inv_man_intake/run.py` artifacts, especially `run.json`,
+  `metadata.json`, `threshold-summary.json`, `explainability.json`, and
+  `manifest.json`.
+- Existing queue state contracts from `src/inv_man_intake/workflow_validation.py`
+  and `docs/contracts/queue_states.md`.
+
+## Users
+
+- Analyst: reviews pending or escalated fields, sees why a manager package needs
+  attention, and records corrections through the existing validation workflow.
+- Operations reviewer: monitors queue health, stale items, ownership, SLA, and
+  run artifact completeness before a manager profile moves downstream.
+- Local operator: runs the intake on a work PC and inspects outputs without
+  sending proprietary manager documents outside the local data zone.
+
+## Headless Boundary
+
+The application must treat this repo as a library and artifact producer. It may
+call public Python APIs and read output artifacts, but it must not require a new
+FastAPI, Gradio, or cloud service server in `src/inv_man_intake`.
+
+The local app can live under `app/` or a thin external shell. If it stays in this
+repo, it remains a consumer of the headless package. The backend package should
+continue to expose deterministic functions, dataclasses, and run artifacts that
+other analyst queues can consume.
+
+## Local-First Data Zone
+
+The operator app is local-first and runs on the work PC. It must not upload raw documents,
+raw extracted field values, or proprietary manager identifiers to an external
+service by default.
+
+Required checks for child implementation:
+
+- LangSmith and fleet telemetry stay disabled for local proprietary runs unless
+  the operator explicitly enables a redacted telemetry mode.
+- `run.json` remains in an operator-supplied output directory and is not written
+  to the fleet telemetry sink.
+- The app does not fetch external runtime code when loading proprietary package
+  artifacts.
+- Any LLM path must go through the egress guard from
+  [#724](https://github.com/stranske/Inv-Man-Intake/issues/724).
+
+## Views
+
+The first operator workflow should include:
+
+- Run list: package id, firm/fund ids, status, artifact manifest, score, warning
+  count, and run timestamp.
+- Queue triage: validation state, owner role, owner id, SLA age, escalation
+  reason, and filtering backed by `ValidationQueueQuery`.
+- Package detail: document versions, extracted fields, confidence state,
+  threshold decision, explainability, red-flag reason, and evidence refs.
+- Correction review: latest corrections and calibration impact, backed by
+  [#711](https://github.com/stranske/Inv-Man-Intake/issues/711).
+- Recommendation inbox: read-only assistant recommendations from
+  [#725](https://github.com/stranske/Inv-Man-Intake/issues/725), never direct
+  config writes.
+
+## Child Issue Map
+
+[#718](https://github.com/stranske/Inv-Man-Intake/issues/718) is the planning
+epic. Its implementation children are:
+
+- [#721](https://github.com/stranske/Inv-Man-Intake/issues/721): standard
+  element-library contract and classify/split consumption.
+- [#722](https://github.com/stranske/Inv-Man-Intake/issues/722): packet-level
+  ingestion pipeline and cross-document reconciliation.
+- [#723](https://github.com/stranske/Inv-Man-Intake/issues/723): operator app
+  MVP.
+- [#724](https://github.com/stranske/Inv-Man-Intake/issues/724): LLM egress
+  guard and redaction boundary.
+- [#725](https://github.com/stranske/Inv-Man-Intake/issues/725): intake
+  improvement assistant.
+- [#726](https://github.com/stranske/Inv-Man-Intake/issues/726): PPM
+  standard/non-standard evaluator.
+- [#727](https://github.com/stranske/Inv-Man-Intake/issues/727): return-stream
+  non-standard characterizer.
+
+## Verification
+
+The operator app MVP should have a named gate that loads committed fixture
+artifacts, renders the queue and package detail views, and asserts:
+
+- `ValidationQueueQuery` drives state/owner/SLA filters.
+- The run artifact manifest resolves every displayed artifact.
+- No external document call is made by default.
+- Assistant recommendations are displayed as read-only proposals.

--- a/tests/test_operator_assistant_design.py
+++ b/tests/test_operator_assistant_design.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_operator_and_assistant_design_docs_lock_issue_718_boundaries() -> None:
+    operator_doc = (ROOT / "docs/design/operator-application.md").read_text(encoding="utf-8")
+    assistant_doc = (ROOT / "docs/design/intake-improvement-assistant.md").read_text(
+        encoding="utf-8"
+    )
+    combined = f"{operator_doc}\n{assistant_doc}"
+
+    for required in (
+        "#718",
+        "#721",
+        "#722",
+        "#723",
+        "#724",
+        "#725",
+        "#726",
+        "#727",
+        "#711",
+        "#714",
+        "#716",
+        "#717",
+        "validation_queue_api.py",
+        "run.py",
+        "local-first",
+        "no raw document payload egress",
+        "requires_human_apply",
+        "never edits `config/*`",
+    ):
+        assert required in combined
+
+    assert "headless backend" in operator_doc
+    assert "No Auto-Apply" in assistant_doc

--- a/tests/test_operator_assistant_design.py
+++ b/tests/test_operator_assistant_design.py
@@ -10,10 +10,16 @@ def test_operator_and_assistant_design_docs_lock_issue_718_boundaries() -> None:
     assistant_doc = (ROOT / "docs/design/intake-improvement-assistant.md").read_text(
         encoding="utf-8"
     )
-    combined = f"{operator_doc}\n{assistant_doc}"
-
     for required in (
         "#718",
+        "validation_queue_api.py",
+        "run.py",
+        "local-first",
+        "no raw document payload egress",
+    ):
+        assert required in f"{operator_doc}\n{assistant_doc}"
+
+    for required in (
         "#721",
         "#722",
         "#723",
@@ -21,18 +27,20 @@ def test_operator_and_assistant_design_docs_lock_issue_718_boundaries() -> None:
         "#725",
         "#726",
         "#727",
+        "validation_queue_api.py",
+        "run.py",
+    ):
+        assert required in operator_doc
+
+    for required in (
         "#711",
         "#714",
         "#716",
         "#717",
-        "validation_queue_api.py",
-        "run.py",
-        "local-first",
-        "no raw document payload egress",
         "requires_human_apply",
         "never edits `config/*`",
     ):
-        assert required in combined
+        assert required in assistant_doc
 
     assert "headless backend" in operator_doc
     assert "No Auto-Apply" in assistant_doc


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:718 -->
> **Source:** Issue #718

Closes #718

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The audit (finding L) surfaced a real product gap: **there is no plan for how an end user actually applies the
product.** Inv-Man-Intake is headless by design (`README.md:22-39`), and the only human-facing surfaces planned
are (a) a query/filter CONTRACT for an *external, unbuilt* analyst queue (`src/inv_man_intake/validation_queue_api.py`)
and (b) the engineer-operated `inv-man-ingest` CLI (`docs/runbooks/headless_ingest.md`). The V1 plan scoped the
analyst/ops surface as "queue states + triage dashboard CONTRACTS + export interfaces" (`docs/INV_MAN_INTAKE_PLAN_V1.md:151-153`),
and the Streamlit app is explicitly demo-only ("not a planned production human-facing UI"). The stated V1 outcome
ranking puts **analyst trust #2** — but nothing in the repo delivers an operator experience to earn it.

Concretely, the owner intends to **run this on a work PC** and wants a **LangChain-driven assistant to interact
over "what needs to change to improve the intake"** — i.e., an operator-facing layer that reads the pipeline's own
signals (escalations, low-confidence fields, corrections, scores, drift) and recommends config changes
(thresholds, weights, missing parsers, doc-type profiles). This is the human-facing consumer the README says
"should integrate," and it is the natural operator surface OVER the analytics the roadmap children build
(#711 calibration, #714 drift, #716 weight governance, #717 doc-type).

This is **latent (a missing plan), not a break.** This epic captures the planning; children carry the build.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#2](https://github.com/stranske/Inv-Man-Intake/issues/2)
- [#711](https://github.com/stranske/Inv-Man-Intake/issues/711)
- [#714](https://github.com/stranske/Inv-Man-Intake/issues/714)
- [#716](https://github.com/stranske/Inv-Man-Intake/issues/716)
- [#717](https://github.com/stranske/Inv-Man-Intake/issues/717)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] Headless contract + consumer seam: `README.md:22-39`, `src/inv_man_intake/validation_queue_api.py`,
  `src/inv_man_intake/run.py` (`run_pipeline` → `run.json` + artifacts), `docs/runbooks/headless_ingest.md`.
- [ ] Signals the assistant reads: `extraction/confidence.py` (escalation reasons), `data/provenance.py`
  (`CorrectionRecord`), `scoring/contracts.py` (`ScoreResult.red_flag_reason`/contributions), plus #711/#714/#716 outputs.
- [ ] LangChain/LangSmith are already deps for observability — reuse the local/no-egress posture; structured-output
  via instructor/Pydantic (see `Code/Audits/2026-06-28-pdf-extraction-methodology.md` §3).

#### Acceptance criteria
- [ ] Both design docs exist and are reviewed; each names the headless-contract boundary it respects.
- [ ] At least three children are filed (operator app · assistant analysis · recommendation/apply HITL loop),
  AGENT_ISSUE_FORMAT-compliant with named gates, linked to this epic.
- [ ] The plan explicitly states the local-first + no-auto-apply + no-external-document-egress constraints, with
  a verification step for each (e.g. a test/asserted check that the assistant path makes no outbound document call
  by default, and never writes `config/*`).

<!-- auto-status-summary:end -->