### PR TITLE
Codex bootstrap for #680

### DIFF
--- a/agents/codex-680.md
+++ b/agents/codex-680.md
@@ -1,0 +1,1 @@
+<!-- bootstrap for codex on issue #680 -->

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,0 +1,16 @@
+{
+  "agent": "codex",
+  "cli_version": "0.125.0",
+  "emitted_at": "2026-07-20T12:49:54.467709Z",
+  "execution_profile": "codex-default",
+  "fallback_models": [
+    "gpt-5.4"
+  ],
+  "operation_role": "worker",
+  "pr_number": "819",
+  "requested_model": "gpt-5.5",
+  "runner": "reusable-codex-run",
+  "schema": "langsmith-fleet/v1",
+  "selected_model": "",
+  "selection_reason": ""
+}


### PR DESCRIPTION
<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
`src/inv_man_intake/workflow_validation.py` renders queue rows for terminal states. The audit found that `completed` and fallthrough paths both render `"No action"`, while `docs/contracts/queue_states.md` documents `rejected` as a distinct terminal state. This is a small Route-Weight opener that may need a one-line production fix plus a focused regression test.

#### Tasks
- [ ] Add a focused test that transitions or constructs a rejected queue item and asserts its `next_action` is distinct from the completed-state copy.
- [ ] If needed, make the smallest production change to render rejected items with non-ambiguous copy such as `"No further action"` or `"Archive rejected package"`.
- [ ] Preserve existing completed-state behavior.

#### Acceptance criteria
- [ ] Tests are deterministic and do not require network, browser, or external services.
- [ ] `rejected` queue rows no longer share the exact same `next_action` string as `completed`.
- [ ] The change is limited to queue-row presentation/copy unless existing code proves a narrower helper is needed.

<!-- auto-status-summary:end -->

<details>

<summary>Full Issue Text</summary>



## Why

`src/inv_man_intake/workflow_validation.py` renders queue rows for terminal states. The audit found that `completed` and fallthrough paths both render `"No action"`, while `docs/contracts/queue_states.md` documents `rejected` as a distinct terminal state. This is a small Route-Weight opener that may need a one-line production fix plus a focused regression test.

## Scope

- Add a focused test that transitions or constructs a rejected queue item and asserts its `next_action` is distinct from the completed-state copy.
- If needed, make the smallest production change to render rejected items with non-ambiguous copy such as `"No further action"` or `"Archive rejected package"`.
- Preserve existing completed-state behavior.

## Acceptance Criteria

- Tests are deterministic and do not require network, browser, or external services.
- `rejected` queue rows no longer share the exact same `next_action` string as `completed`.
- The change is limited to queue-row presentation/copy unless existing code proves a narrower helper is needed.

## Validation

```bash
pytest tests/test_workflow_validation.py -k "rejected_next_action" -q
```

## Route-Weight Metadata

- `task_type`: `testgen`
- `lane`: `opener`
- `safe_opener`: `true`
- `defect_class`: `queue-state-presentation-coverage-gap`
- `source`: `Audits/Inv-Man-Intake/2026-06-27-route-weight-findings.md`

## Non-Goals

- Do not change queue state-machine transitions.
- Do not add UI workflows.
- Do not alter completed-state copy.



</details>

—
PR created automatically to engage Codex.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an initial bootstrap note for the Codex work associated with issue 680.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- pr-preamble:start -->
<!-- meta:issue:680 -->
> **Source:** Issue #680

Closes #680

<!-- pr-preamble:end -->