### PR TITLE
Add packet-level ingestion pipeline

### DIFF
--- a/src/inv_man_intake/extraction/doc_type.py
+++ b/src/inv_man_intake/extraction/doc_type.py
@@ -108,6 +108,12 @@ def _contains_delimited_term(text: str, term: str) -> bool:
     return re.search(pattern, text) is not None
 
 
+def contains_delimited_term(text: str, term: str) -> bool:
+    """Return whether a normalized term appears on token boundaries."""
+
+    return _contains_delimited_term(text, term)
+
+
 def _normalize_identifier(value: str) -> str:
     return value.strip().casefold().replace("-", "_").replace(" ", "_")
 

--- a/src/inv_man_intake/intake/standard_elements.py
+++ b/src/inv_man_intake/intake/standard_elements.py
@@ -236,5 +236,11 @@ def _field_present_detector(extracted: Mapping[str, Any]) -> bool:
 def _numeric_field_present_detector(extracted: Mapping[str, Any]) -> bool:
     if not _field_present_detector(extracted):
         return False
-    value = extracted.get("value")
+    field_key = extracted.get("field_key")
+    values = extracted.get("values")
+    value = (
+        values.get(field_key)
+        if isinstance(field_key, str) and isinstance(values, Mapping)
+        else extracted.get("value")
+    )
     return isinstance(value, int | float) and not isinstance(value, bool)

--- a/src/inv_man_intake/packet.py
+++ b/src/inv_man_intake/packet.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from types import MappingProxyType
@@ -12,8 +13,8 @@ from inv_man_intake.extraction.cross_check import (
 )
 from inv_man_intake.extraction.doc_type import (
     DocumentType,
-    _contains_delimited_term,
     classify_doc_type,
+    contains_delimited_term,
 )
 from inv_man_intake.extraction.providers.base import (
     ExtractedDocumentResult,
@@ -170,7 +171,7 @@ def _library_doc_type_from_content(
             doc_type.casefold().replace("_", " "),
             doc_type.casefold().replace("_", "-"),
         }
-        if any(_contains_delimited_term(normalized, variant) for variant in variants):
+        if any(contains_delimited_term(normalized, variant) for variant in variants):
             return doc_type
     return DocumentType.UNKNOWN.value
 
@@ -185,9 +186,30 @@ def _evaluate_coverage(
         return ()
     extracted = {
         "fields": {field.key for field in extraction.fields},
-        "values": {field.key: field.value for field in extraction.fields},
+        "values": {field.key: _coverage_value(field.value) for field in extraction.fields},
     }
     return standard_library.evaluate_coverage(document_type, extracted)
+
+
+_NUMERIC_VALUE_RE = re.compile(
+    r"^\s*[$€£]?\s*([+-]?(?:\d+(?:,\d{3})*|\d*)(?:\.\d+)?)\s*([%kmb])?\s*$",
+    re.IGNORECASE,
+)
+
+
+def _coverage_value(value: str) -> str | float:
+    match = _NUMERIC_VALUE_RE.match(value)
+    if match is None:
+        return value
+    number_text = match.group(1)
+    if not number_text or number_text in {"+", "-", "."}:
+        return value
+    numeric = float(number_text.replace(",", ""))
+    suffix = (match.group(2) or "").casefold()
+    multipliers = {"k": 1_000.0, "m": 1_000_000.0, "b": 1_000_000_000.0}
+    if suffix in multipliers:
+        numeric *= multipliers[suffix]
+    return numeric
 
 
 def _collect_fields(

--- a/src/inv_man_intake/packet.py
+++ b/src/inv_man_intake/packet.py
@@ -1,0 +1,230 @@
+"""Packet-level ingestion orchestration for multi-document manager profiles."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+
+from inv_man_intake.extraction.cross_check import (
+    CrossCheckReport,
+    cross_check_extraction_results,
+)
+from inv_man_intake.extraction.doc_type import DocumentType, classify_doc_type
+from inv_man_intake.extraction.providers.base import (
+    ExtractedDocumentResult,
+    ExtractionProvider,
+)
+from inv_man_intake.intake.standard_elements import (
+    ElementCoverage,
+    StandardElementLibrary,
+)
+
+
+@dataclass(frozen=True)
+class PacketFile:
+    """One source document in a packet."""
+
+    document_id: str
+    content: bytes
+    filename: str | None = None
+
+
+@dataclass(frozen=True)
+class PacketDocumentProfile:
+    """Per-document extraction, routing, coverage, and lineage."""
+
+    document_id: str
+    filename: str | None
+    document_type: str
+    extraction: ExtractedDocumentResult
+    standard_element_coverage: tuple[ElementCoverage, ...]
+    lineage_refs: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ManagerProfile:
+    """Unified packet output consumed by the operator app and CLI."""
+
+    packet_id: str
+    documents: tuple[PacketDocumentProfile, ...]
+    identity: Mapping[str, str]
+    terms: Mapping[str, str]
+    returns_metrics: Mapping[str, str]
+    graphics_refs: tuple[str, ...]
+    per_doc_standard_element_coverage: Mapping[str, tuple[ElementCoverage, ...]]
+    flagged_non_standard_items: tuple[str, ...]
+    scores: Mapping[str, float]
+    lineage_refs: tuple[str, ...]
+    reconciliation: CrossCheckReport
+
+    @property
+    def escalations(self) -> tuple[str, ...]:
+        """Field-level reconciliation reasons that need analyst triage."""
+
+        return self.reconciliation.escalation_reasons
+
+
+def ingest_packet(
+    files: Sequence[PacketFile],
+    *,
+    provider: ExtractionProvider,
+    standard_library: StandardElementLibrary,
+    packet_id: str = "packet",
+    tolerance_percent: float = 5.0,
+) -> ManagerProfile:
+    """Extract a packet of documents and assemble one reconciled manager profile."""
+
+    if not files:
+        raise ValueError("packet must contain at least one file")
+
+    document_profiles: list[PacketDocumentProfile] = []
+    for packet_file in files:
+        extraction = provider.extract(packet_file.document_id, packet_file.content)
+        document_type = _classify_packet_document(
+            packet_file=packet_file,
+            extraction=extraction,
+            standard_library=standard_library,
+        )
+        coverage = _evaluate_coverage(
+            document_type=document_type,
+            extraction=extraction,
+            standard_library=standard_library,
+        )
+        document_profiles.append(
+            PacketDocumentProfile(
+                document_id=packet_file.document_id,
+                filename=packet_file.filename,
+                document_type=document_type,
+                extraction=extraction,
+                standard_element_coverage=coverage,
+                lineage_refs=_lineage_refs(extraction),
+            )
+        )
+
+    extractions = tuple(document.extraction for document in document_profiles)
+    reconciliation = cross_check_extraction_results(
+        extractions,
+        tolerance_percent=tolerance_percent,
+    )
+    return ManagerProfile(
+        packet_id=packet_id,
+        documents=tuple(document_profiles),
+        identity=_collect_fields(extractions, prefix="identity."),
+        terms=_collect_fields(extractions, prefix="terms."),
+        returns_metrics=_collect_fields(extractions, prefix="performance."),
+        graphics_refs=_graphics_refs(extractions),
+        per_doc_standard_element_coverage={
+            document.document_id: document.standard_element_coverage
+            for document in document_profiles
+        },
+        flagged_non_standard_items=_flagged_non_standard_items(document_profiles),
+        scores=_scores(extractions),
+        lineage_refs=tuple(
+            lineage_ref for document in document_profiles for lineage_ref in document.lineage_refs
+        ),
+        reconciliation=reconciliation,
+    )
+
+
+def _classify_packet_document(
+    *,
+    packet_file: PacketFile,
+    extraction: ExtractedDocumentResult,
+    standard_library: StandardElementLibrary,
+) -> str:
+    content = _classification_content(packet_file=packet_file, extraction=extraction)
+    document_type = classify_doc_type(content, standard_library=standard_library)
+    if document_type is DocumentType.UNKNOWN:
+        return _library_doc_type_from_content(content, standard_library=standard_library)
+    return document_type.value
+
+
+def _classification_content(
+    *,
+    packet_file: PacketFile,
+    extraction: ExtractedDocumentResult,
+) -> tuple[str, ...]:
+    content = packet_file.content.decode("utf-8", errors="ignore")
+    field_values = tuple(field.value for field in extraction.fields)
+    filename = (packet_file.filename,) if packet_file.filename else ()
+    return (content, *field_values, *filename)
+
+
+def _library_doc_type_from_content(
+    content: Sequence[str],
+    *,
+    standard_library: StandardElementLibrary,
+) -> str:
+    normalized = "\n".join(content).casefold()
+    for doc_type in standard_library.doc_types():
+        variants = {
+            doc_type.casefold(),
+            doc_type.casefold().replace("_", " "),
+            doc_type.casefold().replace("_", "-"),
+        }
+        if any(variant in normalized for variant in variants):
+            return doc_type
+    return DocumentType.UNKNOWN.value
+
+
+def _evaluate_coverage(
+    *,
+    document_type: str,
+    extraction: ExtractedDocumentResult,
+    standard_library: StandardElementLibrary,
+) -> tuple[ElementCoverage, ...]:
+    if document_type not in standard_library.doc_types():
+        return ()
+    extracted = {
+        "fields": {field.key for field in extraction.fields},
+        "values": {field.key: field.value for field in extraction.fields},
+    }
+    return standard_library.evaluate_coverage(document_type, extracted)
+
+
+def _collect_fields(
+    results: Sequence[ExtractedDocumentResult],
+    *,
+    prefix: str,
+) -> dict[str, str]:
+    collected: dict[str, str] = {}
+    for result in results:
+        for field in result.fields:
+            if field.key.startswith(prefix):
+                collected.setdefault(field.key, field.value)
+    return collected
+
+
+def _graphics_refs(results: Sequence[ExtractedDocumentResult]) -> tuple[str, ...]:
+    refs: list[str] = []
+    for result in results:
+        images = getattr(result, "images", ())
+        refs.extend(f"{result.source_doc_id}:image:{index}" for index, _ in enumerate(images))
+    return tuple(refs)
+
+
+def _flagged_non_standard_items(
+    documents: Sequence[PacketDocumentProfile],
+) -> tuple[str, ...]:
+    flags: list[str] = []
+    for document in documents:
+        for coverage in document.standard_element_coverage:
+            if coverage.standardness != "unknown":
+                flags.append(f"{document.document_id}:{coverage.key}:{coverage.standardness}")
+    return tuple(flags)
+
+
+def _scores(results: Sequence[ExtractedDocumentResult]) -> dict[str, float]:
+    fields = [field for result in results for field in result.fields]
+    if not fields:
+        return {"extraction_confidence": 0.0}
+    return {
+        "extraction_confidence": sum(field.confidence for field in fields) / len(fields),
+    }
+
+
+def _lineage_refs(extraction: ExtractedDocumentResult) -> tuple[str, ...]:
+    return tuple(
+        f"{field.source_doc_id}:{field.key}:p{field.source_page}:{field.method}"
+        for field in extraction.fields
+    )

--- a/src/inv_man_intake/packet.py
+++ b/src/inv_man_intake/packet.py
@@ -4,12 +4,17 @@ from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
+from types import MappingProxyType
 
 from inv_man_intake.extraction.cross_check import (
     CrossCheckReport,
     cross_check_extraction_results,
 )
-from inv_man_intake.extraction.doc_type import DocumentType, classify_doc_type
+from inv_man_intake.extraction.doc_type import (
+    DocumentType,
+    _contains_delimited_term,
+    classify_doc_type,
+)
 from inv_man_intake.extraction.providers.base import (
     ExtractedDocumentResult,
     ExtractionProvider,
@@ -76,6 +81,7 @@ def ingest_packet(
 
     if not files:
         raise ValueError("packet must contain at least one file")
+    _validate_unique_document_ids(files)
 
     document_profiles: list[PacketDocumentProfile] = []
     for packet_file in files:
@@ -109,16 +115,18 @@ def ingest_packet(
     return ManagerProfile(
         packet_id=packet_id,
         documents=tuple(document_profiles),
-        identity=_collect_fields(extractions, prefix="identity."),
-        terms=_collect_fields(extractions, prefix="terms."),
-        returns_metrics=_collect_fields(extractions, prefix="performance."),
+        identity=MappingProxyType(_collect_fields(extractions, prefix="identity.")),
+        terms=MappingProxyType(_collect_fields(extractions, prefix="terms.")),
+        returns_metrics=MappingProxyType(_collect_fields(extractions, prefix="performance.")),
         graphics_refs=_graphics_refs(extractions),
-        per_doc_standard_element_coverage={
-            document.document_id: document.standard_element_coverage
-            for document in document_profiles
-        },
+        per_doc_standard_element_coverage=MappingProxyType(
+            {
+                document.document_id: document.standard_element_coverage
+                for document in document_profiles
+            }
+        ),
         flagged_non_standard_items=_flagged_non_standard_items(document_profiles),
-        scores=_scores(extractions),
+        scores=MappingProxyType(_scores(extractions)),
         lineage_refs=tuple(
             lineage_ref for document in document_profiles for lineage_ref in document.lineage_refs
         ),
@@ -145,7 +153,7 @@ def _classification_content(
     extraction: ExtractedDocumentResult,
 ) -> tuple[str, ...]:
     content = packet_file.content.decode("utf-8", errors="ignore")
-    field_values = tuple(field.value for field in extraction.fields)
+    field_values = tuple(str(field.value) for field in extraction.fields)
     filename = (packet_file.filename,) if packet_file.filename else ()
     return (content, *field_values, *filename)
 
@@ -162,7 +170,7 @@ def _library_doc_type_from_content(
             doc_type.casefold().replace("_", " "),
             doc_type.casefold().replace("_", "-"),
         }
-        if any(variant in normalized for variant in variants):
+        if any(_contains_delimited_term(normalized, variant) for variant in variants):
             return doc_type
     return DocumentType.UNKNOWN.value
 
@@ -209,6 +217,8 @@ def _flagged_non_standard_items(
     flags: list[str] = []
     for document in documents:
         for coverage in document.standard_element_coverage:
+            if coverage.mandatory and not coverage.detected:
+                flags.append(f"{document.document_id}:{coverage.key}:missing_mandatory")
             if coverage.standardness != "unknown":
                 flags.append(f"{document.document_id}:{coverage.key}:{coverage.standardness}")
     return tuple(flags)
@@ -228,3 +238,16 @@ def _lineage_refs(extraction: ExtractedDocumentResult) -> tuple[str, ...]:
         f"{field.source_doc_id}:{field.key}:p{field.source_page}:{field.method}"
         for field in extraction.fields
     )
+
+
+def _validate_unique_document_ids(files: Sequence[PacketFile]) -> None:
+    seen: set[str] = set()
+    duplicates: set[str] = set()
+    for packet_file in files:
+        if packet_file.document_id in seen:
+            duplicates.add(packet_file.document_id)
+        seen.add(packet_file.document_id)
+    if duplicates:
+        raise ValueError(
+            "packet document_id values must be unique: " + ", ".join(sorted(duplicates))
+        )

--- a/tests/test_packet_pipeline.py
+++ b/tests/test_packet_pipeline.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from dataclasses import replace
 from pathlib import Path
-from typing import cast
 
 import inv_man_intake.packet
 from inv_man_intake.extraction.providers.base import ExtractedDocumentResult, ExtractedField
@@ -271,7 +270,7 @@ def test_packet_numeric_detector_uses_field_values_payload() -> None:
                 "deck": _result(
                     source_doc_id="deck",
                     provider_name="deck-provider",
-                    fields=(_field("operations.aum", cast(str, 100.0), "deck", 0.8),),
+                    fields=(_field("operations.aum", "$100.0M", "deck", 0.8),),
                 )
             }
         ),

--- a/tests/test_packet_pipeline.py
+++ b/tests/test_packet_pipeline.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 from dataclasses import replace
+from pathlib import Path
+from typing import cast
 
+import inv_man_intake.packet
 from inv_man_intake.extraction.providers.base import ExtractedDocumentResult, ExtractedField
 from inv_man_intake.intake.standard_elements import load_standard_element_library
 from inv_man_intake.packet import PacketFile, ingest_packet
@@ -77,6 +80,57 @@ def test_multi_doc_packet_assembles_profile_and_reconciles() -> None:
     assert profile.escalations[0].startswith("cross_check_disagreement:operations.aum")
     assert profile.lineage_refs
     assert profile.scores["extraction_confidence"] > 0
+
+
+def test_packet_rejects_duplicate_document_ids() -> None:
+    provider = _PacketProvider(
+        {
+            "duplicate": _result(
+                source_doc_id="duplicate",
+                provider_name="provider",
+                fields=(),
+            )
+        }
+    )
+
+    try:
+        ingest_packet(
+            (
+                PacketFile(document_id="duplicate", content=b"left"),
+                PacketFile(document_id="duplicate", content=b"right"),
+            ),
+            provider=provider,
+            standard_library=_library_for_doc_type("duplicate"),
+        )
+    except ValueError as exc:
+        assert "document_id values must be unique" in str(exc)
+    else:  # pragma: no cover - assertion branch
+        raise AssertionError("duplicate document ids should fail fast")
+
+
+def test_manager_profile_mappings_are_read_only() -> None:
+    profile = ingest_packet(
+        (PacketFile(document_id="deck", content=b"deck"),),
+        provider=_PacketProvider(
+            {
+                "deck": _result(
+                    source_doc_id="deck",
+                    provider_name="deck-provider",
+                    fields=(_field("identity.manager", "Alpha", "deck", 0.9),),
+                )
+            }
+        ),
+        standard_library=_library_for_doc_type("deck"),
+    )
+
+    for mapping in (
+        profile.identity,
+        profile.terms,
+        profile.returns_metrics,
+        profile.per_doc_standard_element_coverage,
+        profile.scores,
+    ):
+        assert type(mapping).__name__ == "mappingproxy"
 
 
 def test_multi_doc_packet_fails_without_reconciliation() -> None:
@@ -153,9 +207,96 @@ def test_packet_routes_throwaway_doc_type_through_library_data() -> None:
 
     assert profile.documents[0].document_type == throwaway_doc_type
     assert profile.per_doc_standard_element_coverage["custom"][0].detected is True
-    packet_source = __import__("pathlib").Path("src/inv_man_intake/packet.py").read_text()
+    packet_source = Path(inv_man_intake.packet.__file__).read_text()
     assert throwaway_doc_type not in packet_source
     assert "custom.metric" not in packet_source
+
+
+def test_packet_library_doc_type_fallback_is_delimiter_aware() -> None:
+    library = load_standard_element_library(
+        {
+            "version": "packet-test",
+            "non_authoritative": True,
+            "doc_types": {
+                "deck": [
+                    {
+                        "key": "operations.aum",
+                        "detector_name": "field_present",
+                        "mandatory": True,
+                    }
+                ]
+            },
+        }
+    )
+
+    profile = ingest_packet(
+        (PacketFile(document_id="feedback", content=b"customer feedback"),),
+        provider=_PacketProvider(
+            {
+                "feedback": _result(
+                    source_doc_id="feedback",
+                    provider_name="feedback-provider",
+                    fields=(_field("operations.aum", "$100M", "feedback", 0.8),),
+                )
+            }
+        ),
+        standard_library=library,
+    )
+
+    assert profile.documents[0].document_type == "unknown"
+    assert profile.per_doc_standard_element_coverage["feedback"] == ()
+
+
+def test_packet_numeric_detector_uses_field_values_payload() -> None:
+    library = load_standard_element_library(
+        {
+            "version": "packet-test",
+            "non_authoritative": True,
+            "doc_types": {
+                "deck": [
+                    {
+                        "key": "operations.aum",
+                        "detector_name": "numeric_field_present",
+                        "mandatory": True,
+                    }
+                ]
+            },
+        }
+    )
+
+    profile = ingest_packet(
+        (PacketFile(document_id="deck", content=b"deck"),),
+        provider=_PacketProvider(
+            {
+                "deck": _result(
+                    source_doc_id="deck",
+                    provider_name="deck-provider",
+                    fields=(_field("operations.aum", cast(str, 100.0), "deck", 0.8),),
+                )
+            }
+        ),
+        standard_library=library,
+    )
+
+    assert profile.per_doc_standard_element_coverage["deck"][0].detected is True
+
+
+def test_packet_flags_missing_mandatory_elements() -> None:
+    profile = ingest_packet(
+        (PacketFile(document_id="deck", content=b"deck"),),
+        provider=_PacketProvider(
+            {
+                "deck": _result(
+                    source_doc_id="deck",
+                    provider_name="deck-provider",
+                    fields=(),
+                )
+            }
+        ),
+        standard_library=_library_for_doc_type("deck"),
+    )
+
+    assert profile.flagged_non_standard_items == ("deck:operations.aum:missing_mandatory",)
 
 
 class _PacketProvider:
@@ -194,4 +335,22 @@ def _field(
         source_doc_id="source",
         source_page=1,
         method=method,
+    )
+
+
+def _library_for_doc_type(doc_type: str):
+    return load_standard_element_library(
+        {
+            "version": "packet-test",
+            "non_authoritative": True,
+            "doc_types": {
+                doc_type: [
+                    {
+                        "key": "operations.aum",
+                        "detector_name": "field_present",
+                        "mandatory": True,
+                    }
+                ]
+            },
+        }
     )

--- a/tests/test_packet_pipeline.py
+++ b/tests/test_packet_pipeline.py
@@ -1,0 +1,197 @@
+"""Tests for packet-level manager profile assembly."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+from inv_man_intake.extraction.providers.base import ExtractedDocumentResult, ExtractedField
+from inv_man_intake.intake.standard_elements import load_standard_element_library
+from inv_man_intake.packet import PacketFile, ingest_packet
+
+
+def test_multi_doc_packet_assembles_profile_and_reconciles() -> None:
+    library = load_standard_element_library(
+        {
+            "version": "packet-test",
+            "non_authoritative": True,
+            "doc_types": {
+                "deck": [
+                    {
+                        "key": "operations.aum",
+                        "detector_name": "field_present",
+                        "mandatory": True,
+                    }
+                ],
+                "track_record": [
+                    {
+                        "key": "performance.net_return_1y",
+                        "detector_name": "field_present",
+                        "mandatory": True,
+                    }
+                ],
+            },
+        }
+    )
+    provider = _PacketProvider(
+        {
+            "deck": _result(
+                source_doc_id="deck",
+                provider_name="deck-provider",
+                fields=(
+                    _field("operations.aum", "$100.0M", "deck-regex", 0.91),
+                    _field("terms.management_fee", "1.25%", "deck-regex", 0.88),
+                ),
+            ),
+            "track": _result(
+                source_doc_id="track",
+                provider_name="track-provider",
+                fields=(
+                    _field("operations.aum", "$89.0M", "track-regex", 0.89),
+                    _field("performance.net_return_1y", "12.5%", "track-regex", 0.87),
+                ),
+            ),
+        }
+    )
+
+    profile = ingest_packet(
+        (
+            PacketFile(document_id="deck", content=b"deck packet", filename="deck.txt"),
+            PacketFile(
+                document_id="track",
+                content=b"track_record packet",
+                filename="track-record.txt",
+            ),
+        ),
+        provider=provider,
+        standard_library=library,
+        packet_id="manager-packet",
+    )
+
+    assert profile.packet_id == "manager-packet"
+    assert {document.document_id for document in profile.documents} == {"deck", "track"}
+    assert profile.terms["terms.management_fee"] == "1.25%"
+    assert profile.returns_metrics["performance.net_return_1y"] == "12.5%"
+    assert profile.per_doc_standard_element_coverage["deck"][0].detected is True
+    assert profile.per_doc_standard_element_coverage["track"][0].detected is True
+    assert profile.escalations
+    assert profile.escalations[0].startswith("cross_check_disagreement:operations.aum")
+    assert profile.lineage_refs
+    assert profile.scores["extraction_confidence"] > 0
+
+
+def test_multi_doc_packet_fails_without_reconciliation() -> None:
+    profile = ingest_packet(
+        (
+            PacketFile(document_id="left", content=b"left"),
+            PacketFile(document_id="right", content=b"right"),
+        ),
+        provider=_PacketProvider(
+            {
+                "left": _result(
+                    source_doc_id="left",
+                    provider_name="left-provider",
+                    fields=(_field("operations.aum", "$100M", "left", 0.9),),
+                ),
+                "right": _result(
+                    source_doc_id="right",
+                    provider_name="right-provider",
+                    fields=(_field("operations.aum", "$80M", "right", 0.8),),
+                ),
+            }
+        ),
+        standard_library=load_standard_element_library(
+            {
+                "version": "packet-test",
+                "non_authoritative": True,
+                "doc_types": {
+                    "left": [
+                        {
+                            "key": "operations.aum",
+                            "detector_name": "field_present",
+                            "mandatory": True,
+                        }
+                    ]
+                },
+            },
+        ),
+    )
+
+    assert profile.escalations, "disabling cross-document reconciliation must fail this gate"
+
+
+def test_packet_routes_throwaway_doc_type_through_library_data() -> None:
+    throwaway_doc_type = "library_added_packet_type"
+    library = load_standard_element_library(
+        {
+            "version": "packet-test",
+            "non_authoritative": True,
+            "doc_types": {
+                throwaway_doc_type: [
+                    {
+                        "key": "custom.metric",
+                        "detector_name": "field_present",
+                        "mandatory": False,
+                    }
+                ]
+            },
+        }
+    )
+
+    profile = ingest_packet(
+        (PacketFile(document_id="custom", content=throwaway_doc_type.encode()),),
+        provider=_PacketProvider(
+            {
+                "custom": _result(
+                    source_doc_id="custom",
+                    provider_name="custom-provider",
+                    fields=(_field("custom.metric", "present", "custom", 0.8),),
+                )
+            }
+        ),
+        standard_library=library,
+    )
+
+    assert profile.documents[0].document_type == throwaway_doc_type
+    assert profile.per_doc_standard_element_coverage["custom"][0].detected is True
+    packet_source = __import__("pathlib").Path("src/inv_man_intake/packet.py").read_text()
+    assert throwaway_doc_type not in packet_source
+    assert "custom.metric" not in packet_source
+
+
+class _PacketProvider:
+    def __init__(self, results: dict[str, ExtractedDocumentResult]) -> None:
+        self._results = results
+
+    def extract(self, source_doc_id: str, content: bytes) -> ExtractedDocumentResult:
+        _ = content
+        result = self._results[source_doc_id]
+        return replace(result, source_doc_id=source_doc_id)
+
+
+def _result(
+    *,
+    source_doc_id: str,
+    provider_name: str,
+    fields: tuple[ExtractedField, ...],
+) -> ExtractedDocumentResult:
+    return ExtractedDocumentResult(
+        source_doc_id=source_doc_id,
+        provider_name=provider_name,
+        fields=fields,
+    )
+
+
+def _field(
+    key: str,
+    value: str,
+    method: str,
+    confidence: float,
+) -> ExtractedField:
+    return ExtractedField(
+        key=key,
+        value=value,
+        confidence=confidence,
+        source_doc_id="source",
+        source_page=1,
+        method=method,
+    )


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:722 -->
> **Source:** Issue #722

Closes #722

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Today the pipeline ingests a **single bundle** (`run.run_pipeline` → `v1_smoke._run_pipeline_core`). The operator
app needs a **packet-level** process: many files of different doc types ingested together, each routed to its
type's processing, then reconciled into one manager profile. No packet orchestration exists. Latent capability gap.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#718](https://github.com/stranske/Inv-Man-Intake/issues/718)
- [#721](https://github.com/stranske/Inv-Man-Intake/issues/721)
- [#717](https://github.com/stranske/Inv-Man-Intake/issues/717)
- [#715](https://github.com/stranske/Inv-Man-Intake/issues/715)
- [#723](https://github.com/stranske/Inv-Man-Intake/issues/723)
- [#726](https://github.com/stranske/Inv-Man-Intake/issues/726)
- [#727](https://github.com/stranske/Inv-Man-Intake/issues/727)
- [#725](https://github.com/stranske/Inv-Man-Intake/issues/725)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] Add `src/inv_man_intake/packet.py::ingest_packet(files, ...) -> ManagerProfile` composing existing stages
  (`register_intake_bundle_file`, providers, `images`, `performance`, `confidence`, `scoring`) per doc type.
- [ ] Add a `ManagerProfile` contract (identity, terms, returns+metrics, graphics refs, per-doc standard-element
  coverage, flagged non-standard items, scores, lineage refs).
- [ ] Cross-document reconciliation of shared facts (AUM/returns/fees across deck/ADV/track-record) via the #715
  cross-check; conflicts → escalation rows.

#### Acceptance criteria
- [ ] Named test `tests/test_packet_pipeline.py::test_multi_doc_packet_assembles_profile_and_reconciles` passes:
  a 2-doc packet (deck + track record) with an AUM that disagrees beyond tolerance produces a profile AND an
  escalation for the conflicting fact.
- [ ] **Deliberate-break gate:** disable cross-document reconciliation; the named test **must FAIL** (no
  escalation for the conflicting AUM); revert → passes.
- [ ] `pytest tests/ -q` green; single-bundle behavior unchanged.
- [ ] **Decoupling gate:** a test adds a throwaway doc type to the #721 stub data and asserts the packet pipeline
  routes/handles it through the port with **zero code change here**; a check asserts no doc-type/element identifier
  is hardcoded in this module.

<!-- auto-status-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added packet-level intake for processing multiple documents into one unified profile.
  * Added per-document coverage, scoring, lineage, and escalation details to the final output.

* **Bug Fixes**
  * Improved numeric field detection so values are recognized from structured field data as well as legacy direct values.
  * Added safer handling for document type fallback when content does not match a known type.
  * Duplicate document IDs are now rejected early.
  * Missing required elements are now flagged more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->