### PR TITLE
Codex bootstrap for #787

### DIFF
--- a/agents/codex-787.md
+++ b/agents/codex-787.md
@@ -1,0 +1,1 @@
+<!-- bootstrap for codex on issue #787 -->

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-14T14:35:50.651716Z",
+  "emitted_at": "2026-07-14T14:39:36.878142Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,13 +1,13 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-14T13:13:52.298989Z",
+  "emitted_at": "2026-07-14T14:30:57.109949Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"
   ],
   "operation_role": "worker",
-  "pr_number": "791",
+  "pr_number": "792",
   "requested_model": "gpt-5.5",
   "runner": "reusable-codex-run",
   "schema": "langsmith-fleet/v1",

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-14T14:30:57.109949Z",
+  "emitted_at": "2026-07-14T14:35:50.651716Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"


### PR DESCRIPTION
<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
This is the owner-approved bounded offline/no-egress delivery slice for umbrella issue #777, following the merged browser-flow child (#781) and Streamlit-retirement child (#785). It addresses the remaining completion debt from the post-merge verifier disposition on #776 without reopening the full umbrella.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#777](https://github.com/stranske/Inv-Man-Intake/issues/777)
- [#781](https://github.com/stranske/Inv-Man-Intake/issues/781)
- [#785](https://github.com/stranske/Inv-Man-Intake/issues/785)
- [#776](https://github.com/stranske/Inv-Man-Intake/issues/776)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] Add a browser test that enables offline or network interception before initial SPA navigation, loads the local static bundle, and completes the real packet-processing interaction path.
  - [ ] Configure browser test environment to enable offline mode or network interception before navigation starts (verify: config validated)
  - [ ] Implement test logic to load the local static SPA bundle from the test server (verify: confirm completion in repo)
  - [ ] Add test steps that execute the complete packet-processing interaction path through the UI (verify: tests pass)
- [ ] Implement browser-level request enforcement so the test fails on every non-local `http://` or `https://` request and permits only the local test-server origin.
  - [ ] Implement request interception that blocks all http (verify: confirm completion in repo) https requests in the browser test (verify: confirm completion in repo)
  - [ ] Configure the request interceptor to permit only the local test-server origin (verify: config validated)
  - [ ] Add assertions that verify the test fails when any non-local request is attempted
- [ ] Update the exercised browser flow to verify the Pyodide bridge runs the deterministic packet path instead of a demo or reduced offline fallback.
- [ ] Test that existing static-SPA browser and offline-bundle checks remain green in CI/local test tooling.

#### Acceptance criteria
- [ ] A browser test enables offline or network interception before initial SPA navigation, loads the local static bundle, and completes the real packet-processing interaction path.
- [ ] The test fails on every non-local `http://` or `https://` request during load and the exercised deterministic flow; the local test-server origin is the only permitted origin.
- [ ] The test demonstrates that the Pyodide bridge runs the deterministic packet path rather than silently selecting a demo or reduced fallback when offline.
- [ ] Existing static-SPA browser and offline-bundle checks remain green.

<!-- auto-status-summary:end -->

<details>

<summary>Full Issue Text</summary>



## Why

This is the owner-approved bounded offline/no-egress delivery slice for umbrella issue #777, following the merged browser-flow child (#781) and Streamlit-retirement child (#785). It addresses the remaining completion debt from the post-merge verifier disposition on #776 without reopening the full umbrella.

## Scope

Make the static SPA execute its deterministic Pyodide packet path under simulated offline conditions from initial navigation through a real packet interaction. Add browser-level enforcement that the exercised flow makes zero non-local outbound requests and loads no external CDN resources. Keep evidence deterministic and runnable in repository CI/local test tooling.

## Non-Goals

Do not change the UX-policy, browser accessibility/deliberate-break, Streamlit-retirement, or MVP-surface slices already tracked or delivered under #777. Do not introduce a server, cloud dependency, external CDN, or live provider call on the deterministic path.

## Tasks

- [ ] Add a browser test that enables offline or network interception before initial SPA navigation, loads the local static bundle, and completes the real packet-processing interaction path.
  - [ ] Configure browser test environment to enable offline mode or network interception before navigation starts (verify: config validated)
  - [ ] Implement test logic to load the local static SPA bundle from the test server (verify: confirm completion in repo)
  - [ ] Add test steps that execute the complete packet-processing interaction path through the UI (verify: tests pass)
- [ ] Implement browser-level request enforcement so the test fails on every non-local `http://` or `https://` request and permits only the local test-server origin.
  - [ ] Implement request interception that blocks all http (verify: confirm completion in repo)
  - [ ] https requests in the browser test (verify: confirm completion in repo)
  - [ ] Configure the request interceptor to permit only the local test-server origin (verify: config validated)
  - [ ] Add assertions that verify the test fails when any non-local request is attempted
- [ ] Update the exercised browser flow to verify the Pyodide bridge runs the deterministic packet path instead of a demo or reduced offline fallback.
- [ ] Test that existing static-SPA browser and offline-bundle checks remain green in CI/local test tooling.

## Acceptance Criteria

- [ ] A browser test enables offline or network interception before initial SPA navigation, loads the local static bundle, and completes the real packet-processing interaction path.
- [ ] The test fails on every non-local `http://` or `https://` request during load and the exercised deterministic flow; the local test-server origin is the only permitted origin.
- [ ] The test demonstrates that the Pyodide bridge runs the deterministic packet path rather than silently selecting a demo or reduced fallback when offline.
- [ ] Existing static-SPA browser and offline-bundle checks remain green.

## Implementation Notes

_Not provided._

<details>
<summary>Original Issue</summary>

```text
## Why

This is the owner-approved bounded offline/no-egress delivery slice for umbrella issue #777, following the merged browser-flow child (#781) and Streamlit-retirement child (#785). It addresses the remaining completion debt from the post-merge verifier disposition on #776 without reopening the full umbrella.

## Scope

- Make the static SPA execute its deterministic Pyodide packet path under simulated offline conditions from initial navigation through a real packet interaction.
- Add browser-level enforcement that the exercised flow makes zero non-local outbound requests and loads no external CDN resources.
- Keep evidence deterministic and runnable in repository CI/local test tooling.

## Acceptance criteria

- A browser test enables offline/network interception before initial SPA navigation, loads the local static bundle, and completes the real packet-processing interaction path.
- The test fails on every non-local `http://` or `https://` request during load and the exercised deterministic flow; the local test-server origin is the only permitted origin.
- The test demonstrates that the Pyodide bridge runs the deterministic packet path rather than silently selecting a demo or reduced fallback when offline.
- Existing static-SPA browser and offline-bundle checks remain green.

## Non-goals

- Do not change the UX-policy, browser accessibility/deliberate-break, Streamlit-retirement, or MVP-surface slices already tracked or delivered under #777.
- Do not introduce a server, cloud dependency, external CDN, or live provider call on the deterministic path.

## Source

- Umbrella: #777
- Verifier context: #776, #785
- Owner-approved delivery structure: issuecomment-4936089938
```
</details>

<!-- issue-pr-context:formatted-body:v1 {"sha256":"69f468a8678d05378164e4ad55a57bf44f520c8610c278c39af8cc96721408c2","workflows":["agents-auto-pilot","agents-issue-optimizer","agents-63-issue-intake","issue_formatter","issue_optimizer"]} -->



</details>

—
PR created automatically to engage Codex.

<!-- pr-preamble:start -->
<!-- meta:issue:787 -->
> **Source:** Issue #787

Closes #787

<!-- pr-preamble:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a top-of-file bootstrap comment for issue 787.
  * Refreshed run attempt metadata with an updated timestamp and pull request number, keeping the same execution profile and fallback model settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->