### PR TITLE
Wire classifier to standard element library port

### DIFF
--- a/src/inv_man_intake/extraction/doc_type.py
+++ b/src/inv_man_intake/extraction/doc_type.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from collections.abc import Iterable
 from enum import StrEnum
 
@@ -56,7 +57,7 @@ def classify_doc_type(
     *,
     standard_library: StandardElementLibrary | None = None,
 ) -> DocumentType:
-    """Classify a document from deterministic text cues, falling back to unknown."""
+    """Classify a document from library IDs, then deterministic text cues."""
 
     text = _normalize_content(content)
     if not text:
@@ -81,7 +82,9 @@ def _classify_library_doc_type(
     for library_doc_type in standard_library.doc_types():
         normalized_doc_type = _normalize_identifier(library_doc_type)
         if _library_doc_type_present(text, normalized_doc_type):
-            return _document_type_from_library_id(normalized_doc_type)
+            document_type = _document_type_from_library_id(normalized_doc_type)
+            if document_type is not DocumentType.UNKNOWN:
+                return document_type
     return DocumentType.UNKNOWN
 
 
@@ -94,7 +97,15 @@ def _library_doc_type_present(text: str, normalized_doc_type: str) -> bool:
         _strip_stub_prefix(normalized_doc_type).replace("_", " "),
         _strip_stub_prefix(normalized_doc_type).replace("_", "-"),
     }
-    return any(variant and variant in text for variant in variants)
+    return any(variant and _contains_delimited_term(text, variant) for variant in variants)
+
+
+def _contains_delimited_term(text: str, term: str) -> bool:
+    parts = [re.escape(part) for part in re.split(r"[\s_-]+", term.strip()) if part]
+    if not parts:
+        return False
+    pattern = r"(?<![a-z0-9])" + r"[\s_-]+".join(parts) + r"(?![a-z0-9])"
+    return re.search(pattern, text) is not None
 
 
 def _normalize_identifier(value: str) -> str:
@@ -110,10 +121,24 @@ def _document_type_from_library_id(value: str) -> DocumentType:
     direct = _STANDARD_LIBRARY_TYPE_ALIASES.get(normalized)
     if direct is not None:
         return direct
+    tokens = tuple(token for token in normalized.split("_") if token)
     for alias, document_type in _STANDARD_LIBRARY_TYPE_ALIASES.items():
-        if normalized.endswith(f"_{alias}") or normalized.startswith(f"{alias}_"):
+        alias_tokens = tuple(alias.split("_"))
+        if _tokens_contain_alias(tokens, alias_tokens):
             return document_type
     return DocumentType.UNKNOWN
+
+
+def _tokens_contain_alias(tokens: tuple[str, ...], alias_tokens: tuple[str, ...]) -> bool:
+    if len(tokens) <= len(alias_tokens):
+        return False
+    starts_with_alias = tokens[: len(alias_tokens)] == alias_tokens
+    ends_with_alias = tokens[-len(alias_tokens) :] == alias_tokens
+    if starts_with_alias:
+        return True
+    if not ends_with_alias:
+        return False
+    return not any(token in {"no", "non", "not"} for token in tokens[: -len(alias_tokens)])
 
 
 def _normalize_content(content: str | bytes | Iterable[str]) -> str:

--- a/src/inv_man_intake/extraction/doc_type.py
+++ b/src/inv_man_intake/extraction/doc_type.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from collections.abc import Iterable
 from enum import StrEnum
 
+from inv_man_intake.intake.standard_elements import StandardElementLibrary
+
 
 class DocumentType(StrEnum):
     """Known screening document types used to select expected-field profiles."""
@@ -35,18 +37,82 @@ _DOCUMENT_TYPE_KEYWORDS: tuple[tuple[DocumentType, tuple[str, ...]], ...] = (
     ),
 )
 
+_STANDARD_LIBRARY_TYPE_ALIASES: dict[str, DocumentType] = {
+    "pitchbook": DocumentType.PITCHBOOK,
+    "pitch_book": DocumentType.PITCHBOOK,
+    "tear_sheet": DocumentType.TEAR_SHEET,
+    "tearsheet": DocumentType.TEAR_SHEET,
+    "factsheet": DocumentType.TEAR_SHEET,
+    "fact_sheet": DocumentType.TEAR_SHEET,
+    "monthly_letter": DocumentType.MONTHLY_LETTER,
+    "investor_letter": DocumentType.MONTHLY_LETTER,
+    "ddq": DocumentType.DDQ,
+    "due_diligence_questionnaire": DocumentType.DDQ,
+}
 
-def classify_doc_type(content: str | bytes | Iterable[str]) -> DocumentType:
+
+def classify_doc_type(
+    content: str | bytes | Iterable[str],
+    *,
+    standard_library: StandardElementLibrary | None = None,
+) -> DocumentType:
     """Classify a document from deterministic text cues, falling back to unknown."""
 
     text = _normalize_content(content)
     if not text:
         return DocumentType.UNKNOWN
 
+    if standard_library is not None:
+        library_match = _classify_library_doc_type(text, standard_library)
+        if library_match is not DocumentType.UNKNOWN:
+            return library_match
+
     for document_type, keywords in _DOCUMENT_TYPE_KEYWORDS:
         if any(keyword in text for keyword in keywords):
             return document_type
 
+    return DocumentType.UNKNOWN
+
+
+def _classify_library_doc_type(
+    text: str,
+    standard_library: StandardElementLibrary,
+) -> DocumentType:
+    for library_doc_type in standard_library.doc_types():
+        normalized_doc_type = _normalize_identifier(library_doc_type)
+        if _library_doc_type_present(text, normalized_doc_type):
+            return _document_type_from_library_id(normalized_doc_type)
+    return DocumentType.UNKNOWN
+
+
+def _library_doc_type_present(text: str, normalized_doc_type: str) -> bool:
+    variants = {
+        normalized_doc_type,
+        normalized_doc_type.replace("_", " "),
+        normalized_doc_type.replace("_", "-"),
+        _strip_stub_prefix(normalized_doc_type),
+        _strip_stub_prefix(normalized_doc_type).replace("_", " "),
+        _strip_stub_prefix(normalized_doc_type).replace("_", "-"),
+    }
+    return any(variant and variant in text for variant in variants)
+
+
+def _normalize_identifier(value: str) -> str:
+    return value.strip().casefold().replace("-", "_").replace(" ", "_")
+
+
+def _strip_stub_prefix(value: str) -> str:
+    return value.removeprefix("stub_")
+
+
+def _document_type_from_library_id(value: str) -> DocumentType:
+    normalized = _strip_stub_prefix(value)
+    direct = _STANDARD_LIBRARY_TYPE_ALIASES.get(normalized)
+    if direct is not None:
+        return direct
+    for alias, document_type in _STANDARD_LIBRARY_TYPE_ALIASES.items():
+        if normalized.endswith(f"_{alias}") or normalized.startswith(f"{alias}_"):
+            return document_type
     return DocumentType.UNKNOWN
 
 

--- a/tests/extraction/test_doc_type.py
+++ b/tests/extraction/test_doc_type.py
@@ -104,9 +104,16 @@ def test_classifier_consumes_standard_library_doc_types_from_data() -> None:
                         "mandatory": True,
                     }
                 ],
-                "custom_pitchbook": [
+                "custom_pitch_book": [
                     {
                         "key": "operations.aum",
+                        "detector_name": "field_present",
+                        "mandatory": True,
+                    }
+                ],
+                "not_a_pitch_book": [
+                    {
+                        "key": "operations.not_pitch_book",
                         "detector_name": "field_present",
                         "mandatory": True,
                     }
@@ -116,11 +123,18 @@ def test_classifier_consumes_standard_library_doc_types_from_data() -> None:
     )
 
     assert (
-        classify_doc_type("Fund VI custom pitchbook with AUM", standard_library=library)
+        classify_doc_type(
+            "Fund VI custom_pitch_book with AUM and capital_call_notice appendix",
+            standard_library=library,
+        )
         is DocumentType.PITCHBOOK
     )
     assert (
         classify_doc_type("Capital call notice for Fund VI", standard_library=library)
+        is DocumentType.UNKNOWN
+    )
+    assert (
+        classify_doc_type("not_a_pitch_book appendix", standard_library=library)
         is DocumentType.UNKNOWN
     )
 

--- a/tests/extraction/test_doc_type.py
+++ b/tests/extraction/test_doc_type.py
@@ -13,6 +13,7 @@ from inv_man_intake.extraction.confidence import (
 )
 from inv_man_intake.extraction.doc_type import DocumentType, classify_doc_type
 from inv_man_intake.extraction.providers.base import ExtractedDocumentResult, ExtractedField
+from inv_man_intake.intake.standard_elements import load_standard_element_library
 
 _CONFIG_PATH = Path(__file__).resolve().parents[2] / "config" / "extraction_thresholds.yaml"
 _GLOBAL_KEY_FIELDS = (
@@ -88,6 +89,47 @@ def test_classifier_handles_specific_document_types_without_ambiguous_matches() 
     assert classify_doc_type("Monthly commentary for investors") is DocumentType.MONTHLY_LETTER
     assert classify_doc_type("Private placement memorandum for Fund VI") is DocumentType.PITCHBOOK
     assert classify_doc_type("ESG parts per million emissions appendix") is DocumentType.UNKNOWN
+
+
+def test_classifier_consumes_standard_library_doc_types_from_data() -> None:
+    library = load_standard_element_library(
+        {
+            "version": "test",
+            "non_authoritative": True,
+            "doc_types": {
+                "capital_call_notice": [
+                    {
+                        "key": "operations.capital_call_due_date",
+                        "detector_name": "field_present",
+                        "mandatory": True,
+                    }
+                ],
+                "custom_pitchbook": [
+                    {
+                        "key": "operations.aum",
+                        "detector_name": "field_present",
+                        "mandatory": True,
+                    }
+                ],
+            },
+        }
+    )
+
+    assert (
+        classify_doc_type("Fund VI custom pitchbook with AUM", standard_library=library)
+        is DocumentType.PITCHBOOK
+    )
+    assert (
+        classify_doc_type("Capital call notice for Fund VI", standard_library=library)
+        is DocumentType.UNKNOWN
+    )
+
+    source_text = "\n".join(
+        path.read_text(encoding="utf-8")
+        for path in (Path(__file__).resolve().parents[2] / "src" / "inv_man_intake").rglob("*.py")
+    )
+    assert "capital_call_notice" not in source_text
+    assert "operations.capital_call_due_date" not in source_text
 
 
 def test_profile_overrides_are_merged_for_each_document_type() -> None:


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:721 -->
> **Source:** Issue #721

Closes #721

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The packet pipeline needs, per document type, the **standard elements** to detect deterministically and the
deviations to route to the LLM lane. But the **library CONTENT is a separate, human-judgment-heavy project,
deliberately deferred** (decision 4). To avoid constraining that future work, this issue builds **only the seam**:
a **minimal, data-driven, judgment-free port** the app depends on, a **deliberately-dumb stub library**, and a
**conformance test suite**. The app must depend on the *interface*, never on library content or a closed doc-type
set, so the real library can later be authored freely and swapped behind the port. Latent (no seam exists).

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#718](https://github.com/stranske/Inv-Man-Intake/issues/718)
- [#717](https://github.com/stranske/Inv-Man-Intake/issues/717)
- [#722](https://github.com/stranske/Inv-Man-Intake/issues/722)
- [#723](https://github.com/stranske/Inv-Man-Intake/issues/723)
- [#726](https://github.com/stranske/Inv-Man-Intake/issues/726)
- [#727](https://github.com/stranske/Inv-Man-Intake/issues/727)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] Add `src/inv_man_intake/intake/standard_elements.py`: the port Protocol + a `StandardElement` data shape
  (key/id, detector_name, mandatory) + a **data-driven** `load_standard_element_library(source)` that validates an
  externally-supplied data file (fail closed on schema violation) and exposes `doc_types()`/`elements_for()`.
- [ ] Add a **detector registry** (`register_detector(name)` / dispatch) so element detection is pluggable by name.
- [ ] Add a **no-op judgment hook** interface (`classify_element_standardness(...) -> "unknown"` stub) the future project replaces.
- [ ] Ship a labeled stub library data file (`config/standard_elements/_stub.*`, marked non-authoritative).
- [ ] Add `docs/contracts/standard_element_library.md` — the contract the external project must satisfy.
- [ ] Wire the classifier (#717) to consume `doc_types()` from the port (not a hardcoded list).

#### Acceptance criteria
- [ ] Named test `tests/intake/test_standard_element_library.py::test_conformance_against_stub` passes: the stub
  satisfies the port (loads, exposes types/elements, coverage runs).
- [ ] **Decoupling gate (the load-bearing one):** a test adds a brand-new throwaway doc type + element to the stub
  **data file only** and asserts it surfaces through the port (`doc_types()` includes it, `elements_for()` returns
  it) with **zero app code change**. Then a test asserts no doc-type/element identifier string is hardcoded in the
  pipeline/app modules (grep-style or import-boundary check).
- [ ] **Deliberate-break gate:** hardcode a doc type in the loader/pipeline instead of reading the data; the
  decoupling test **must FAIL**; revert → passes.
- [ ] A test asserts the judgment hook returns only "unknown" (encodes no standardness judgment) at this stage.

<!-- auto-status-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Document type detection can now use an optional standard library of document definitions before falling back to keyword matching.
  * Broader text normalization helps recognize more naming variants, including aliases and separator differences.

* **Bug Fixes**
  * Improved classification accuracy for documents with custom or library-provided type names.
  * Unknown documents still safely fall back to an unknown type when no match is found.

* **Tests**
  * Added coverage for classification using dynamically loaded standard library data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->