### PR TITLE
Add intake-improvement assistant

### DIFF
--- a/app/streamlit_app.py
+++ b/app/streamlit_app.py
@@ -16,7 +16,7 @@ DESIGN_SYSTEM_ROOT = Path(__file__).resolve().parents[1] / "design-system"
 if str(DESIGN_SYSTEM_ROOT) not in sys.path:
     sys.path.insert(0, str(DESIGN_SYSTEM_ROOT))
 
-from inv_man_intake.assist.intake_assistant import IntakeRecommendation  # noqa: E402
+from inv_man_intake.assist import IntakeRecommendation  # noqa: E402
 from inv_man_intake.extraction.providers.base import (  # noqa: E402
     ExtractedDocumentResult,
     ExtractedField,
@@ -649,7 +649,11 @@ def render_assistant_panel(
             rationale=recommendation.rationale,
             citations=", ".join(recommendation.cited_evidence),
             expected_effect=recommendation.expected_effect,
-            action="Apply manually",
+            action=(
+                "Apply manually"
+                if recommendation.apply_manually
+                else "Blocked (auto-apply not permitted)"
+            ),
         )
         for recommendation in recommendations
     )

--- a/app/streamlit_app.py
+++ b/app/streamlit_app.py
@@ -24,6 +24,7 @@ from inv_man_intake.intake.standard_elements import (  # noqa: E402
     StandardElementLibrary,
     load_standard_element_library,
 )
+from inv_man_intake.assist.intake_assistant import IntakeRecommendation  # noqa: E402
 from inv_man_intake.observability import InMemoryTraceSink  # noqa: E402
 from inv_man_intake.packet import PacketFile, ingest_packet  # noqa: E402
 from inv_man_intake.readiness.fixture_batches import DEFAULT_BATCH_PACKAGES  # noqa: E402
@@ -143,6 +144,18 @@ class OperatorPacketView:
     return_rows: list[dict[str, object]]
     exception_rows: list[dict[str, object]]
     outbound_calls: int
+
+
+@dataclass(frozen=True)
+class AssistantPanelRecommendation:
+    """Browser-renderable assistant recommendation row."""
+
+    rank: int
+    change: str
+    rationale: str
+    citations: str
+    expected_effect: str
+    action: str
 
 
 QUEUE_ACTION_STATE_KEY = "analyst_queue_action_state"
@@ -608,6 +621,54 @@ def render_operator_packet(
     return view
 
 
+def demo_assistant_recommendations(result: DemoResult) -> tuple[IntakeRecommendation, ...]:
+    """Return deterministic recommend-only rows for the browser demo surface."""
+
+    evidence = f"{result.package_id}:score:{result.final_score:.4f}"
+    return (
+        IntakeRecommendation(
+            rank=1,
+            change="Review threshold inputs for the selected packet",
+            rationale=f"Pipeline decision: {result.decision_reason}",
+            cited_evidence=(evidence,),
+            expected_effect="Clarifies whether the next run should escalate or auto-pass",
+        ),
+    )
+
+
+def render_assistant_panel(
+    st: StreamlitLike,
+    recommendations: Sequence[IntakeRecommendation],
+) -> tuple[AssistantPanelRecommendation, ...]:
+    """Render assistant recommendations with explicit manual-apply actions."""
+
+    rows = tuple(
+        AssistantPanelRecommendation(
+            rank=recommendation.rank,
+            change=recommendation.change,
+            rationale=recommendation.rationale,
+            citations=", ".join(recommendation.cited_evidence),
+            expected_effect=recommendation.expected_effect,
+            action="Apply manually",
+        )
+        for recommendation in recommendations
+    )
+    st.table(
+        [
+            {
+                "Rank": row.rank,
+                "Recommendation": row.change,
+                "Rationale": row.rationale,
+                "Citations": row.citations,
+                "Expected effect": row.expected_effect,
+                "Action": row.action,
+            }
+            for row in rows
+        ]
+    )
+    return rows
+
+
 def render_app(st: StreamlitLike | None = None) -> DemoResult:
     """Render the browser demo and return the underlying deterministic result."""
 
@@ -638,6 +699,8 @@ def render_app(st: StreamlitLike | None = None) -> DemoResult:
     st.subheader("Analyst queue")
     render_analyst_queue(st, result)
     render_operator_packet(st, use_real_streamlit=use_real_streamlit)
+    st.subheader("Assistant")
+    render_assistant_panel(st, demo_assistant_recommendations(result))
     return result
 
 

--- a/app/streamlit_app.py
+++ b/app/streamlit_app.py
@@ -16,6 +16,7 @@ DESIGN_SYSTEM_ROOT = Path(__file__).resolve().parents[1] / "design-system"
 if str(DESIGN_SYSTEM_ROOT) not in sys.path:
     sys.path.insert(0, str(DESIGN_SYSTEM_ROOT))
 
+from inv_man_intake.assist.intake_assistant import IntakeRecommendation  # noqa: E402
 from inv_man_intake.extraction.providers.base import (  # noqa: E402
     ExtractedDocumentResult,
     ExtractedField,
@@ -24,7 +25,6 @@ from inv_man_intake.intake.standard_elements import (  # noqa: E402
     StandardElementLibrary,
     load_standard_element_library,
 )
-from inv_man_intake.assist.intake_assistant import IntakeRecommendation  # noqa: E402
 from inv_man_intake.observability import InMemoryTraceSink  # noqa: E402
 from inv_man_intake.packet import PacketFile, ingest_packet  # noqa: E402
 from inv_man_intake.readiness.fixture_batches import DEFAULT_BATCH_PACKAGES  # noqa: E402

--- a/src/inv_man_intake/assist/__init__.py
+++ b/src/inv_man_intake/assist/__init__.py
@@ -8,12 +8,24 @@ from inv_man_intake.assist.egress_guard import (
     redact_payload,
     send_to_llm,
 )
+from inv_man_intake.assist.intake_assistant import (
+    AssistantAnswer,
+    IntakeRecommendation,
+    RunSignal,
+    answer_intake_question,
+    collect_run_signals,
+)
 
 __all__ = [
+    "AssistantAnswer",
     "EgressConsent",
     "EgressLogRecord",
     "EgressResponse",
+    "IntakeRecommendation",
     "ProviderConfig",
+    "RunSignal",
+    "answer_intake_question",
+    "collect_run_signals",
     "redact_payload",
     "send_to_llm",
 ]

--- a/src/inv_man_intake/assist/intake_assistant.py
+++ b/src/inv_man_intake/assist/intake_assistant.py
@@ -1,0 +1,234 @@
+"""Grounded intake-improvement assistant over packet/run signals."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from inv_man_intake.assist.egress_guard import (
+    EgressConsent,
+    LlmClient,
+    ProviderConfig,
+    send_to_llm,
+)
+from inv_man_intake.data.provenance import CorrectionRecord
+from inv_man_intake.packet import ManagerProfile
+from inv_man_intake.scoring.contracts import ScoreResult
+
+
+@dataclass(frozen=True)
+class RunSignal:
+    """One cited signal available to the assistant."""
+
+    signal_id: str
+    category: str
+    summary: str
+    source_ref: str
+    severity: float
+
+
+@dataclass(frozen=True)
+class IntakeRecommendation:
+    """Operator-facing recommendation that must remain human-applied."""
+
+    change: str
+    rationale: str
+    cited_evidence: tuple[str, ...]
+    expected_effect: str
+    rank: int
+    apply_manually: bool = True
+
+
+@dataclass(frozen=True)
+class AssistantAnswer:
+    """Grounded assistant response for one operator question."""
+
+    answer: str
+    citations: tuple[str, ...]
+    recommendations: tuple[IntakeRecommendation, ...]
+
+
+class _RecommendationPayload(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    change: str = Field(min_length=1)
+    rationale: str = Field(min_length=1)
+    cited_evidence: tuple[str, ...] = Field(min_length=1)
+    expected_effect: str = Field(min_length=1)
+    rank: int | None = Field(default=None, ge=1)
+
+    @field_validator("cited_evidence")
+    @classmethod
+    def _citations_must_be_non_empty(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        if any(not citation.strip() for citation in value):
+            raise ValueError("citations must be non-empty strings")
+        return value
+
+
+class _AssistantResponsePayload(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    answer: str = Field(min_length=1)
+    citations: tuple[str, ...]
+    recommendations: tuple[_RecommendationPayload, ...]
+
+    @field_validator("citations")
+    @classmethod
+    def _citations_must_be_non_empty(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        if any(not citation.strip() for citation in value):
+            raise ValueError("citations must be non-empty strings")
+        return value
+
+
+def answer_intake_question(
+    *,
+    manager_profile: ManagerProfile,
+    question: str,
+    consent: EgressConsent,
+    provider_config: ProviderConfig,
+    log_path: Path,
+    client: LlmClient,
+    corrections: Sequence[CorrectionRecord] = (),
+    score_result: ScoreResult | None = None,
+    now: Callable[[], Any] | None = None,
+) -> AssistantAnswer:
+    """Return cited, recommend-only guidance through the egress guard."""
+
+    signals = collect_run_signals(
+        manager_profile=manager_profile,
+        corrections=corrections,
+        score_result=score_result,
+    )
+    signal_by_id = {signal.signal_id: signal for signal in signals}
+    payload = {
+        "task": "rank intake-improvement recommendations",
+        "question": question,
+        "packet_id": manager_profile.packet_id,
+        "signals": [
+            {
+                "id": signal.signal_id,
+                "category": signal.category,
+                "summary": signal.summary,
+                "source_ref": signal.source_ref,
+                "severity": signal.severity,
+            }
+            for signal in signals
+        ],
+        "constraints": {
+            "recommend_only": True,
+            "must_cite_signal_ids": True,
+            "no_config_writes": True,
+        },
+    }
+    guarded = send_to_llm(
+        payload,
+        consent=consent,
+        provider_config=provider_config,
+        log_path=log_path,
+        client=client,
+        now=now,
+    )
+    return _validate_assistant_response(guarded.provider_response, signal_by_id=signal_by_id)
+
+
+def collect_run_signals(
+    *,
+    manager_profile: ManagerProfile,
+    corrections: Sequence[CorrectionRecord] = (),
+    score_result: ScoreResult | None = None,
+) -> tuple[RunSignal, ...]:
+    """Flatten packet, provenance, and score signals into citeable inputs."""
+
+    signals: list[RunSignal] = []
+    for index, reason in enumerate(manager_profile.escalations, start=1):
+        signals.append(
+            RunSignal(
+                signal_id=f"escalation:{index}",
+                category="escalation",
+                summary=reason,
+                source_ref=(
+                    manager_profile.lineage_refs[0]
+                    if manager_profile.lineage_refs
+                    else manager_profile.packet_id
+                ),
+                severity=0.95,
+            )
+        )
+    for flag in manager_profile.flagged_non_standard_items:
+        document_id, _, _ = flag.partition(":")
+        signals.append(
+            RunSignal(
+                signal_id=f"standardness:{len(signals) + 1}",
+                category="standardness",
+                summary=flag,
+                source_ref=document_id or manager_profile.packet_id,
+                severity=0.80,
+            )
+        )
+    for correction in corrections:
+        signals.append(
+            RunSignal(
+                signal_id=f"correction:{correction.correction_id}",
+                category="correction",
+                summary=correction.reason or f"corrected {correction.field_id}",
+                source_ref=correction.field_id,
+                severity=0.70,
+            )
+        )
+    if score_result and score_result.red_flag_reason:
+        signals.append(
+            RunSignal(
+                signal_id="score:red_flag",
+                category="score",
+                summary=score_result.red_flag_reason,
+                source_ref=score_result.manager_id,
+                severity=0.90,
+            )
+        )
+    return tuple(signals)
+
+
+def _validate_assistant_response(
+    response: Mapping[str, Any],
+    *,
+    signal_by_id: Mapping[str, RunSignal],
+) -> AssistantAnswer:
+    parsed = _AssistantResponsePayload.model_validate(response)
+    if not parsed.citations and parsed.recommendations:
+        raise ValueError("assistant response must cite evidence")
+
+    recommendations = tuple(
+        _recommendation_from_payload(index=index, payload=payload, signal_by_id=signal_by_id)
+        for index, payload in enumerate(parsed.recommendations, start=1)
+    )
+    for citation in parsed.citations:
+        if citation not in signal_by_id:
+            raise ValueError(f"assistant citation is not backed by a run signal: {citation}")
+    return AssistantAnswer(
+        answer=parsed.answer,
+        citations=parsed.citations,
+        recommendations=recommendations,
+    )
+
+
+def _recommendation_from_payload(
+    *,
+    index: int,
+    payload: _RecommendationPayload,
+    signal_by_id: Mapping[str, RunSignal],
+) -> IntakeRecommendation:
+    for citation in payload.cited_evidence:
+        if citation not in signal_by_id:
+            raise ValueError(f"recommendation citation is not backed by a run signal: {citation}")
+    return IntakeRecommendation(
+        change=payload.change,
+        rationale=payload.rationale,
+        cited_evidence=payload.cited_evidence,
+        expected_effect=payload.expected_effect,
+        rank=payload.rank or index,
+        apply_manually=True,
+    )

--- a/src/inv_man_intake/assist/intake_assistant.py
+++ b/src/inv_man_intake/assist/intake_assistant.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
@@ -22,7 +23,7 @@ from inv_man_intake.scoring.contracts import ScoreResult
 
 @dataclass(frozen=True)
 class RunSignal:
-    """One cited signal available to the assistant."""
+    """One citable signal available to the assistant."""
 
     signal_id: str
     category: str
@@ -73,7 +74,7 @@ class _AssistantResponsePayload(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     answer: str = Field(min_length=1)
-    citations: tuple[str, ...]
+    citations: tuple[str, ...] = Field(min_length=1)
     recommendations: tuple[_RecommendationPayload, ...]
 
     @field_validator("citations")
@@ -94,7 +95,7 @@ def answer_intake_question(
     client: LlmClient,
     corrections: Sequence[CorrectionRecord] = (),
     score_result: ScoreResult | None = None,
-    now: Callable[[], Any] | None = None,
+    now: Callable[[], datetime] | None = None,
 ) -> AssistantAnswer:
     """Return cited, recommend-only guidance through the egress guard."""
 
@@ -141,7 +142,7 @@ def collect_run_signals(
     corrections: Sequence[CorrectionRecord] = (),
     score_result: ScoreResult | None = None,
 ) -> tuple[RunSignal, ...]:
-    """Flatten packet, provenance, and score signals into citeable inputs."""
+    """Flatten packet, provenance, and score signals into citable inputs."""
 
     signals: list[RunSignal] = []
     for index, reason in enumerate(manager_profile.escalations, start=1):
@@ -158,11 +159,11 @@ def collect_run_signals(
                 severity=0.95,
             )
         )
-    for flag in manager_profile.flagged_non_standard_items:
+    for index, flag in enumerate(manager_profile.flagged_non_standard_items, start=1):
         document_id, _, _ = flag.partition(":")
         signals.append(
             RunSignal(
-                signal_id=f"standardness:{len(signals) + 1}",
+                signal_id=f"standardness:{index}",
                 category="standardness",
                 summary=flag,
                 source_ref=document_id or manager_profile.packet_id,
@@ -198,9 +199,6 @@ def _validate_assistant_response(
     signal_by_id: Mapping[str, RunSignal],
 ) -> AssistantAnswer:
     parsed = _AssistantResponsePayload.model_validate(response)
-    if not parsed.citations and parsed.recommendations:
-        raise ValueError("assistant response must cite evidence")
-
     recommendations = tuple(
         _recommendation_from_payload(index=index, payload=payload, signal_by_id=signal_by_id)
         for index, payload in enumerate(parsed.recommendations, start=1)

--- a/src/inv_man_intake/assist/intake_assistant.py
+++ b/src/inv_man_intake/assist/intake_assistant.py
@@ -20,6 +20,11 @@ from inv_man_intake.data.provenance import CorrectionRecord
 from inv_man_intake.packet import ManagerProfile
 from inv_man_intake.scoring.contracts import ScoreResult
 
+_ESCALATION_SEVERITY = 0.95
+_STANDARDNESS_SEVERITY = 0.80
+_CORRECTION_SEVERITY = 0.70
+_SCORE_RED_FLAG_SEVERITY = 0.90
+
 
 @dataclass(frozen=True)
 class RunSignal:
@@ -53,6 +58,13 @@ class AssistantAnswer:
     recommendations: tuple[IntakeRecommendation, ...]
 
 
+def _require_non_empty_citations(value: tuple[str, ...]) -> tuple[str, ...]:
+    stripped = tuple(citation.strip() for citation in value)
+    if any(not citation for citation in stripped):
+        raise ValueError("citations must be non-empty strings")
+    return stripped
+
+
 class _RecommendationPayload(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -65,9 +77,7 @@ class _RecommendationPayload(BaseModel):
     @field_validator("cited_evidence")
     @classmethod
     def _citations_must_be_non_empty(cls, value: tuple[str, ...]) -> tuple[str, ...]:
-        if any(not citation.strip() for citation in value):
-            raise ValueError("citations must be non-empty strings")
-        return value
+        return _require_non_empty_citations(value)
 
 
 class _AssistantResponsePayload(BaseModel):
@@ -80,9 +90,7 @@ class _AssistantResponsePayload(BaseModel):
     @field_validator("citations")
     @classmethod
     def _citations_must_be_non_empty(cls, value: tuple[str, ...]) -> tuple[str, ...]:
-        if any(not citation.strip() for citation in value):
-            raise ValueError("citations must be non-empty strings")
-        return value
+        return _require_non_empty_citations(value)
 
 
 def answer_intake_question(
@@ -156,7 +164,7 @@ def collect_run_signals(
                     if manager_profile.lineage_refs
                     else manager_profile.packet_id
                 ),
-                severity=0.95,
+                severity=_ESCALATION_SEVERITY,
             )
         )
     for index, flag in enumerate(manager_profile.flagged_non_standard_items, start=1):
@@ -167,7 +175,7 @@ def collect_run_signals(
                 category="standardness",
                 summary=flag,
                 source_ref=document_id or manager_profile.packet_id,
-                severity=0.80,
+                severity=_STANDARDNESS_SEVERITY,
             )
         )
     for correction in corrections:
@@ -177,7 +185,7 @@ def collect_run_signals(
                 category="correction",
                 summary=correction.reason or f"corrected {correction.field_id}",
                 source_ref=correction.field_id,
-                severity=0.70,
+                severity=_CORRECTION_SEVERITY,
             )
         )
     if score_result and score_result.red_flag_reason:
@@ -187,7 +195,7 @@ def collect_run_signals(
                 category="score",
                 summary=score_result.red_flag_reason,
                 source_ref=score_result.manager_id,
-                severity=0.90,
+                severity=_SCORE_RED_FLAG_SEVERITY,
             )
         )
     return tuple(signals)

--- a/tests/app/test_streamlit_app_smoke.py
+++ b/tests/app/test_streamlit_app_smoke.py
@@ -11,8 +11,10 @@ from app.streamlit_app import (
     _operator_queue_rows,
     build_operator_packet_view,
     render_app,
+    render_assistant_panel,
 )
 
+from inv_man_intake.assist import IntakeRecommendation
 from inv_man_intake.observability import InMemoryTraceSink
 from inv_man_intake.packet import PacketFile
 
@@ -122,6 +124,27 @@ def test_app_renders_score_for_fixture_bundle(monkeypatch: pytest.MonkeyPatch) -
     assert "langsmith_project" not in result.trace_tags
     assert recorder.metrics == [("Final score", "0.7809")]
     assert recorder.tables[0] == result.components
+
+
+def test_assistant_panel_honors_manual_apply_contract() -> None:
+    recorder = _StreamlitRecorder()
+
+    rows = render_assistant_panel(
+        recorder,
+        (
+            IntakeRecommendation(
+                rank=1,
+                change="Review threshold inputs",
+                rationale="Grounded in packet evidence.",
+                cited_evidence=("escalation:1",),
+                expected_effect="Keeps the operator in control.",
+                apply_manually=False,
+            ),
+        ),
+    )
+
+    assert rows[0].action == "Blocked (auto-apply not permitted)"
+    assert recorder.tables[0][0]["Action"] == "Blocked (auto-apply not permitted)"
 
 
 def test_demo_presentation_hides_developer_observability_details() -> None:

--- a/tests/assist/test_intake_assistant.py
+++ b/tests/assist/test_intake_assistant.py
@@ -94,6 +94,46 @@ def test_recommendations_are_grounded_and_not_auto_applied(tmp_path: Path) -> No
     assert marker.read_text(encoding="utf-8") == '{"aum": 0.05}\n'
 
 
+def test_assistant_normalizes_citation_whitespace(tmp_path: Path) -> None:
+    def fake_client(
+        payload: dict[str, Any],
+        provider_config: ProviderConfig,
+    ) -> Mapping[str, Any]:
+        return {
+            "answer": "The packet escalated because sources disagree.",
+            "citations": [" escalation:1 "],
+            "recommendations": [
+                {
+                    "change": "Review source reconciliation",
+                    "rationale": "The escalation is grounded in cross-document evidence.",
+                    "cited_evidence": [" escalation:1 "],
+                    "expected_effect": "Keeps recommendations tied to known packet signals.",
+                }
+            ],
+        }
+
+    answer = answer_intake_question(
+        manager_profile=_manager_profile(),
+        question="what should change?",
+        consent=EgressConsent(
+            granted_by="operator",
+            purpose="rank intake-improvement recommendations",
+            granted_at="2026-07-07T09:00:00Z",
+        ),
+        provider_config=ProviderConfig(
+            provider="frontier-zero-retention",
+            model="secure-model",
+            zero_retention=True,
+            baa_eligible=True,
+        ),
+        log_path=tmp_path / "egress.jsonl",
+        client=fake_client,
+    )
+
+    assert answer.citations == ("escalation:1",)
+    assert answer.recommendations[0].cited_evidence == ("escalation:1",)
+
+
 def test_assistant_rejects_uncited_recommendations(tmp_path: Path) -> None:
     def fake_client(
         payload: dict[str, Any],

--- a/tests/assist/test_intake_assistant.py
+++ b/tests/assist/test_intake_assistant.py
@@ -9,7 +9,7 @@ from typing import Any
 import pytest
 
 from inv_man_intake.assist.egress_guard import EgressConsent, ProviderConfig
-from inv_man_intake.assist.intake_assistant import answer_intake_question
+from inv_man_intake.assist.intake_assistant import answer_intake_question, collect_run_signals
 from inv_man_intake.data.provenance import CorrectionRecord
 from inv_man_intake.extraction.cross_check import CrossCheckReport, FieldCrossCheck
 from inv_man_intake.extraction.providers.base import ExtractedDocumentResult, ExtractedField
@@ -130,6 +130,43 @@ def test_assistant_rejects_uncited_recommendations(tmp_path: Path) -> None:
             log_path=tmp_path / "egress.jsonl",
             client=fake_client,
         )
+
+
+def test_assistant_rejects_uncited_answers(tmp_path: Path) -> None:
+    def fake_client(
+        payload: dict[str, Any],
+        provider_config: ProviderConfig,
+    ) -> Mapping[str, Any]:
+        return {"answer": "No evidence cited.", "citations": [], "recommendations": []}
+
+    with pytest.raises(ValueError, match="citations"):
+        answer_intake_question(
+            manager_profile=_manager_profile(),
+            question="what should change?",
+            consent=EgressConsent(
+                granted_by="operator",
+                purpose="rank intake-improvement recommendations",
+                granted_at="2026-07-07T09:00:00Z",
+            ),
+            provider_config=ProviderConfig(
+                provider="frontier-zero-retention",
+                model="secure-model",
+                zero_retention=True,
+                baa_eligible=True,
+            ),
+            log_path=tmp_path / "egress.jsonl",
+            client=fake_client,
+        )
+
+
+def test_standardness_signal_ids_are_category_stable() -> None:
+    profile = _manager_profile()
+
+    signals = collect_run_signals(manager_profile=profile)
+
+    assert [signal.signal_id for signal in signals if signal.category == "standardness"] == [
+        "standardness:1"
+    ]
 
 
 def test_assistant_routes_through_egress_guard(tmp_path: Path) -> None:

--- a/tests/assist/test_intake_assistant.py
+++ b/tests/assist/test_intake_assistant.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from inv_man_intake.assist.egress_guard import EgressConsent, ProviderConfig
+from inv_man_intake.assist.intake_assistant import answer_intake_question
+from inv_man_intake.data.provenance import CorrectionRecord
+from inv_man_intake.extraction.cross_check import CrossCheckReport, FieldCrossCheck
+from inv_man_intake.extraction.providers.base import ExtractedDocumentResult, ExtractedField
+from inv_man_intake.packet import ManagerProfile, PacketDocumentProfile
+from inv_man_intake.scoring.contracts import ScoreResult
+
+
+def test_recommendations_are_grounded_and_not_auto_applied(tmp_path: Path) -> None:
+    outbound_calls: list[dict[str, Any]] = []
+
+    def fake_client(
+        payload: dict[str, Any],
+        provider_config: ProviderConfig,
+    ) -> Mapping[str, Any]:
+        outbound_calls.append(payload)
+        return {
+            "answer": "The packet escalated because AUM disagreed across cited sources.",
+            "citations": ["escalation:1"],
+            "recommendations": [
+                {
+                    "rank": 1,
+                    "change": "Tighten AUM parser review thresholds",
+                    "rationale": "The AUM disagreement exceeded tolerance.",
+                    "cited_evidence": ["escalation:1", "correction:7"],
+                    "expected_effect": "Fewer silent AUM mismatches before analyst review.",
+                }
+            ],
+        }
+
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    marker = config_dir / "thresholds.json"
+    marker.write_text('{"aum": 0.05}\n', encoding="utf-8")
+
+    answer = answer_intake_question(
+        manager_profile=_manager_profile(),
+        question="what should change?",
+        corrections=(
+            CorrectionRecord(
+                correction_id=7,
+                field_id="ppm-1:operations.aum",
+                corrected_value="$105M",
+                reason="analyst corrected AUM after source mismatch",
+                corrected_by="operator",
+                corrected_at="2026-07-07T09:00:00Z",
+            ),
+        ),
+        score_result=ScoreResult(
+            manager_id="manager-1",
+            asset_class="credit",
+            base_score=0.7,
+            final_score=0.5,
+            contributions={"operational_quality": 0.2},
+            red_flag_applied=True,
+            red_flag_reason="missing mandatory PPM fee disclosure",
+        ),
+        consent=EgressConsent(
+            granted_by="operator",
+            purpose="rank intake-improvement recommendations",
+            granted_at="2026-07-07T09:00:00Z",
+        ),
+        provider_config=ProviderConfig(
+            provider="frontier-zero-retention",
+            model="secure-model",
+            zero_retention=True,
+            baa_eligible=True,
+        ),
+        log_path=tmp_path / "egress.jsonl",
+        client=fake_client,
+        now=lambda: datetime(2026, 7, 7, 9, 1, tzinfo=UTC),
+    )
+
+    assert answer.citations == ("escalation:1",)
+    assert answer.recommendations[0].cited_evidence == ("escalation:1", "correction:7")
+    assert answer.recommendations[0].apply_manually is True
+    assert outbound_calls
+    assert outbound_calls[0]["constraints"] == {
+        "recommend_only": True,
+        "must_cite_signal_ids": True,
+        "no_config_writes": True,
+    }
+    assert marker.read_text(encoding="utf-8") == '{"aum": 0.05}\n'
+
+
+def test_assistant_rejects_uncited_recommendations(tmp_path: Path) -> None:
+    def fake_client(
+        payload: dict[str, Any],
+        provider_config: ProviderConfig,
+    ) -> Mapping[str, Any]:
+        return {
+            "answer": "Make a change.",
+            "citations": ["escalation:1"],
+            "recommendations": [
+                {
+                    "change": "Change parser",
+                    "rationale": "No citation is available.",
+                    "cited_evidence": ["made-up-signal"],
+                    "expected_effect": "Unknown",
+                }
+            ],
+        }
+
+    with pytest.raises(ValueError, match="not backed by a run signal"):
+        answer_intake_question(
+            manager_profile=_manager_profile(),
+            question="what should change?",
+            consent=EgressConsent(
+                granted_by="operator",
+                purpose="rank intake-improvement recommendations",
+                granted_at="2026-07-07T09:00:00Z",
+            ),
+            provider_config=ProviderConfig(
+                provider="frontier-zero-retention",
+                model="secure-model",
+                zero_retention=True,
+                baa_eligible=True,
+            ),
+            log_path=tmp_path / "egress.jsonl",
+            client=fake_client,
+        )
+
+
+def test_assistant_routes_through_egress_guard(tmp_path: Path) -> None:
+    def fake_client(
+        payload: dict[str, Any],
+        provider_config: ProviderConfig,
+    ) -> Mapping[str, Any]:
+        return {"answer": "grounded", "citations": ["escalation:1"], "recommendations": []}
+
+    answer_intake_question(
+        manager_profile=_manager_profile(),
+        question="what changed?",
+        consent=EgressConsent(
+            granted_by="operator",
+            purpose="rank intake-improvement recommendations",
+            granted_at="2026-07-07T09:00:00Z",
+        ),
+        provider_config=ProviderConfig(
+            provider="frontier-zero-retention",
+            model="secure-model",
+            zero_retention=True,
+            baa_eligible=True,
+        ),
+        log_path=tmp_path / "egress.jsonl",
+        client=fake_client,
+    )
+
+    log_record = json.loads((tmp_path / "egress.jsonl").read_text(encoding="utf-8"))
+    assert log_record["purpose"] == "rank intake-improvement recommendations"
+
+
+def _manager_profile() -> ManagerProfile:
+    extraction = ExtractedDocumentResult(
+        source_doc_id="ppm-1",
+        provider_name="stub",
+        fields=(
+            ExtractedField(
+                key="operations.aum",
+                value="$100M",
+                confidence=0.64,
+                source_doc_id="ppm-1",
+                source_page=3,
+                snippet="AUM $100M",
+                method="text",
+            ),
+        ),
+    )
+    document = PacketDocumentProfile(
+        document_id="ppm-1",
+        filename="ppm.pdf",
+        document_type="ppm",
+        extraction=extraction,
+        standard_element_coverage=(),
+        lineage_refs=("ppm-1:operations.aum:p3:text",),
+    )
+    return ManagerProfile(
+        packet_id="packet-1",
+        documents=(document,),
+        identity={},
+        terms={},
+        returns_metrics={},
+        graphics_refs=(),
+        per_doc_standard_element_coverage={},
+        flagged_non_standard_items=("ppm-1:fees:missing_mandatory",),
+        scores={"extraction_confidence": 0.64},
+        lineage_refs=("ppm-1:operations.aum:p3:text",),
+        reconciliation=CrossCheckReport(
+            fields=(
+                FieldCrossCheck(
+                    key="operations.aum",
+                    observations=(),
+                    accepted_value="$100M",
+                    accepted_source="stub:text:ppm-1:p3",
+                    escalate=True,
+                    reason="cross_check_disagreement:operations.aum:ppm-1!=deck-1",
+                ),
+            ),
+        ),
+    )


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:725 -->
> **Source:** Issue #725

Closes #725

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The owner wants a LangChain-driven assistant to interact over "what needs to change to improve the intake" — on a
work PC. The signals already exist (escalations, low-confidence fields, `CorrectionRecord`s, score/red-flag
reasons, plus calibration #711 / drift #714 / weight-sensitivity #716 once built) but nothing turns them into
operator-facing, cited recommendations. The assistant is the human-facing layer over those analytics.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#718](https://github.com/stranske/Inv-Man-Intake/issues/718)
- [#724](https://github.com/stranske/Inv-Man-Intake/issues/724)
- [#722](https://github.com/stranske/Inv-Man-Intake/issues/722)
- [#711](https://github.com/stranske/Inv-Man-Intake/issues/711)
- [#714](https://github.com/stranske/Inv-Man-Intake/issues/714)
- [#716](https://github.com/stranske/Inv-Man-Intake/issues/716)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] Add `src/inv_man_intake/assist/intake_assistant.py`: given a `ManagerProfile` (M2) + the run's signals,
  produce grounded answers + a ranked recommendation list (each: change, rationale, cited evidence, expected effect).
- [ ] Route all model calls through `egress_guard.send_to_llm` (M4); structured output via instructor/Pydantic
  (methodology §3), value-validated.
- [ ] Surface in the operator app (M3) as the assistant panel; recommendations render with their citations and an
  explicit "apply manually" affordance (no auto-apply).

#### Acceptance criteria
- [ ] Named test `tests/assist/test_intake_assistant.py::test_recommendations_are_grounded_and_not_auto_applied`
  passes (with a stubbed egress-guard): every recommendation references a real run signal/source, and the
  assistant performs **no** write to `config/*`.
- [ ] **Deliberate-break gate:** make the assistant call a provider directly (bypassing the egress-guard); a
  guard-routing test **must FAIL**; revert → passes. (Proves the egress boundary is enforced.)
- [ ] A test asserts no `config/*` mutation occurs on any assistant path.

<!-- auto-status-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an Assistant panel in the demo that shows recommendations alongside the existing results.
  * Introduced structured assistant guidance with cited evidence to help users review intake suggestions.
  * Exposed assistant-related APIs for generating and displaying recommendations.

* **Bug Fixes**
  * Improved validation so recommendations and citations must be grounded in available evidence.
  * Added safeguards to reject uncited or unsupported assistant responses and keep manual review in the loop.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->