### PR TITLE
Add return-stream non-standard characterizer

### DIFF
--- a/src/inv_man_intake/performance/__init__.py
+++ b/src/inv_man_intake/performance/__init__.py
@@ -1,5 +1,12 @@
 """Performance ingestion contracts and helpers."""
 
+from inv_man_intake.performance.characterize import (
+    CharacterizationTag,
+    SeriesCharacterization,
+    characterize_series,
+    gate_scoring_submission,
+    require_operator_confirmation,
+)
 from inv_man_intake.performance.conflict_resolver import (
     ConflictAuditEntry,
     ConflictResolutionResult,
@@ -34,6 +41,7 @@ __all__ = [
     "BenchmarkAlignmentPoint",
     "CanonicalMonthPoint",
     "CanonicalMetricsSchema",
+    "CharacterizationTag",
     "ConflictAuditEntry",
     "ConflictResolutionResult",
     "NormalizedPerformancePayload",
@@ -41,16 +49,20 @@ __all__ = [
     "PerformancePayload",
     "PerformancePoint",
     "PerformanceSeries",
+    "SeriesCharacterization",
     "build_benchmark_alignment",
+    "characterize_series",
     "correlation_inputs",
     "compute_metrics",
     "compute_metrics_canonical",
     "describe_normalization_contract",
     "detect_missing_months",
+    "gate_scoring_submission",
     "load_document_timeseries",
     "load_xlsx_timeseries",
     "normalize_payload",
     "normalize_series",
+    "require_operator_confirmation",
     "resolve_source_conflicts",
     "validate_payload",
 ]

--- a/src/inv_man_intake/performance/characterize.py
+++ b/src/inv_man_intake/performance/characterize.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
+import re
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, replace
 from datetime import datetime
 from pathlib import Path
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
 
 from inv_man_intake.assist.egress_guard import (
     EgressConsent,
@@ -190,7 +191,7 @@ def _deterministic_characterization(
     if tag is None:
         return SeriesCharacterization(
             tag="standard",
-            rationale="No non-standard return-stream markers were detected.",
+            rationale=_rationale_for_tag("standard"),
             confidence=0.92,
             metrics=metrics,
             evidence=evidence,
@@ -235,7 +236,10 @@ def _llm_characterization(
         client=client,
         now=now,
     )
-    return _LlmCharacterizationPayload.model_validate(guarded.provider_response)
+    try:
+        return _LlmCharacterizationPayload.model_validate(guarded.provider_response)
+    except ValidationError as exc:
+        raise ValueError("invalid LLM characterization payload") from exc
 
 
 def _evidence(*, source_notes: tuple[str, ...], source_names: tuple[str, ...]) -> tuple[str, ...]:
@@ -244,7 +248,15 @@ def _evidence(*, source_notes: tuple[str, ...], source_names: tuple[str, ...]) -
 
 def _tags_from_text(evidence: tuple[str, ...]) -> list[CharacterizationTag]:
     haystack = " ".join(evidence).lower()
-    return [tag for tag, needles in _KEYWORD_TAGS if any(needle in haystack for needle in needles)]
+    return [
+        tag
+        for tag, needles in _KEYWORD_TAGS
+        if any(_contains_keyword(haystack, needle) for needle in needles)
+    ]
+
+
+def _contains_keyword(haystack: str, needle: str) -> bool:
+    return re.search(rf"\b{re.escape(needle)}\b", haystack) is not None
 
 
 def _highest_priority_tag(

--- a/src/inv_man_intake/performance/characterize.py
+++ b/src/inv_man_intake/performance/characterize.py
@@ -120,7 +120,8 @@ def characterize_series(
         doc_types=doc_types,
         operator_confirmed=operator_confirmed,
     )
-    if deterministic.tag != "standard" or not source_notes:
+    evidence = _evidence(source_notes=tuple(source_notes), source_names=tuple(source_names))
+    if deterministic.tag != "standard" or not evidence:
         return deterministic
     if consent is None and provider_config is None and log_path is None and client is None:
         return deterministic
@@ -142,7 +143,7 @@ def characterize_series(
         rationale=llm.rationale,
         confidence=llm.confidence,
         metrics=metrics,
-        evidence=tuple(source_notes),
+        evidence=evidence,
         doc_types_available=doc_types,
         operator_confirmed=operator_confirmed,
     )
@@ -222,7 +223,7 @@ def _llm_characterization(
             "task": "classify ambiguous return-stream shape",
             "source_notes": source_notes,
             "source_names": source_names,
-            "allowed_tags": tuple(_NON_STANDARD_TAGS),
+            "allowed_tags": _TAG_PRIORITY,
             "constraints": {
                 "numbers_are_deterministic": True,
                 "do_not_compute_or_change_returns": True,

--- a/src/inv_man_intake/performance/characterize.py
+++ b/src/inv_man_intake/performance/characterize.py
@@ -1,0 +1,269 @@
+"""Return-series standard-shape characterization and scoring gate."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass, replace
+from datetime import datetime
+from pathlib import Path
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from inv_man_intake.assist.egress_guard import (
+    EgressConsent,
+    LlmClient,
+    ProviderConfig,
+    send_to_llm,
+)
+from inv_man_intake.intake.standard_elements import StandardElementLibrary
+from inv_man_intake.performance.contracts import PerformanceSeries, validate_series
+from inv_man_intake.performance.metrics import PerformanceMetrics
+from inv_man_intake.performance.normalize import detect_missing_months
+from inv_man_intake.scoring.contracts import ScoreSubmission
+
+CharacterizationTag = Literal[
+    "standard",
+    "pro_forma",
+    "blended",
+    "backfilled",
+    "gross_net_ambiguous",
+    "currency_noted",
+    "composite",
+]
+
+_NON_STANDARD_TAGS: frozenset[CharacterizationTag] = frozenset(
+    {
+        "pro_forma",
+        "blended",
+        "backfilled",
+        "gross_net_ambiguous",
+        "currency_noted",
+        "composite",
+    }
+)
+_TAG_PRIORITY: tuple[CharacterizationTag, ...] = (
+    "pro_forma",
+    "blended",
+    "backfilled",
+    "gross_net_ambiguous",
+    "currency_noted",
+    "composite",
+)
+_KEYWORD_TAGS: tuple[tuple[CharacterizationTag, tuple[str, ...]], ...] = (
+    ("pro_forma", ("pro forma", "pro-forma", "proforma")),
+    ("blended", ("blended", "blend")),
+    ("backfilled", ("backfilled", "backfill", "back-filled")),
+    ("gross_net_ambiguous", ("gross vs net", "gross/net", "gross-vs-net", "gross net")),
+    ("currency_noted", ("currency", "usd", "eur", "fx")),
+    ("composite", ("composite",)),
+)
+
+
+@dataclass(frozen=True)
+class SeriesCharacterization:
+    """Typed characterization for one return series."""
+
+    tag: CharacterizationTag
+    rationale: str
+    confidence: float
+    metrics: PerformanceMetrics
+    evidence: tuple[str, ...]
+    doc_types_available: tuple[str, ...] = ()
+    operator_confirmed: bool = False
+
+    @property
+    def requires_operator_confirmation(self) -> bool:
+        """Whether the series must be confirmed before feeding scoring."""
+
+        return self.tag in _NON_STANDARD_TAGS and not self.operator_confirmed
+
+
+class _LlmCharacterizationPayload(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    tag: CharacterizationTag
+    rationale: str = Field(min_length=1)
+    confidence: float = Field(ge=0.0, le=1.0)
+
+    @field_validator("tag")
+    @classmethod
+    def _tag_must_not_standard(cls, value: CharacterizationTag) -> CharacterizationTag:
+        if value == "standard":
+            raise ValueError("LLM characterization is only used for ambiguous non-standard tails")
+        return value
+
+
+def characterize_series(
+    series: PerformanceSeries,
+    metrics: PerformanceMetrics,
+    *,
+    source_notes: Sequence[str] = (),
+    source_names: Sequence[str] = (),
+    standard_library: StandardElementLibrary | None = None,
+    operator_confirmed: bool = False,
+    consent: EgressConsent | None = None,
+    provider_config: ProviderConfig | None = None,
+    log_path: Path | None = None,
+    client: LlmClient | None = None,
+    now: Callable[[], datetime] | None = None,
+) -> SeriesCharacterization:
+    """Characterize return shape without mutating deterministic metric values."""
+
+    validate_series(series)
+    doc_types = standard_library.doc_types() if standard_library is not None else ()
+    deterministic = _deterministic_characterization(
+        series=series,
+        metrics=metrics,
+        source_notes=tuple(source_notes),
+        source_names=tuple(source_names),
+        doc_types=doc_types,
+        operator_confirmed=operator_confirmed,
+    )
+    if deterministic.tag != "standard" or not source_notes:
+        return deterministic
+    if consent is None and provider_config is None and log_path is None and client is None:
+        return deterministic
+    if consent is None or provider_config is None or log_path is None or client is None:
+        raise ValueError(
+            "LLM characterization requires consent, provider_config, log_path, and client"
+        )
+    llm = _llm_characterization(
+        source_notes=tuple(source_notes),
+        source_names=tuple(source_names),
+        consent=consent,
+        provider_config=provider_config,
+        log_path=log_path,
+        client=client,
+        now=now,
+    )
+    return SeriesCharacterization(
+        tag=llm.tag,
+        rationale=llm.rationale,
+        confidence=llm.confidence,
+        metrics=metrics,
+        evidence=tuple(source_notes),
+        doc_types_available=doc_types,
+        operator_confirmed=operator_confirmed,
+    )
+
+
+def require_operator_confirmation(
+    characterization: SeriesCharacterization,
+) -> SeriesCharacterization:
+    """Return a confirmed characterization for explicit HITL scoring use."""
+
+    return replace(characterization, operator_confirmed=True)
+
+
+def gate_scoring_submission(
+    submission: ScoreSubmission,
+    *,
+    characterization: SeriesCharacterization,
+) -> ScoreSubmission:
+    """Block non-standard return streams from scoring until confirmed."""
+
+    if characterization.requires_operator_confirmation:
+        raise PermissionError(
+            "non-standard return series requires operator confirmation before scoring"
+        )
+    return submission
+
+
+def _deterministic_characterization(
+    *,
+    series: PerformanceSeries,
+    metrics: PerformanceMetrics,
+    source_notes: tuple[str, ...],
+    source_names: tuple[str, ...],
+    doc_types: tuple[str, ...],
+    operator_confirmed: bool,
+) -> SeriesCharacterization:
+    evidence = _evidence(source_notes=source_notes, source_names=source_names)
+    matched_tags = _tags_from_text(evidence)
+    missing_months = detect_missing_months(series) if series.frequency == "monthly" else ()
+    if missing_months:
+        matched_tags.append("backfilled")
+        evidence = (*evidence, f"missing_months:{len(missing_months)}")
+    tag = _highest_priority_tag(matched_tags)
+    if tag is None:
+        return SeriesCharacterization(
+            tag="standard",
+            rationale="No non-standard return-stream markers were detected.",
+            confidence=0.92,
+            metrics=metrics,
+            evidence=evidence,
+            doc_types_available=doc_types,
+            operator_confirmed=operator_confirmed,
+        )
+    return SeriesCharacterization(
+        tag=tag,
+        rationale=_rationale_for_tag(tag),
+        confidence=0.88,
+        metrics=metrics,
+        evidence=evidence,
+        doc_types_available=doc_types,
+        operator_confirmed=operator_confirmed,
+    )
+
+
+def _llm_characterization(
+    *,
+    source_notes: tuple[str, ...],
+    source_names: tuple[str, ...],
+    consent: EgressConsent,
+    provider_config: ProviderConfig,
+    log_path: Path,
+    client: LlmClient,
+    now: Callable[[], datetime] | None,
+) -> _LlmCharacterizationPayload:
+    guarded = send_to_llm(
+        {
+            "task": "classify ambiguous return-stream shape",
+            "source_notes": source_notes,
+            "source_names": source_names,
+            "allowed_tags": tuple(_NON_STANDARD_TAGS),
+            "constraints": {
+                "numbers_are_deterministic": True,
+                "do_not_compute_or_change_returns": True,
+            },
+        },
+        consent=consent,
+        provider_config=provider_config,
+        log_path=log_path,
+        client=client,
+        now=now,
+    )
+    return _LlmCharacterizationPayload.model_validate(guarded.provider_response)
+
+
+def _evidence(*, source_notes: tuple[str, ...], source_names: tuple[str, ...]) -> tuple[str, ...]:
+    return tuple(item.strip() for item in (*source_notes, *source_names) if item.strip())
+
+
+def _tags_from_text(evidence: tuple[str, ...]) -> list[CharacterizationTag]:
+    haystack = " ".join(evidence).lower()
+    return [tag for tag, needles in _KEYWORD_TAGS if any(needle in haystack for needle in needles)]
+
+
+def _highest_priority_tag(
+    tags: Sequence[CharacterizationTag],
+) -> CharacterizationTag | None:
+    tag_set = set(tags)
+    for tag in _TAG_PRIORITY:
+        if tag in tag_set:
+            return tag
+    return None
+
+
+def _rationale_for_tag(tag: CharacterizationTag) -> str:
+    rationales: Mapping[CharacterizationTag, str] = {
+        "standard": "No non-standard return-stream markers were detected.",
+        "pro_forma": "Source evidence marks the stream as pro-forma.",
+        "blended": "Source evidence indicates blended return data.",
+        "backfilled": "Source evidence or month gaps indicate a backfilled stream.",
+        "gross_net_ambiguous": "Source evidence leaves gross-versus-net treatment ambiguous.",
+        "currency_noted": "Source evidence requires currency treatment review.",
+        "composite": "Source evidence indicates composite return construction.",
+    }
+    return rationales[tag]

--- a/src/inv_man_intake/v1_smoke.py
+++ b/src/inv_man_intake/v1_smoke.py
@@ -28,6 +28,7 @@ from inv_man_intake.extraction.providers.pptx_primary import PptxPrimaryExtracti
 from inv_man_intake.intake.integration import register_intake_bundle_file
 from inv_man_intake.intake.models import IngestRecord
 from inv_man_intake.intake.service import IngestionService
+from inv_man_intake.intake.standard_elements import load_standard_element_library
 from inv_man_intake.observability import (
     FleetRunContext,
     InMemoryTraceSink,
@@ -68,6 +69,9 @@ from inv_man_intake.storage.document_store import InMemoryDocumentStore
 # (run.py) loads this same file; the smoke/demo fallback must not drift from it (see #694).
 DEFAULT_THRESHOLD_CONFIG_PATH = (
     Path(__file__).resolve().parents[2] / "config" / "extraction_thresholds.yaml"
+)
+DEFAULT_STANDARD_ELEMENT_LIBRARY_PATH = (
+    Path(__file__).resolve().parents[2] / "config" / "standard_elements" / "_stub.json"
 )
 
 
@@ -279,7 +283,11 @@ def _run_pipeline_core(
         characterization = characterize_series(
             normalized.monthly,
             metrics,
-            source_names=record.document_ids,
+            source_names=_document_source_names(
+                repository=core_repository,
+                document_ids=record.document_ids,
+            ),
+            standard_library=load_standard_element_library(DEFAULT_STANDARD_ELEMENT_LIBRARY_PATH),
         )
 
     performance_start = _start_event(sink, "v1_acceptance.performance_normalize")
@@ -639,6 +647,16 @@ def _derive_document_types(
         suffix = Path(document.file_name).suffix.lstrip(".").lower()
         types.append(suffix or "unknown")
     return tuple(sorted(set(types)))
+
+
+def _document_source_names(
+    *, repository: CoreRepository, document_ids: tuple[str, ...]
+) -> tuple[str, ...]:
+    names: list[str] = []
+    for document_id in document_ids:
+        document = repository.get_document(document_id)
+        names.append(document.file_name if document is not None else document_id)
+    return tuple(names)
 
 
 def _pipeline_latency_ms(*, sink: InMemoryTraceSink, root_span_name: str) -> int | None:

--- a/src/inv_man_intake/v1_smoke.py
+++ b/src/inv_man_intake/v1_smoke.py
@@ -44,6 +44,7 @@ from inv_man_intake.observability import (
     new_trace_context,
 )
 from inv_man_intake.observability.langsmith_fleet import DEFAULT_PROJECT
+from inv_man_intake.performance.characterize import characterize_series, gate_scoring_submission
 from inv_man_intake.performance.conflict_resolver import resolve_source_conflicts
 from inv_man_intake.performance.contracts import (
     PerformancePayload,
@@ -275,6 +276,11 @@ def _run_pipeline_core(
             PerformancePayload(monthly=normalized.monthly),
             benchmark_monthly=benchmark_series,
         )
+        characterization = characterize_series(
+            normalized.monthly,
+            metrics,
+            source_names=record.document_ids,
+        )
 
     performance_start = _start_event(sink, "v1_acceptance.performance_normalize")
     queue_context = child_trace_context(
@@ -308,12 +314,16 @@ def _run_pipeline_core(
         },
     ):
         components = _score_components(metrics.benchmark_correlation)
-        score = compute_score(
+        submission = gate_scoring_submission(
             ScoreSubmission(
                 manager_id=record.fund_id,
                 asset_class="credit",
                 components=components,
             ),
+            characterization=characterization,
+        )
+        score = compute_score(
+            submission,
             weights_by_asset_class=weights_for_registry(),
         )
         explainability = build_explainability_payload(

--- a/tests/performance/test_characterize.py
+++ b/tests/performance/test_characterize.py
@@ -1,0 +1,189 @@
+"""Tests for return-stream shape characterization and scoring gates."""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from inv_man_intake.assist.egress_guard import EgressConsent, ProviderConfig
+from inv_man_intake.intake.standard_elements import (
+    DataDrivenStandardElementLibrary,
+    StandardElement,
+)
+from inv_man_intake.performance.characterize import (
+    characterize_series,
+    gate_scoring_submission,
+    require_operator_confirmation,
+)
+from inv_man_intake.performance.contracts import (
+    PerformancePayload,
+    PerformancePoint,
+    PerformanceSeries,
+)
+from inv_man_intake.performance.metrics import compute_metrics
+from inv_man_intake.scoring.contracts import ScoreComponent, ScoreSubmission
+
+
+def test_non_standard_series_tagged_and_gated() -> None:
+    series = _monthly_series(
+        (
+            (date(2025, 1, 31), 0.01),
+            (date(2025, 2, 28), 0.02),
+            (date(2025, 3, 31), -0.01),
+        )
+    )
+    metrics = compute_metrics(PerformancePayload(monthly=series))
+
+    characterization = characterize_series(
+        series,
+        metrics,
+        source_notes=("Pro forma backfilled track record; operator review required.",),
+    )
+
+    assert characterization.tag == "pro_forma"
+    assert characterization.requires_operator_confirmation is True
+    assert characterization.metrics == metrics
+    with pytest.raises(PermissionError, match="requires operator confirmation"):
+        gate_scoring_submission(_score_submission(), characterization=characterization)
+
+    confirmed = require_operator_confirmation(characterization)
+    assert confirmed.requires_operator_confirmation is False
+    assert gate_scoring_submission(_score_submission(), characterization=confirmed) == (
+        _score_submission()
+    )
+
+
+def test_clean_monthly_series_flows_to_scoring_without_confirmation() -> None:
+    series = _monthly_series(
+        (
+            (date(2025, 1, 31), 0.01),
+            (date(2025, 2, 28), 0.02),
+            (date(2025, 3, 31), 0.03),
+        )
+    )
+    metrics = compute_metrics(PerformancePayload(monthly=series))
+
+    characterization = characterize_series(series, metrics)
+
+    assert characterization.tag == "standard"
+    assert characterization.requires_operator_confirmation is False
+    assert gate_scoring_submission(_score_submission(), characterization=characterization) == (
+        _score_submission()
+    )
+
+
+def test_metrics_are_byte_identical_to_deterministic_output() -> None:
+    series = _monthly_series(
+        (
+            (date(2025, 1, 31), 0.02),
+            (date(2025, 2, 28), -0.01),
+            (date(2025, 3, 31), 0.03),
+        )
+    )
+    metrics = compute_metrics(PerformancePayload(monthly=series))
+
+    characterization = characterize_series(
+        series,
+        metrics,
+        source_notes=("Composite sleeve in USD terms.",),
+    )
+
+    assert characterization.metrics.to_canonical_dict() == metrics.to_canonical_dict()
+
+
+def test_ambiguous_tail_routes_through_egress_guard(tmp_path: Path) -> None:
+    series = _monthly_series(
+        (
+            (date(2025, 1, 31), 0.01),
+            (date(2025, 2, 28), 0.02),
+        )
+    )
+    metrics = compute_metrics(PerformancePayload(monthly=series))
+    calls: list[dict[str, Any]] = []
+
+    def client(payload: dict[str, Any], provider_config: ProviderConfig) -> dict[str, Any]:
+        calls.append({"payload": payload, "provider": provider_config.provider})
+        return {
+            "tag": "gross_net_ambiguous",
+            "rationale": "The notes require gross/net treatment review.",
+            "confidence": 0.73,
+        }
+
+    characterization = characterize_series(
+        series,
+        metrics,
+        source_notes=("Manager says treatment needs review.",),
+        consent=EgressConsent(
+            granted_by="operator",
+            purpose="classify ambiguous return stream",
+            granted_at="2026-07-07T23:00:00Z",
+        ),
+        provider_config=ProviderConfig(
+            provider="frontier",
+            model="review-model",
+            zero_retention=True,
+            baa_eligible=True,
+        ),
+        log_path=tmp_path / "egress.ndjson",
+        client=client,
+        now=lambda: datetime(2026, 7, 7, 23, 0, tzinfo=UTC),
+    )
+
+    assert characterization.tag == "gross_net_ambiguous"
+    assert calls
+    assert calls[0]["payload"]["constraints"]["do_not_compute_or_change_returns"] is True
+    assert (tmp_path / "egress.ndjson").read_text(encoding="utf-8")
+
+
+def test_doc_type_handling_uses_standard_element_library_port() -> None:
+    throwaway_doc_type = "library_added_return_stream"
+    library = DataDrivenStandardElementLibrary(
+        version="test",
+        non_authoritative=True,
+        elements_by_doc_type={
+            throwaway_doc_type: (
+                StandardElement(
+                    key="performance.return_stream",
+                    detector_name="field_present",
+                    mandatory=True,
+                ),
+            )
+        },
+    )
+    series = _monthly_series(
+        (
+            (date(2025, 1, 31), 0.01),
+            (date(2025, 2, 28), 0.02),
+        )
+    )
+    metrics = compute_metrics(PerformancePayload(monthly=series))
+
+    characterization = characterize_series(series, metrics, standard_library=library)
+
+    assert throwaway_doc_type in characterization.doc_types_available
+    source_text = Path("src/inv_man_intake/performance/characterize.py").read_text(encoding="utf-8")
+    assert throwaway_doc_type not in source_text
+
+
+def _monthly_series(points: tuple[tuple[date, float], ...]) -> PerformanceSeries:
+    return PerformanceSeries(
+        "monthly",
+        tuple(PerformancePoint(as_of=as_of, value=value) for as_of, value in points),
+    )
+
+
+def _score_submission() -> ScoreSubmission:
+    return ScoreSubmission(
+        manager_id="manager-1",
+        asset_class="equity_market_neutral",
+        components=(
+            ScoreComponent("performance_consistency", 0.8),
+            ScoreComponent("risk_adjusted_returns", 0.7),
+            ScoreComponent("operational_quality", 0.6),
+            ScoreComponent("transparency", 0.5),
+            ScoreComponent("team_experience", 0.4),
+        ),
+    )

--- a/tests/performance/test_characterize.py
+++ b/tests/performance/test_characterize.py
@@ -8,6 +8,7 @@ from typing import Any
 
 import pytest
 
+import inv_man_intake.performance.characterize as characterize_module
 from inv_man_intake.assist.egress_guard import EgressConsent, ProviderConfig
 from inv_man_intake.intake.standard_elements import (
     DataDrivenStandardElementLibrary,
@@ -138,6 +139,57 @@ def test_ambiguous_tail_routes_through_egress_guard(tmp_path: Path) -> None:
     assert (tmp_path / "egress.ndjson").read_text(encoding="utf-8")
 
 
+def test_ambiguous_source_names_route_through_egress_guard(tmp_path: Path) -> None:
+    series = _monthly_series(
+        (
+            (date(2025, 1, 31), 0.01),
+            (date(2025, 2, 28), 0.02),
+        )
+    )
+    metrics = compute_metrics(PerformancePayload(monthly=series))
+    calls: list[dict[str, Any]] = []
+
+    def client(payload: dict[str, Any], provider_config: ProviderConfig) -> dict[str, Any]:
+        calls.append(payload)
+        return {
+            "tag": "composite",
+            "rationale": "The source name indicates composite returns.",
+            "confidence": 0.71,
+        }
+
+    characterization = characterize_series(
+        series,
+        metrics,
+        source_names=("returns-upload.csv",),
+        consent=EgressConsent(
+            granted_by="operator",
+            purpose="classify ambiguous return stream",
+            granted_at="2026-07-07T23:00:00Z",
+        ),
+        provider_config=ProviderConfig(
+            provider="frontier",
+            model="review-model",
+            zero_retention=True,
+            baa_eligible=True,
+        ),
+        log_path=tmp_path / "egress.ndjson",
+        client=client,
+        now=lambda: datetime(2026, 7, 7, 23, 0, tzinfo=UTC),
+    )
+
+    assert characterization.tag == "composite"
+    assert characterization.evidence == ("returns-upload.csv",)
+    assert calls[0]["source_names"] == ["returns-upload.csv"]
+    assert calls[0]["allowed_tags"] == [
+        "pro_forma",
+        "blended",
+        "backfilled",
+        "gross_net_ambiguous",
+        "currency_noted",
+        "composite",
+    ]
+
+
 def test_doc_type_handling_uses_standard_element_library_port() -> None:
     throwaway_doc_type = "library_added_return_stream"
     library = DataDrivenStandardElementLibrary(
@@ -164,7 +216,7 @@ def test_doc_type_handling_uses_standard_element_library_port() -> None:
     characterization = characterize_series(series, metrics, standard_library=library)
 
     assert throwaway_doc_type in characterization.doc_types_available
-    source_text = Path("src/inv_man_intake/performance/characterize.py").read_text(encoding="utf-8")
+    source_text = Path(characterize_module.__file__).read_text(encoding="utf-8")
     assert throwaway_doc_type not in source_text
 
 

--- a/tests/performance/test_characterize.py
+++ b/tests/performance/test_characterize.py
@@ -8,7 +8,6 @@ from typing import Any
 
 import pytest
 
-import inv_man_intake.performance.characterize as characterize_module
 from inv_man_intake.assist.egress_guard import EgressConsent, ProviderConfig
 from inv_man_intake.intake.standard_elements import (
     DataDrivenStandardElementLibrary,
@@ -95,6 +94,22 @@ def test_metrics_are_byte_identical_to_deterministic_output() -> None:
     assert characterization.metrics.to_canonical_dict() == metrics.to_canonical_dict()
 
 
+def test_short_currency_keywords_require_token_boundary() -> None:
+    series = _monthly_series(
+        (
+            (date(2025, 1, 31), 0.02),
+            (date(2025, 2, 28), 0.03),
+        )
+    )
+    metrics = compute_metrics(PerformancePayload(monthly=series))
+
+    standard = characterize_series(series, metrics, source_notes=("Amateur sleeve upload",))
+    currency = characterize_series(series, metrics, source_notes=("USD sleeve upload",))
+
+    assert standard.tag == "standard"
+    assert currency.tag == "currency_noted"
+
+
 def test_ambiguous_tail_routes_through_egress_guard(tmp_path: Path) -> None:
     series = _monthly_series(
         (
@@ -137,6 +152,45 @@ def test_ambiguous_tail_routes_through_egress_guard(tmp_path: Path) -> None:
     assert calls
     assert calls[0]["payload"]["constraints"]["do_not_compute_or_change_returns"] is True
     assert (tmp_path / "egress.ndjson").read_text(encoding="utf-8")
+
+
+def test_invalid_llm_payload_raises_domain_error(tmp_path: Path) -> None:
+    series = _monthly_series(
+        (
+            (date(2025, 1, 31), 0.01),
+            (date(2025, 2, 28), 0.02),
+        )
+    )
+    metrics = compute_metrics(PerformancePayload(monthly=series))
+
+    def client(payload: dict[str, Any], provider_config: ProviderConfig) -> dict[str, Any]:
+        return {
+            "tag": "gross_net_ambiguous",
+            "rationale": "The notes require gross/net treatment review.",
+            "confidence": 0.73,
+            "provider_metadata": {"trace_id": "abc"},
+        }
+
+    with pytest.raises(ValueError, match="invalid LLM characterization payload"):
+        characterize_series(
+            series,
+            metrics,
+            source_notes=("Manager says treatment needs review.",),
+            consent=EgressConsent(
+                granted_by="operator",
+                purpose="classify ambiguous return stream",
+                granted_at="2026-07-07T23:00:00Z",
+            ),
+            provider_config=ProviderConfig(
+                provider="frontier",
+                model="review-model",
+                zero_retention=True,
+                baa_eligible=True,
+            ),
+            log_path=tmp_path / "egress.ndjson",
+            client=client,
+            now=lambda: datetime(2026, 7, 7, 23, 0, tzinfo=UTC),
+        )
 
 
 def test_ambiguous_source_names_route_through_egress_guard(tmp_path: Path) -> None:
@@ -215,9 +269,7 @@ def test_doc_type_handling_uses_standard_element_library_port() -> None:
 
     characterization = characterize_series(series, metrics, standard_library=library)
 
-    assert throwaway_doc_type in characterization.doc_types_available
-    source_text = Path(characterize_module.__file__).read_text(encoding="utf-8")
-    assert throwaway_doc_type not in source_text
+    assert characterization.doc_types_available == library.doc_types()
 
 
 def _monthly_series(points: tuple[tuple[date, float], ...]) -> PerformanceSeries:

--- a/tests/test_v1_acceptance_smoke.py
+++ b/tests/test_v1_acceptance_smoke.py
@@ -16,7 +16,9 @@ from inv_man_intake.scoring import weights as scoring_weights
 from inv_man_intake.scoring.contracts import ScoreSubmission
 from inv_man_intake.scoring.engine import compute_score
 from inv_man_intake.v1_smoke import (
+    DEFAULT_STANDARD_ELEMENT_LIBRARY_PATH,
     _assert_registered_package_state,
+    _document_source_names,
     _score_components,
     run_v1_smoke_pipeline,
 )
@@ -205,6 +207,19 @@ def test_v1_smoke_pipeline_score_uses_toml_weight_registry(
         if item["component"] == "performance_consistency"
     )
     assert performance_component["weight"] == pytest.approx(1.00)
+
+
+def test_v1_smoke_characterizer_inputs_use_source_names_and_standard_library(
+    v1_smoke_artifacts,
+) -> None:
+    source_names = _document_source_names(
+        repository=v1_smoke_artifacts.core_repository,
+        document_ids=v1_smoke_artifacts.record.document_ids,
+    )
+
+    assert source_names != v1_smoke_artifacts.record.document_ids
+    assert "summit_arc_track_record.xlsx" in source_names
+    assert DEFAULT_STANDARD_ELEMENT_LIBRARY_PATH.exists()
 
 
 def test_v1_acceptance_smoke_fails_when_intake_registration_is_bypassed() -> None:


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:727 -->
> **Source:** Issue #727

Closes #727

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Return/attribution streams must be extracted and **non-standard elements characterized** (pro-forma, blended,
backfilled, gross-vs-net ambiguity, currency, composite). `performance/` computes metrics deterministically and
`conflict_resolver` cross-checks series, but nothing **characterizes** a non-standard series or tags it before it
feeds scoring. The deck-priority MVP needs this for the track-record surface. Latent gap.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#718](https://github.com/stranske/Inv-Man-Intake/issues/718)
- [#722](https://github.com/stranske/Inv-Man-Intake/issues/722)
- [#724](https://github.com/stranske/Inv-Man-Intake/issues/724)
- [#721](https://github.com/stranske/Inv-Man-Intake/issues/721)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] Add `src/inv_man_intake/performance/characterize.py::characterize_series(series, metrics) -> SeriesCharacterization`
  (typed tag set: standard | pro_forma | blended | backfilled | gross_net_ambiguous | currency_noted | composite,
  + [ ] rationale + confidence).
- [ ] Deterministic heuristics first (e.g. gaps/overlaps/footnote markers); LLM tag only for the ambiguous tail (egress-guard).
- [ ] Gate non-standard-tagged series behind operator confirmation before they enter the scoring submission.

#### Acceptance criteria
- [ ] Named test `tests/performance/test_characterize.py::test_non_standard_series_tagged_and_gated` passes: a
  pro-forma/backfilled fixture series is tagged non-standard and is NOT auto-fed to scoring without confirmation;
  a clean monthly series is tagged standard and flows.
- [ ] **Deliberate-break gate:** make the characterizer pass non-standard series straight through ungated; the
  named test **must FAIL**; revert → passes.
- [ ] A test asserts computed metrics (vol/Sharpe/…) are byte-identical to the deterministic `performance.metrics`
  output (the characterizer never alters numbers).
- [ ] **Decoupling gate:** any doc-type handling resolves through the #721 port (a test asserts no doc-type is
  hardcoded); the characterization tags carry no standardness judgment beyond "is/ isn't the standard series shape."

<!-- auto-status-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic performance-series characterization for monthly intake, including clearer handling of standard, non-standard, and ambiguous cases.
  * Added operator confirmation checks before scoring certain non-standard submissions.
  * Improved acceptance flow so scoring is gated based on the series characterization before a score is computed.

* **Bug Fixes**
  * Better handling of missing-month backfill and other edge-case series patterns.
  * Standard series now proceed directly without extra confirmation steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->