### PR TITLE
docs: deprecate legacy Streamlit fixture renderer

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,12 @@ Live verification gate (no terminal required for reviewer):
 4. Verification evidence and screenshot are recorded in
    `app/live-verification.md`.
 
-The legacy stlite/Streamlit surface is retained only as transition reference
-while the static SPA reaches full Gate 1 and Gate 2 parity.
+### Deprecated Streamlit/stlite fixture renderer
+
+`app/streamlit_app.py` is a deprecated compatibility renderer for deterministic
+fixture tests. It is not a production entrypoint and must not be used for
+browser verification or user-facing deployment. Use `app/index.html` and the
+static-Pyodide verification path above instead.
 
 The repository uses the shared
 [`stranske/Workflows`](https://github.com/stranske/Workflows) CI and agent

--- a/app/streamlit_app.py
+++ b/app/streamlit_app.py
@@ -1,4 +1,9 @@
-"""Streamlit/stlite demo for the local intake-to-score smoke path."""
+"""Deprecated Streamlit/stlite fixture renderer for the local smoke path.
+
+The supported browser verification surface is ``app/index.html`` (the static
+Pyodide SPA).  This module remains only for deterministic fixture compatibility
+and must not be presented as a production or supported launch path.
+"""
 
 from __future__ import annotations
 
@@ -42,6 +47,11 @@ from inv_man_intake.validation_queue_api import (  # noqa: E402
     list_validation_queue,
 )
 from inv_man_intake.workflow_validation import ValidationQueueRow  # noqa: E402
+
+DEPRECATION_NOTICE = (
+    "Deprecated fixture renderer: use app/index.html, the static Pyodide SPA, "
+    "for supported browser verification."
+)
 
 FIXTURE_ROOT = Path(__file__).resolve().parents[1] / "tests" / "fixtures" / "intake"
 FIXTURE_OPTIONS = tuple(package["intake_bundle_file"] for package in DEFAULT_BATCH_PACKAGES)

--- a/app/streamlit_app.py
+++ b/app/streamlit_app.py
@@ -1,7 +1,7 @@
 """Deprecated Streamlit/stlite fixture renderer for the local smoke path.
 
 The supported browser verification surface is ``app/index.html`` (the static
-Pyodide SPA).  This module remains only for deterministic fixture compatibility
+Pyodide SPA). This module remains only for deterministic fixture compatibility
 and must not be presented as a production or supported launch path.
 """
 

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,16 +1,16 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-10T21:58:39.273235Z",
+  "emitted_at": "2026-07-13T12:33:35.978811Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"
   ],
   "operation_role": "worker",
-  "pr_number": "781",
+  "pr_number": "785",
   "requested_model": "gpt-5.5",
   "runner": "reusable-codex-run",
   "schema": "langsmith-fleet/v1",
-  "selected_model": "gpt-5.5",
-  "selection_reason": "input"
+  "selected_model": "",
+  "selection_reason": ""
 }

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-13T13:07:45.894851Z",
+  "emitted_at": "2026-07-13T13:12:48.304520Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-13T13:49:49.100766Z",
+  "emitted_at": "2026-07-13T13:53:27.038437Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-13T12:43:35.106101Z",
+  "emitted_at": "2026-07-13T13:07:45.894851Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-13T13:38:42.663161Z",
+  "emitted_at": "2026-07-13T13:42:28.252548Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-13T13:57:40.111189Z",
+  "emitted_at": "2026-07-13T14:13:07.098558Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-13T13:53:27.038437Z",
+  "emitted_at": "2026-07-13T13:57:40.111189Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-13T13:46:14.102504Z",
+  "emitted_at": "2026-07-13T13:49:49.100766Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-13T12:33:35.978811Z",
+  "emitted_at": "2026-07-13T12:39:32.715002Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-13T13:12:48.304520Z",
+  "emitted_at": "2026-07-13T13:21:15.256311Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,16 +1,16 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-10T21:58:39.273235Z",
+  "emitted_at": "2026-07-13T12:06:50.259661Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"
   ],
   "operation_role": "worker",
-  "pr_number": "781",
+  "pr_number": "785",
   "requested_model": "gpt-5.5",
   "runner": "reusable-codex-run",
   "schema": "langsmith-fleet/v1",
-  "selected_model": "gpt-5.5",
-  "selection_reason": "input"
+  "selected_model": "",
+  "selection_reason": ""
 }

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-13T13:33:31.739514Z",
+  "emitted_at": "2026-07-13T13:38:42.663161Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-13T13:42:28.252548Z",
+  "emitted_at": "2026-07-13T13:46:14.102504Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,16 +1,16 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-13T12:06:50.259661Z",
+  "emitted_at": "2026-07-10T21:58:39.273235Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"
   ],
   "operation_role": "worker",
-  "pr_number": "785",
+  "pr_number": "781",
   "requested_model": "gpt-5.5",
   "runner": "reusable-codex-run",
   "schema": "langsmith-fleet/v1",
-  "selected_model": "",
-  "selection_reason": ""
+  "selected_model": "gpt-5.5",
+  "selection_reason": "input"
 }

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-13T13:21:15.256311Z",
+  "emitted_at": "2026-07-13T13:33:31.739514Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-13T14:13:07.098558Z",
+  "emitted_at": "2026-07-13T14:17:21.449245Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-13T12:39:32.715002Z",
+  "emitted_at": "2026-07-13T12:43:35.106101Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/tests/app/test_streamlit_app_smoke.py
+++ b/tests/app/test_streamlit_app_smoke.py
@@ -9,6 +9,7 @@ from typing import cast
 import pytest
 from app.streamlit_app import (
     ASSISTANT_FOLLOWUP_STATE_KEY,
+    DEPRECATION_NOTICE,
     QUEUE_ACTION_STATE_KEY,
     _operator_queue_rows,
     build_operator_assistant_session,
@@ -19,6 +20,11 @@ from app.streamlit_app import (
 
 from inv_man_intake.observability import InMemoryTraceSink
 from inv_man_intake.packet import PacketFile
+
+
+def test_streamlit_renderer_is_explicitly_deprecated() -> None:
+    assert "Deprecated fixture renderer" in DEPRECATION_NOTICE
+    assert "static Pyodide SPA" in DEPRECATION_NOTICE
 
 
 class _StreamlitRecorder:

--- a/tests/app/test_streamlit_app_smoke.py
+++ b/tests/app/test_streamlit_app_smoke.py
@@ -24,7 +24,9 @@ from inv_man_intake.packet import PacketFile
 
 def test_streamlit_renderer_is_explicitly_deprecated() -> None:
     assert "Deprecated fixture renderer" in DEPRECATION_NOTICE
+    assert "app/index.html" in DEPRECATION_NOTICE
     assert "static Pyodide SPA" in DEPRECATION_NOTICE
+    assert "supported browser verification" in DEPRECATION_NOTICE
 
 
 class _StreamlitRecorder:


### PR DESCRIPTION
## Bounded Streamlit-retirement slice

This PR implements the owner-approved Streamlit retirement and static-SPA documentation slice for umbrella issue #777. It deliberately does **not** close #777; the remaining UX, browser-flow, offline, and MVP-surface slices stay tracked there.

Validation: focused smoke tests plus Ruff checks passed, and the current Gate, Health, and CodeRabbit checks are green.