### PR TITLE
Add standard element library port

### DIFF
--- a/config/standard_elements/_stub.json
+++ b/config/standard_elements/_stub.json
@@ -1,0 +1,25 @@
+{
+  "version": "stub-2026-07-07",
+  "non_authoritative": true,
+  "doc_types": {
+    "stub_pitchbook": [
+      {
+        "key": "operations.aum",
+        "detector_name": "numeric_field_present",
+        "mandatory": true
+      },
+      {
+        "key": "terms.management_fee",
+        "detector_name": "field_present",
+        "mandatory": false
+      }
+    ],
+    "stub_tear_sheet": [
+      {
+        "key": "performance.net_return_1y",
+        "detector_name": "numeric_field_present",
+        "mandatory": true
+      }
+    ]
+  }
+}

--- a/docs/contracts/standard_element_library.md
+++ b/docs/contracts/standard_element_library.md
@@ -1,0 +1,37 @@
+# Standard Element Library Contract
+
+This contract defines the narrow port between `inv-man-intake` and the future externally authored standard-element library. The current repository ships only a non-authoritative stub so downstream packet and operator-app work can bind to the interface without encoding human judgment.
+
+## Data Source
+
+The library is loaded at runtime from data. Document type identifiers and element identifiers are data values, not Python enums or application conditionals. Adding or renaming a document type must be possible by editing the library data and rerunning conformance tests.
+
+Required root fields:
+
+- `version`: non-empty string.
+- `non_authoritative`: boolean. The bundled `_stub.json` must remain `true`.
+- `doc_types`: object mapping document type id to a non-empty list of element specs.
+
+Each element spec includes:
+
+- `key`: stable element id, such as `operations.aum`.
+- `detector_name`: name resolved through the app's detector registry.
+- `mandatory`: boolean.
+
+## Runtime Port
+
+Consumers depend on `inv_man_intake.intake.standard_elements.StandardElementLibrary`:
+
+- `doc_types() -> tuple[str, ...]`
+- `elements_for(doc_type) -> tuple[StandardElement, ...]`
+- `evaluate_coverage(doc_type, extracted) -> tuple[ElementCoverage, ...]`
+
+The detector registry maps `detector_name` to callable detector functions. Library authors may choose regex, keyword, layout, or LLM-backed detectors later by adding registry entries; the app must not branch on element ids.
+
+## Judgment Boundary
+
+`classify_element_standardness()` deliberately returns only `unknown` in this repo. It is the future hook for authored standardness and red-flag deviation logic. The bundled stub must not encode claims about what is standard, acceptable, or a red flag.
+
+## Conformance
+
+The external library must pass `tests/intake/test_standard_element_library.py::test_conformance_against_stub` and the decoupling gate in the same file. A data-only document type addition must surface through `doc_types()` and `elements_for()` without application code changes.

--- a/src/inv_man_intake/intake/__init__.py
+++ b/src/inv_man_intake/intake/__init__.py
@@ -1,1 +1,23 @@
 """Intake contracts, models, lifecycle services, and versioning primitives."""
+
+from inv_man_intake.intake.standard_elements import (
+    DataDrivenStandardElementLibrary,
+    ElementCoverage,
+    StandardElement,
+    StandardElementLibrary,
+    classify_element_standardness,
+    default_detector_registry,
+    load_standard_element_library,
+    register_detector,
+)
+
+__all__ = [
+    "DataDrivenStandardElementLibrary",
+    "ElementCoverage",
+    "StandardElement",
+    "StandardElementLibrary",
+    "classify_element_standardness",
+    "default_detector_registry",
+    "load_standard_element_library",
+    "register_detector",
+]

--- a/src/inv_man_intake/intake/standard_elements.py
+++ b/src/inv_man_intake/intake/standard_elements.py
@@ -1,0 +1,218 @@
+"""Data-driven standard-element-library port for intake packet routing."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal, Protocol, cast
+
+Standardness = Literal["unknown"]
+Detector = Callable[[Mapping[str, Any]], bool]
+
+
+@dataclass(frozen=True)
+class StandardElement:
+    """One externally-authored element contract entry."""
+
+    key: str
+    detector_name: str
+    mandatory: bool = False
+
+
+@dataclass(frozen=True)
+class ElementCoverage:
+    """Coverage result for a single element without standardness judgment."""
+
+    key: str
+    detected: bool
+    mandatory: bool
+    standardness: Standardness
+
+
+class StandardElementLibrary(Protocol):
+    """Minimal port the intake app consumes from a standard-element library."""
+
+    def doc_types(self) -> tuple[str, ...]:
+        """Return document type identifiers supplied by library data."""
+
+    def elements_for(self, doc_type: str) -> tuple[StandardElement, ...]:
+        """Return element specs for a document type."""
+
+    def evaluate_coverage(
+        self, doc_type: str, extracted: Mapping[str, Any]
+    ) -> tuple[ElementCoverage, ...]:
+        """Evaluate element detector coverage for extracted data."""
+
+
+class DataDrivenStandardElementLibrary:
+    """Runtime-loaded standard-element library backed only by data."""
+
+    def __init__(
+        self,
+        *,
+        version: str,
+        non_authoritative: bool,
+        elements_by_doc_type: Mapping[str, tuple[StandardElement, ...]],
+        detectors: Mapping[str, Detector] | None = None,
+    ) -> None:
+        if not version:
+            raise ValueError("standard element library version must be non-empty")
+        if not elements_by_doc_type:
+            raise ValueError("standard element library must define at least one document type")
+        self.version = version
+        self.non_authoritative = non_authoritative
+        self._elements_by_doc_type = dict(elements_by_doc_type)
+        self._detectors = dict(detectors or default_detector_registry())
+        self._validate_detector_references()
+
+    def doc_types(self) -> tuple[str, ...]:
+        return tuple(self._elements_by_doc_type)
+
+    def elements_for(self, doc_type: str) -> tuple[StandardElement, ...]:
+        try:
+            return self._elements_by_doc_type[doc_type]
+        except KeyError as exc:
+            raise KeyError(f"unknown standard-element doc_type: {doc_type}") from exc
+
+    def evaluate_coverage(
+        self, doc_type: str, extracted: Mapping[str, Any]
+    ) -> tuple[ElementCoverage, ...]:
+        coverage: list[ElementCoverage] = []
+        for element in self.elements_for(doc_type):
+            detector = self._detectors[element.detector_name]
+            detector_payload = {**extracted, "field_key": element.key}
+            coverage.append(
+                ElementCoverage(
+                    key=element.key,
+                    detected=detector(detector_payload),
+                    mandatory=element.mandatory,
+                    standardness=classify_element_standardness(
+                        element=element, extracted=extracted
+                    ),
+                )
+            )
+        return tuple(coverage)
+
+    def _validate_detector_references(self) -> None:
+        missing = sorted(
+            {
+                element.detector_name
+                for elements in self._elements_by_doc_type.values()
+                for element in elements
+                if element.detector_name not in self._detectors
+            }
+        )
+        if missing:
+            raise ValueError(f"unknown detector reference(s): {', '.join(missing)}")
+
+
+def register_detector(
+    registry: Mapping[str, Detector],
+    name: str,
+    detector: Detector,
+) -> dict[str, Detector]:
+    """Return a detector registry with one additional named detector."""
+
+    if not name:
+        raise ValueError("detector name must be non-empty")
+    updated = dict(registry)
+    updated[name] = detector
+    return updated
+
+
+def default_detector_registry() -> dict[str, Detector]:
+    """Detectors used by the deliberately dumb stub library."""
+
+    return {
+        "field_present": _field_present_detector,
+        "numeric_field_present": _numeric_field_present_detector,
+    }
+
+
+def load_standard_element_library(
+    source: str | Path | Mapping[str, Any],
+    *,
+    detectors: Mapping[str, Detector] | None = None,
+) -> DataDrivenStandardElementLibrary:
+    """Load and validate a standard-element library from JSON-like data."""
+
+    payload = _read_payload(source)
+    if not isinstance(payload, Mapping):
+        raise ValueError("standard element library root must be an object")
+    doc_type_payload = payload.get("doc_types")
+    if not isinstance(doc_type_payload, Mapping):
+        raise ValueError("standard element library must contain object field 'doc_types'")
+
+    elements_by_doc_type: dict[str, tuple[StandardElement, ...]] = {}
+    for doc_type, raw_elements in doc_type_payload.items():
+        if not isinstance(doc_type, str) or not doc_type:
+            raise ValueError("document type identifiers must be non-empty strings")
+        if not isinstance(raw_elements, list) or not raw_elements:
+            raise ValueError(f"doc_type {doc_type!r} must define a non-empty element list")
+        elements_by_doc_type[doc_type] = tuple(
+            _parse_standard_element(doc_type=doc_type, raw_element=raw_element)
+            for raw_element in raw_elements
+        )
+
+    return DataDrivenStandardElementLibrary(
+        version=_required_string(payload, "version"),
+        non_authoritative=bool(payload.get("non_authoritative", False)),
+        elements_by_doc_type=elements_by_doc_type,
+        detectors=detectors,
+    )
+
+
+def classify_element_standardness(
+    *,
+    element: StandardElement,
+    extracted: Mapping[str, Any],
+) -> Standardness:
+    """Placeholder for future human-authored standardness logic."""
+
+    _ = element, extracted
+    return "unknown"
+
+
+def _read_payload(source: str | Path | Mapping[str, Any]) -> Mapping[str, Any]:
+    if isinstance(source, Mapping):
+        return source
+    path = Path(source)
+    return cast(Mapping[str, Any], json.loads(path.read_text(encoding="utf-8")))
+
+
+def _parse_standard_element(
+    *,
+    doc_type: str,
+    raw_element: object,
+) -> StandardElement:
+    if not isinstance(raw_element, Mapping):
+        raise ValueError(f"element entry for {doc_type!r} must be an object")
+    return StandardElement(
+        key=_required_string(raw_element, "key"),
+        detector_name=_required_string(raw_element, "detector_name"),
+        mandatory=bool(raw_element.get("mandatory", False)),
+    )
+
+
+def _required_string(payload: Mapping[str, Any], key: str) -> str:
+    value = payload.get(key)
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"standard element library field {key!r} must be a non-empty string")
+    return value
+
+
+def _field_present_detector(extracted: Mapping[str, Any]) -> bool:
+    field_key = extracted.get("field_key")
+    if not isinstance(field_key, str):
+        return False
+    fields = extracted.get("fields", ())
+    return field_key in fields
+
+
+def _numeric_field_present_detector(extracted: Mapping[str, Any]) -> bool:
+    if not _field_present_detector(extracted):
+        return False
+    value = extracted.get("value")
+    return isinstance(value, int | float) and not isinstance(value, bool)

--- a/src/inv_man_intake/intake/standard_elements.py
+++ b/src/inv_man_intake/intake/standard_elements.py
@@ -34,6 +34,8 @@ class ElementCoverage:
 class StandardElementLibrary(Protocol):
     """Minimal port the intake app consumes from a standard-element library."""
 
+    non_authoritative: bool
+
     def doc_types(self) -> tuple[str, ...]:
         """Return document type identifiers supplied by library data."""
 
@@ -64,11 +66,11 @@ class DataDrivenStandardElementLibrary:
         self.version = version
         self.non_authoritative = non_authoritative
         self._elements_by_doc_type = dict(elements_by_doc_type)
-        self._detectors = dict(detectors or default_detector_registry())
+        self._detectors = dict(detectors if detectors is not None else default_detector_registry())
         self._validate_detector_references()
 
     def doc_types(self) -> tuple[str, ...]:
-        return tuple(self._elements_by_doc_type)
+        return tuple(sorted(self._elements_by_doc_type))
 
     def elements_for(self, doc_type: str) -> tuple[StandardElement, ...]:
         try:
@@ -151,14 +153,23 @@ def load_standard_element_library(
             raise ValueError("document type identifiers must be non-empty strings")
         if not isinstance(raw_elements, list) or not raw_elements:
             raise ValueError(f"doc_type {doc_type!r} must define a non-empty element list")
-        elements_by_doc_type[doc_type] = tuple(
+        elements = tuple(
             _parse_standard_element(doc_type=doc_type, raw_element=raw_element)
             for raw_element in raw_elements
         )
+        duplicate_keys = sorted(
+            key for key in {element.key for element in elements} if _count_key(elements, key) > 1
+        )
+        if duplicate_keys:
+            raise ValueError(
+                f"doc_type {doc_type!r} contains duplicate element key(s): "
+                + ", ".join(duplicate_keys)
+            )
+        elements_by_doc_type[doc_type] = elements
 
     return DataDrivenStandardElementLibrary(
         version=_required_string(payload, "version"),
-        non_authoritative=bool(payload.get("non_authoritative", False)),
+        non_authoritative=_required_bool(payload, "non_authoritative"),
         elements_by_doc_type=elements_by_doc_type,
         detectors=detectors,
     )
@@ -192,7 +203,7 @@ def _parse_standard_element(
     return StandardElement(
         key=_required_string(raw_element, "key"),
         detector_name=_required_string(raw_element, "detector_name"),
-        mandatory=bool(raw_element.get("mandatory", False)),
+        mandatory=_required_bool(raw_element, "mandatory"),
     )
 
 
@@ -201,6 +212,17 @@ def _required_string(payload: Mapping[str, Any], key: str) -> str:
     if not isinstance(value, str) or not value:
         raise ValueError(f"standard element library field {key!r} must be a non-empty string")
     return value
+
+
+def _required_bool(payload: Mapping[str, Any], key: str) -> bool:
+    value = payload.get(key)
+    if not isinstance(value, bool):
+        raise ValueError(f"standard element library field {key!r} must be a boolean")
+    return value
+
+
+def _count_key(elements: tuple[StandardElement, ...], key: str) -> int:
+    return sum(1 for element in elements if element.key == key)
 
 
 def _field_present_detector(extracted: Mapping[str, Any]) -> bool:

--- a/tests/intake/test_standard_element_library.py
+++ b/tests/intake/test_standard_element_library.py
@@ -1,0 +1,76 @@
+"""Conformance gates for the standard-element-library port."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from inv_man_intake.intake.standard_elements import (
+    classify_element_standardness,
+    load_standard_element_library,
+)
+
+STUB_PATH = Path("config/standard_elements/_stub.json")
+SRC_ROOT = Path("src/inv_man_intake")
+
+
+def test_conformance_against_stub() -> None:
+    library = load_standard_element_library(STUB_PATH)
+
+    assert library.non_authoritative is True
+    assert library.doc_types() == ("stub_pitchbook", "stub_tear_sheet")
+
+    elements = library.elements_for("stub_pitchbook")
+    assert [element.key for element in elements] == [
+        "operations.aum",
+        "terms.management_fee",
+    ]
+
+    coverage = library.evaluate_coverage(
+        "stub_pitchbook",
+        {
+            "field_key": "operations.aum",
+            "fields": {"operations.aum"},
+            "value": 42.0,
+        },
+    )
+
+    assert [(item.key, item.detected, item.standardness) for item in coverage] == [
+        ("operations.aum", True, "unknown"),
+        ("terms.management_fee", False, "unknown"),
+    ]
+
+
+def test_data_only_doc_type_addition_surfaces_without_app_code_change(tmp_path: Path) -> None:
+    payload = json.loads(STUB_PATH.read_text(encoding="utf-8"))
+    payload["doc_types"]["capital_call_notice"] = [
+        {
+            "key": "operations.capital_call_due_date",
+            "detector_name": "field_present",
+            "mandatory": True,
+        }
+    ]
+    custom_stub = tmp_path / "standard-elements.json"
+    custom_stub.write_text(json.dumps(payload), encoding="utf-8")
+
+    library = load_standard_element_library(custom_stub)
+
+    assert "capital_call_notice" in library.doc_types()
+    assert library.elements_for("capital_call_notice")[0].key == (
+        "operations.capital_call_due_date"
+    )
+
+    source_text = "\n".join(
+        path.read_text(encoding="utf-8")
+        for path in SRC_ROOT.rglob("*.py")
+        if path.name != "standard_elements.py"
+    )
+    assert "capital_call_notice" not in source_text
+    assert "operations.capital_call_due_date" not in source_text
+
+
+def test_judgment_hook_is_unknown_only() -> None:
+    library = load_standard_element_library(STUB_PATH)
+    element = library.elements_for("stub_tear_sheet")[0]
+
+    assert classify_element_standardness(element=element, extracted={}) == "unknown"

--- a/tests/intake/test_standard_element_library.py
+++ b/tests/intake/test_standard_element_library.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from inv_man_intake.intake.standard_elements import (
+    DataDrivenStandardElementLibrary,
+    StandardElement,
     classify_element_standardness,
     load_standard_element_library,
 )
@@ -74,3 +78,58 @@ def test_judgment_hook_is_unknown_only() -> None:
     element = library.elements_for("stub_tear_sheet")[0]
 
     assert classify_element_standardness(element=element, extracted={}) == "unknown"
+
+
+def test_schema_boolean_fields_fail_closed() -> None:
+    payload = json.loads(STUB_PATH.read_text(encoding="utf-8"))
+
+    payload["non_authoritative"] = "yes"
+    with pytest.raises(ValueError, match="non_authoritative"):
+        load_standard_element_library(payload)
+
+    payload = json.loads(STUB_PATH.read_text(encoding="utf-8"))
+    payload["doc_types"]["stub_pitchbook"][0]["mandatory"] = "false"
+    with pytest.raises(ValueError, match="mandatory"):
+        load_standard_element_library(payload)
+
+
+def test_duplicate_element_keys_are_rejected() -> None:
+    payload = json.loads(STUB_PATH.read_text(encoding="utf-8"))
+    payload["doc_types"]["stub_pitchbook"].append(
+        {
+            "key": "operations.aum",
+            "detector_name": "field_present",
+            "mandatory": False,
+        }
+    )
+
+    with pytest.raises(ValueError, match="duplicate element key") as excinfo:
+        load_standard_element_library(payload)
+    assert "operations.aum" in str(excinfo.value)
+
+
+def test_doc_types_are_deterministic_and_empty_detector_registry_is_honored() -> None:
+    payload = json.loads(STUB_PATH.read_text(encoding="utf-8"))
+    payload["doc_types"] = {
+        "zeta_doc": payload["doc_types"]["stub_pitchbook"],
+        "alpha_doc": payload["doc_types"]["stub_tear_sheet"],
+    }
+
+    library = load_standard_element_library(payload)
+    assert library.doc_types() == ("alpha_doc", "zeta_doc")
+
+    with pytest.raises(ValueError, match="unknown detector reference"):
+        DataDrivenStandardElementLibrary(
+            version="test",
+            non_authoritative=True,
+            elements_by_doc_type={
+                "sample": (
+                    StandardElement(
+                        key="field.alpha",
+                        detector_name="field_present",
+                        mandatory=True,
+                    ),
+                )
+            },
+            detectors={},
+        )


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:721 -->
> **Source:** Issue #721

Closes #721

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The packet pipeline needs, per document type, the **standard elements** to detect deterministically and the
deviations to route to the LLM lane. But the **library CONTENT is a separate, human-judgment-heavy project,
deliberately deferred** (decision 4). To avoid constraining that future work, this issue builds **only the seam**:
a **minimal, data-driven, judgment-free port** the app depends on, a **deliberately-dumb stub library**, and a
**conformance test suite**. The app must depend on the *interface*, never on library content or a closed doc-type
set, so the real library can later be authored freely and swapped behind the port. Latent (no seam exists).

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#718](https://github.com/stranske/Inv-Man-Intake/issues/718)
- [#717](https://github.com/stranske/Inv-Man-Intake/issues/717)
- [#722](https://github.com/stranske/Inv-Man-Intake/issues/722)
- [#723](https://github.com/stranske/Inv-Man-Intake/issues/723)
- [#726](https://github.com/stranske/Inv-Man-Intake/issues/726)
- [#727](https://github.com/stranske/Inv-Man-Intake/issues/727)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] Add `src/inv_man_intake/intake/standard_elements.py`: the port Protocol + a `StandardElement` data shape
  (key/id, detector_name, mandatory) + a **data-driven** `load_standard_element_library(source)` that validates an
  externally-supplied data file (fail closed on schema violation) and exposes `doc_types()`/`elements_for()`.
- [ ] Add a **detector registry** (`register_detector(name)` / dispatch) so element detection is pluggable by name.
- [ ] Add a **no-op judgment hook** interface (`classify_element_standardness(...) -> "unknown"` stub) the future project replaces.
- [ ] Ship a labeled stub library data file (`config/standard_elements/_stub.*`, marked non-authoritative).
- [ ] Add `docs/contracts/standard_element_library.md` — the contract the external project must satisfy.
- [ ] Wire the classifier (#717) to consume `doc_types()` from the port (not a hardcoded list).

#### Acceptance criteria
- [ ] Named test `tests/intake/test_standard_element_library.py::test_conformance_against_stub` passes: the stub
  satisfies the port (loads, exposes types/elements, coverage runs).
- [ ] **Decoupling gate (the load-bearing one):** a test adds a brand-new throwaway doc type + element to the stub
  **data file only** and asserts it surfaces through the port (`doc_types()` includes it, `elements_for()` returns
  it) with **zero app code change**. Then a test asserts no doc-type/element identifier string is hardcoded in the
  pipeline/app modules (grep-style or import-boundary check).
- [ ] **Deliberate-break gate:** hardcode a doc type in the loader/pipeline instead of reading the data; the
  decoupling test **must FAIL**; revert → passes.
- [ ] A test asserts the judgment hook returns only "unknown" (encodes no standardness judgment) at this stage.

<!-- auto-status-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a data-driven standard element library, including loading versioned configurations and evaluating document coverage.
  * Introduced a public intake API for working with standard elements and detector registration.

* **Bug Fixes**
  * Coverage checks now return consistent per-field detection results and a clear “unknown” status for standardness.

* **Tests**
  * Added validation for the bundled stub configuration and verified that new document types can be surfaced through configuration without code changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->