### PR TITLE
deps: sync dev tool versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dev = [
     "pytest-cov==7.1.0",
     "ruff==0.15.22",
     "mypy==2.3.0",
-    "black>=26.5.1",
+    "black==26.5.1",
     "tomlkit==0.15.1",
     "pydantic==2.13.4",
     "pytest-regressions==2.11.0",

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -44,7 +44,7 @@ colorama==0.4.6 ; sys_platform == 'win32'
     #   tqdm
 colorlog==6.10.1
     # via rapidocr
-coverage==7.13.5
+coverage==7.15.2
     # via pytest-cov
 cuda-bindings==13.3.1 ; sys_platform == 'linux'
     # via torch
@@ -152,7 +152,7 @@ mpmath==1.3.0
     # via sympy
 multiprocess==0.70.19
     # via mpire
-mypy==2.1.0
+mypy==2.3.0
     # via inv-man-intake (pyproject.toml)
 mypy-extensions==1.1.0
     # via
@@ -351,7 +351,7 @@ rtree==1.4.1
     # via
     #   docling-ibm-models
     #   docling-slim
-ruff==0.15.20
+ruff==0.15.22
     # via inv-man-intake (pyproject.toml)
 safetensors==0.8.0
     # via


### PR DESCRIPTION
## Dev Tool Version Sync

This PR updates dev tool versions in `pyproject.toml` and related generated dependency files to match the central version pins from [stranske/Workflows](https://github.com/stranske/Workflows).

### Changes
```
Found 4 version updates:
  - black: >=26.5.1 -> ==26.5.1
  - requirements-dev.lock:coverage: 7.13.5 -> ==7.15.2
  - requirements-dev.lock:mypy: 2.1.0 -> ==2.3.0
  - requirements-dev.lock:ruff: 0.15.20 -> ==0.15.22

Run with --apply to update dependency files
```

### Why
Consistent dev tool versions across repos ensures:
- CI behaviors match between repos
- No surprises from version drift
- Easier debugging when tools behave the same everywhere

---
**Source:** `.github/workflows/autofix-versions.env`