### PR TITLE
feat: add export service manifest port

### DIFF
--- a/src/inv_man_intake/export/__init__.py
+++ b/src/inv_man_intake/export/__init__.py
@@ -1,0 +1,33 @@
+"""Export service port and deterministic manifest contracts."""
+
+from inv_man_intake.export.manifest import (
+    ExportArtifact,
+    ExportItem,
+    ExportManifest,
+    ExportSkipReason,
+    ManifestArtifact,
+    ManifestSkip,
+)
+from inv_man_intake.export.service import (
+    DefaultExportService,
+    Exporter,
+    ExportService,
+    ManifestExporter,
+    build_default_export_service,
+    ensure_export_service,
+)
+
+__all__ = [
+    "DefaultExportService",
+    "ExportArtifact",
+    "ExportItem",
+    "ExportManifest",
+    "Exporter",
+    "ExportService",
+    "ExportSkipReason",
+    "ManifestArtifact",
+    "ManifestExporter",
+    "ManifestSkip",
+    "build_default_export_service",
+    "ensure_export_service",
+]

--- a/src/inv_man_intake/export/manifest.py
+++ b/src/inv_man_intake/export/manifest.py
@@ -1,0 +1,91 @@
+"""Deterministic manifest contracts for user-facing exports."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+ExportSkipReason = Literal[
+    "unsupported_colorspace",
+    "unsupported_encoding",
+    "vector_render_failed",
+    "no_table_found",
+    "no_series_found",
+]
+
+
+@dataclass(frozen=True)
+class ExportArtifact:
+    """One materialized export together with its source lineage references."""
+
+    name: str
+    media_type: str
+    content: bytes
+    provenance_refs: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ManifestArtifact:
+    """Associate a produced artifact with the input item it represents."""
+
+    item_ref: str
+    artifact: ExportArtifact
+
+
+@dataclass(frozen=True)
+class ManifestSkip:
+    """Describe an intentionally omitted export item without losing its reason."""
+
+    item_ref: str
+    reason_code: ExportSkipReason
+
+
+@dataclass(frozen=True)
+class ExportItem:
+    """One exporter result, which is either materialized or explicitly skipped."""
+
+    item_ref: str
+    artifact: ExportArtifact | None = None
+    skip_reason: ExportSkipReason | None = None
+
+    def __post_init__(self) -> None:
+        if (self.artifact is None) == (self.skip_reason is None):
+            raise ValueError("an export item must contain exactly one artifact or skip reason")
+
+
+@dataclass(frozen=True)
+class ExportManifest:
+    """A stable, complete record of produced and intentionally skipped exports."""
+
+    artifacts: tuple[ManifestArtifact, ...]
+    skipped: tuple[ManifestSkip, ...]
+
+    @classmethod
+    def from_items(cls, items: tuple[ExportItem, ...]) -> ExportManifest:
+        """Build a deterministic manifest, rejecting duplicate input references."""
+
+        item_refs = [item.item_ref for item in items]
+        if len(item_refs) != len(set(item_refs)):
+            raise ValueError("export item references must be unique")
+
+        artifacts = tuple(
+            sorted(
+                (
+                    ManifestArtifact(item_ref=item.item_ref, artifact=item.artifact)
+                    for item in items
+                    if item.artifact is not None
+                ),
+                key=lambda entry: entry.item_ref,
+            )
+        )
+        skipped = tuple(
+            sorted(
+                (
+                    ManifestSkip(item_ref=item.item_ref, reason_code=item.skip_reason)
+                    for item in items
+                    if item.skip_reason is not None
+                ),
+                key=lambda entry: entry.item_ref,
+            )
+        )
+        return cls(artifacts=artifacts, skipped=skipped)

--- a/src/inv_man_intake/export/service.py
+++ b/src/inv_man_intake/export/service.py
@@ -1,0 +1,82 @@
+"""Swappable export service port with a deterministic manifest boundary."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol, runtime_checkable
+
+from inv_man_intake.export.manifest import ExportItem, ExportManifest
+
+
+@runtime_checkable
+class Exporter(Protocol):
+    """Backend which materializes export results into a complete manifest."""
+
+    @property
+    def name(self) -> str: ...
+
+    def export(self, items: tuple[ExportItem, ...]) -> ExportManifest:
+        """Return every produced item and every intentional skip."""
+
+
+@runtime_checkable
+class ExportService(Protocol):
+    """Stable consumer-facing port for user-deliverable exports."""
+
+    @property
+    def backend_name(self) -> str: ...
+
+    def export(self, items: tuple[ExportItem, ...]) -> ExportManifest:
+        """Materialize an export manifest through the selected backend."""
+
+
+@dataclass(frozen=True)
+class ManifestExporter:
+    """Default local backend: normalize exporter results without egress or I/O."""
+
+    exporter_name: str = "manifest-local"
+
+    @property
+    def name(self) -> str:
+        return self.exporter_name
+
+    def export(self, items: tuple[ExportItem, ...]) -> ExportManifest:
+        return ExportManifest.from_items(items)
+
+
+@dataclass(frozen=True)
+class DefaultExportService:
+    """Concrete service that delegates the export boundary to one backend."""
+
+    backend: Exporter
+
+    @property
+    def backend_name(self) -> str:
+        return self.backend.name
+
+    def export(self, items: tuple[ExportItem, ...]) -> ExportManifest:
+        return self.backend.export(items)
+
+
+def ensure_export_service(candidate: object) -> ExportService:
+    """Validate an export service at the consumer boundary."""
+
+    if isinstance(candidate, ExportService):
+        return candidate
+    raise TypeError("expected an ExportService")
+
+
+def build_default_export_service() -> ExportService:
+    """Build the current no-egress default export service."""
+
+    return DefaultExportService(backend=ManifestExporter())
+
+
+__all__ = [
+    "DefaultExportService",
+    "ExportService",
+    "Exporter",
+    "ManifestExporter",
+    "build_default_export_service",
+    "ensure_export_service",
+]

--- a/tests/export/test_export_service.py
+++ b/tests/export/test_export_service.py
@@ -1,0 +1,103 @@
+"""Tests for the export service port and deterministic manifest contract."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from inv_man_intake.export import (
+    DefaultExportService,
+    ExportArtifact,
+    ExportItem,
+    ExportManifest,
+    ManifestExporter,
+    build_default_export_service,
+    ensure_export_service,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _items() -> tuple[ExportItem, ...]:
+    return (
+        ExportItem(
+            item_ref="deck:page:2:image:1",
+            artifact=ExportArtifact(
+                name="page-2-image-1.png",
+                media_type="image/png",
+                content=b"png-bytes",
+                provenance_refs=("deck:page:2", "deck:image:1"),
+            ),
+        ),
+        ExportItem(
+            item_ref="deck:page:1:image:3",
+            skip_reason="unsupported_colorspace",
+        ),
+    )
+
+
+def test_backend_is_swappable() -> None:
+    default_service = build_default_export_service()
+    fake_service = DefaultExportService(backend=_FakeExporter())
+
+    default_manifest = default_service.export(_items())
+    fake_manifest = fake_service.export(_items())
+
+    assert default_manifest == fake_manifest
+    assert default_service.backend_name == "manifest-local"
+    assert fake_service.backend_name == "fake-exporter"
+
+
+def test_manifest_records_skipped_items_with_reason_codes() -> None:
+    manifest = build_default_export_service().export(_items())
+
+    assert [entry.item_ref for entry in manifest.artifacts] == ["deck:page:2:image:1"]
+    assert manifest.artifacts[0].artifact.media_type == "image/png"
+    assert manifest.artifacts[0].artifact.provenance_refs == ("deck:page:2", "deck:image:1")
+    assert [(entry.item_ref, entry.reason_code) for entry in manifest.skipped] == [
+        ("deck:page:1:image:3", "unsupported_colorspace")
+    ]
+
+
+def test_manifest_sorts_by_item_ref_and_rejects_ambiguous_items() -> None:
+    manifest = ExportManifest.from_items(
+        (
+            ExportItem(item_ref="z", skip_reason="no_series_found"),
+            ExportItem(item_ref="a", skip_reason="no_table_found"),
+        )
+    )
+
+    assert [entry.item_ref for entry in manifest.skipped] == ["a", "z"]
+    with pytest.raises(ValueError, match="exactly one artifact or skip reason"):
+        ExportItem(item_ref="broken")
+
+
+def test_service_boundary_rejects_a_concrete_backend() -> None:
+    assert ensure_export_service(build_default_export_service()).backend_name == "manifest-local"
+    with pytest.raises(TypeError, match="ExportService"):
+        ensure_export_service(ManifestExporter())
+
+
+def test_consumers_do_not_import_concrete_exporters_directly() -> None:
+    consumer_sources = (
+        _REPO_ROOT / "src/inv_man_intake/packet.py",
+        _REPO_ROOT / "src/inv_man_intake/run.py",
+    )
+    banned_tokens = (
+        "ManifestExporter",
+        "from inv_man_intake.export.service import ManifestExporter",
+    )
+
+    for source_path in consumer_sources:
+        source = source_path.read_text()
+        assert not any(token in source for token in banned_tokens), source_path
+
+
+class _FakeExporter:
+    @property
+    def name(self) -> str:
+        return "fake-exporter"
+
+    def export(self, items: tuple[ExportItem, ...]) -> ExportManifest:
+        return ExportManifest.from_items(items)


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:846 -->
> **Source:** Issue #846

Closes #846

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
_Scope section missing from source issue._

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#845](https://github.com/stranske/Inv-Man-Intake/issues/845)
- [#773](https://github.com/stranske/Inv-Man-Intake/issues/773)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] Add `src/inv_man_intake/export/service.py` defining `ExportArtifact` (`name: str`, `media_type: str`,
  `content: bytes`, `provenance_refs: tuple[str, ...]`) and an `Exporter` Protocol + `ExportService` Protocol with a
  swappable backend, mirroring the structure of `src/inv_man_intake/extraction/service.py:16-104`
  (`TransportBackend` / `ExtractionService` / `DefaultExtractionService` / `ensure_extraction_service`).
- [ ] Add `src/inv_man_intake/export/manifest.py`: a deterministic `ExportManifest` listing every produced artifact
  AND every skipped item as `(item_ref, reason_code)` with a closed reason-code set
  (`unsupported_colorspace`, `unsupported_encoding`, `vector_render_failed`, `no_table_found`, `no_series_found`).
  Ordering must be deterministic (sort by `item_ref`) so manifests are diffable.
- [ ] Export the port from `src/inv_man_intake/export/__init__.py`; do not import any concrete exporter into
  `packet.py` or the app — consumers depend on the Protocol only.

#### Acceptance criteria
- [ ] Named test: `tests/export/test_export_service.py::test_backend_is_swappable` — the same packet run through two

<!-- auto-status-summary:end -->