### PR TITLE
test: prove remaining operator MVP browser surfaces

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -65,7 +65,7 @@
 
         <article class="operator-panel" aria-labelledby="returns-heading">
           <h2 id="returns-heading">Return stream</h2>
-          <table id="returns-table">
+          <table id="returns-table" aria-label="Packet return stream">
             <thead>
               <tr>
                 <th>Period</th>
@@ -94,7 +94,8 @@
 
         <article class="operator-panel" aria-labelledby="assistant-heading">
           <h2 id="assistant-heading">Assistant panel</h2>
-          <p id="assistant-answer">Recommendations stay manual and cite deterministic packet evidence.</p>
+          <p id="assistant-answer" aria-live="polite">Recommendations stay manual and cite deterministic packet evidence.</p>
+          <button id="refresh-assistant" type="button">Refresh recommendation</button>
         </article>
       </section>
     </main>

--- a/app/static_operator_app.js
+++ b/app/static_operator_app.js
@@ -65,6 +65,8 @@ function renderProfile(profile) {
   clearRows("queue-table");
 
   const profileList = document.getElementById("profile-list");
+  const manager = profile.manager_profile.Manager || "Uploaded manager";
+  document.getElementById("profile-heading").textContent = `Manager profile: ${manager}`;
   profileList.replaceChildren();
   for (const [label, value] of Object.entries(profile.manager_profile)) {
     const dt = document.createElement("dt");
@@ -190,6 +192,15 @@ document.getElementById("packet-upload").addEventListener("change", async (event
 document.getElementById("seed-conflict").addEventListener("click", () => {
   if (state.profile && !testControls().disableConflictHandler) {
     seedConflict(state.profile);
+  }
+});
+
+document.getElementById("refresh-assistant").addEventListener("click", () => {
+  if (state.profile) {
+    const manager = state.profile.manager_profile.Manager || "the uploaded manager";
+    state.profile.assistant_answer =
+      `Recommendation refreshed for ${manager}. Review packet exceptions before promotion.`;
+    document.getElementById("assistant-answer").textContent = state.profile.assistant_answer;
   }
 });
 

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,13 +1,13 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-17T18:33:20.233489Z",
+  "emitted_at": "2026-07-17T19:53:28.579967Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"
   ],
   "operation_role": "worker",
-  "pr_number": "807",
+  "pr_number": "802",
   "requested_model": "gpt-5.5",
   "runner": "reusable-codex-run",
   "schema": "langsmith-fleet/v1",

--- a/tests/app/test_static_spa_browser_e2e.py
+++ b/tests/app/test_static_spa_browser_e2e.py
@@ -57,7 +57,7 @@ def local_static_spa() -> Iterator[str]:
 
 
 def _verify_static_spa_interactions(page: object) -> None:
-    """Exercise upload, graphic, and escalation paths through accessible browser UI."""
+    """Exercise the MVP packet surfaces through accessible browser UI."""
 
     page.locator("#packet-upload").set_input_files(str(PACKET_FIXTURE))
     upload_count = page.locator("#upload-count")
@@ -75,9 +75,21 @@ def _verify_static_spa_interactions(page: object) -> None:
     )
     assert page.locator("main").get_attribute("data-packet-path") == "inv-man-intake.ingest_packet"
 
+    profile_details = page.locator("#profile-list")
+    assert "Manager" in profile_details.inner_text()
+    assert "Summit Arc Capital" in profile_details.inner_text()
+    assert "Provenance" in profile_details.inner_text()
+    profile_heading = page.get_by_role(
+        "heading", name=re.compile(r"Manager profile: Summit Arc Capital")
+    )
+    assert profile_heading.is_visible()
+
     page.get_by_role("button", name="Open graphic").first.click()
     graphics_table = page.get_by_role("table", name="Packet graphics")
     assert re.search(r"Opened", graphics_table.inner_text(timeout=45_000))
+
+    returns_table = page.get_by_role("table", name="Packet return stream")
+    assert returns_table.locator("tbody tr").count() == 1
 
     page.get_by_role("button", name="Seed deterministic conflict").click()
     queue_table = page.get_by_role("table", name="Exception queue")
@@ -86,6 +98,12 @@ def _verify_static_spa_interactions(page: object) -> None:
         name="Seeded deterministic conflict Browser-verification escalation Operations review",
     )
     assert seeded_row.count() == 1
+
+    assistant_answer = page.locator("#assistant-answer")
+    page.get_by_role("button", name="Refresh recommendation").click()
+    assert "Recommendation refreshed for Summit Arc Capital" in assistant_answer.inner_text()
+    page.get_by_role("button", name="Open graphic").first.click()
+    assert "Recommendation refreshed for Summit Arc Capital" in assistant_answer.inner_text()
 
 
 def _with_page(


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:777 -->
> **Source:** Issue #777

Closes #777

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
PR #776 addressed issue #775 but verification identified concerns (verdict: **FAIL**). This follow-up addresses the remaining gaps with improved task structure, focusing on full browser-based SPA verification, deterministic offline execution, missing UX review logic, MVP surface integration coverage, and removal or deprecation of the legacy Streamlit production path.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#776](https://github.com/stranske/Inv-Man-Intake/issues/776)
- [#775](https://github.com/stranske/Inv-Man-Intake/issues/775)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] Create a browser-based test that loads the SPA and uploads a real packet fixture using accessibility tree interactions
- [ ] Add assertions to verify that coverage output is rendered correctly after packet upload completes
- [ ] Implement a test step that opens a graphic item through accessibility tree queries and verifies the graphic detail view appears
- [ ] Add a test step that triggers a deterministic seeded conflict using a fixed fixture or explicit seed value
- [ ] Implement assertions that verify exactly one expected escalation row appears in the accessibility tree after the seeded conflict
- [ ] Add a deliberate-break regression test that temporarily disables one SPA interaction handler, asserts frontend verification fails for the corresponding step, then restores the handler and asserts the verification passes.
- [ ] Extend the static bundle test suite to run the SPA in simulated offline mode and assert that no outbound network requests occur and no external CDN resources are requested during load or interaction.
- [ ] Create a functional integration test that processes a real packet fixture and asserts the manager profile surface renders profile-specific and provenance elements
- [ ] Add a functional integration test that verifies the graphics gallery surface renders at least one graphic item and responds to user interaction
- [ ] Implement a functional integration test that asserts the return-stream viewer surface renders packet-derived content and responds to navigation interactions
- [ ] Create a functional integration test that verifies the exception queue surface renders queue rows and updates presentation after seeded conflict interactions
- [ ] Add a functional integration test that asserts the assistant panel seam is present and responds to basic interactions without browser errors
- [ ] Remove streamlit_app.py from the repository or modify it to explicitly mark it as deprecated and not a production entrypoint
- [ ] Delete tests/test_streamlit_app_smoke.py or rewrite it to validate deprecation status rather than exercising Streamlit as a supported path
- [ ] Update README.md to remove all instructions for launching the application through Streamlit
- [ ] Add a README.md section describing the supported local package source setup for Pyodide browser execution with explicit file paths and configuration examples
- [ ] Document the deterministic offline browser verification path in README.md by naming the automated test entrypoint and stating it runs without external network dependencies

#### Acceptance criteria
- [ ] `tests/test_static_spa_bundle.py` contains an end-to-end browser test that loads the static SPA, uploads a real packet fixture, and asserts that a coverage result is rendered before any graphic interaction step is executed.
- [ ] The browser-based verification flow asserts the presence of the opened graphic and the escalation row by querying the live accessibility tree or accessibility-role/name selectors, not by inspecting internal application state or raw HTML strings.
- [ ] The end-to-end verification test triggers a deterministic seeded conflict using a fixed fixture or explicit seed value and asserts that exactly one expected escalation row or equivalent conflict indicator is rendered for that seeded condition.
- [ ] A regression test exists that temporarily disables one specific SPA interaction handler required by `frontend_verify.py`, and the verification run fails at the corresponding interaction step with an assertion or error message identifying that missing behavior.
- [ ] The deliberate-break regression test restores the disabled interaction handler within the same test module or test sequence and demonstrates that the same `frontend_verify` step passes after restoration.
- [ ] `ux_review.py` exports callable logic that accepts usability panel results, adversarial agent results, and owner calibration inputs and returns a structured overall UX review result containing at least an overall numeric score and a blocker/severity outcome.
- [ ] `tests/test_ux_review.py` includes at least one test fixture where the combined UX inputs produce an overall score greater than or equal to 7.0 and no severity-4 blocker, and the expected pass result is asserted.
- [ ] `tests/test_ux_review.py` includes at least one test fixture where either the overall score is below 7.0 or a severity-4 issue is present, and the expected failing/blocking result is asserted.
- [ ] The static SPA bundle test suite includes a test that runs the SPA with browser/network offline simulation enabled before initial page load and confirms the application still loads enough to execute the packet-processing interaction path.
- [ ] The offline test asserts that zero outbound network requests are issued to non-local origins during SPA load and the exercised interaction flow, excluding only the local test server origin if one is used to serve static files.
- [ ] The offline/network-isolation test explicitly fails if any requested resource URL matches a known external scheme or host pattern such as `http://`, `https://`, or a CDN domain outside the local test origin.
- [ ] Functional integration tests using a real packet fixture assert that an element with role="heading" and name matching the manager identifier is present, and an element with data-testid="provenance-timestamp" or similar is rendered in the manager profile surface.
- [ ] Functional integration tests using a real packet fixture assert that after clicking a graphic item in the graphics gallery, an element with role="dialog" or data-testid="graphic-detail" appears in the accessibility tree and has aria-hidden="false".
- [ ] Functional integration tests using a real packet fixture assert that after clicking expand in the return-stream viewer, the element with data-testid="stream-content" increases its child count by at least one, or an element transitions from aria-expanded="false" to aria-expanded="true".
- [ ] Functional integration tests using a real packet fixture assert that the exception queue surface renders at least one exception or queue row and that seeded conflict or queue interaction updates the queue presentation in the rendered UI.

- [ ] _(6 further criteria elided; split this issue)_

<!-- auto-status-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Refresh recommendation” button in the Assistant panel to update the recommendation based on the current manager profile (with sensible fallback when missing).
  * Manager profile heading now reflects the uploaded manager name when available.
* **Bug Fixes**
  * Updated the static SPA end-to-end verifier to match the MVP packet UI flow, including manager profile details, “Open graphic” updates, packet return stream row count, and refreshed recommendation checks.
* **Accessibility**
  * Improved Assistant panel accessibility with polite live updates and added an explicit label to the “Packet return stream” table.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->