### PR TITLE
[Epic #845][P1] Image fidelity: capture XObject geometry, rebuild Flate rasters to PNG, wire extractor into packet

### DIFF
--- a/src/inv_man_intake/export/image_export.py
+++ b/src/inv_man_intake/export/image_export.py
@@ -1,0 +1,111 @@
+"""Map extracted visual artifacts onto the deterministic export manifest."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from inv_man_intake.export.manifest import (
+    ExportArtifact,
+    ExportItem,
+    ExportManifest,
+    ExportSkipReason,
+)
+from inv_man_intake.export.service import ExportService, build_default_export_service
+from inv_man_intake.images.extractor import (
+    UNSUPPORTED_COLORSPACE,
+    UNSUPPORTED_ENCODING,
+    UnsupportedVisualSourceError,
+    extract_visual_artifacts,
+)
+from inv_man_intake.images.models import VisualArtifact
+
+_SKIP_REASONS: dict[str, ExportSkipReason] = {
+    UNSUPPORTED_COLORSPACE: "unsupported_colorspace",
+    UNSUPPORTED_ENCODING: "unsupported_encoding",
+}
+
+_EXPORTABLE_MEDIA_TYPES = frozenset(
+    {"image/jpeg", "image/png", "image/gif", "image/bmp", "image/tiff", "image/svg+xml"}
+)
+
+
+def image_item_ref(source_doc_id: str, index: int) -> str:
+    """Stable provenance reference; unchanged so existing consumers keep working."""
+
+    return f"{source_doc_id}:image:{index}"
+
+
+def build_image_export_items(
+    artifacts: Sequence[VisualArtifact],
+    *,
+    source_doc_id: str,
+) -> tuple[ExportItem, ...]:
+    """Produce one export item per artifact: real bytes, or an explicit skip."""
+
+    items: list[ExportItem] = []
+    for index, artifact in enumerate(artifacts):
+        item_ref = image_item_ref(source_doc_id, index)
+        skip_reason = _skip_reason_for(artifact)
+        if skip_reason is not None:
+            items.append(ExportItem(item_ref=item_ref, skip_reason=skip_reason))
+            continue
+        items.append(
+            ExportItem(
+                item_ref=item_ref,
+                artifact=ExportArtifact(
+                    name=artifact.storage_path.rsplit("/", 1)[-1],
+                    media_type=artifact.mime_type,
+                    content=artifact.content,
+                    provenance_refs=(item_ref, artifact.artifact_id),
+                ),
+            )
+        )
+    return tuple(items)
+
+
+def _skip_reason_for(artifact: VisualArtifact) -> ExportSkipReason | None:
+    if artifact.unsupported_reason is not None:
+        return _SKIP_REASONS.get(artifact.unsupported_reason, "unsupported_encoding")
+    if artifact.mime_type not in _EXPORTABLE_MEDIA_TYPES:
+        return "unsupported_encoding"
+    return None
+
+
+def export_document_images(
+    *,
+    source_doc_id: str,
+    file_name: str | None,
+    content: bytes,
+    export_service: ExportService | None = None,
+) -> ExportManifest:
+    """Extract and export one document's images, or an empty manifest if it has none."""
+
+    if not file_name:
+        return ExportManifest(artifacts=(), skipped=())
+    try:
+        artifacts = extract_visual_artifacts(
+            source_doc_id=source_doc_id,
+            file_name=file_name,
+            content=content,
+        )
+    except UnsupportedVisualSourceError:
+        return ExportManifest(artifacts=(), skipped=())
+
+    service = export_service if export_service is not None else build_default_export_service()
+    return service.export(build_image_export_items(artifacts, source_doc_id=source_doc_id))
+
+
+def merge_manifests(manifests: Sequence[ExportManifest]) -> ExportManifest:
+    """Combine per-document manifests, preserving deterministic item ordering."""
+
+    artifacts = tuple(entry for manifest in manifests for entry in manifest.artifacts)
+    skipped = tuple(entry for manifest in manifests for entry in manifest.skipped)
+    return ExportManifest(artifacts=artifacts, skipped=skipped)
+
+
+__all__ = [
+    "build_image_export_items",
+    "export_document_images",
+    "image_item_ref",
+    "merge_manifests",
+]

--- a/src/inv_man_intake/images/extractor.py
+++ b/src/inv_man_intake/images/extractor.py
@@ -2,22 +2,55 @@
 
 from __future__ import annotations
 
+import binascii
 import hashlib
 import io
 import re
 import xml.etree.ElementTree as ET
 import zipfile
+import zlib
+from dataclasses import dataclass
 from pathlib import Path
 
-from inv_man_intake.images.models import ArtifactSource, VisualArtifact
+from inv_man_intake.images.models import ArtifactSource, ImageGeometry, VisualArtifact
+from inv_man_intake.images.png import PngEncodeError, rebuild_flate_raster_to_png
 
 _PDF_OBJECT_PATTERN = re.compile(rb"(\d+)\s+\d+\s+obj(.*?)endobj", re.DOTALL)
 _PDF_STREAM_PATTERN = re.compile(rb"stream\r?\n(.*?)\r?\nendstream", re.DOTALL)
 _PDF_XOBJECT_REF_PATTERN = re.compile(rb"/(?:Im|Img)\w*\s+(\d+)\s+0\s+R")
+_PDF_COLORSPACE_PATTERN = re.compile(rb"/ColorSpace\s*(\[[^\]]*\]|/\w+|\d+\s+\d+\s+R)")
+_PDF_DECODEPARMS_PATTERN = re.compile(rb"/DecodeParms\s*<<(.*?)>>", re.DOTALL)
+_PDF_HEX_STRING_PATTERN = re.compile(rb"<([0-9A-Fa-f\s]*)>")
+_PDF_INDIRECT_REF_PATTERN = re.compile(rb"(\d+)\s+\d+\s+R")
+
+UNSUPPORTED_COLORSPACE = "unsupported_colorspace"
+UNSUPPORTED_ENCODING = "unsupported_encoding"
+
+_OCTET_STREAM = "application/octet-stream"
+
+_EXTENSION_BY_MIME = {
+    "image/jpeg": "jpg",
+    "image/png": "png",
+    "image/jp2": "jp2",
+}
 
 
 class UnsupportedVisualSourceError(ValueError):
     """Raised when visual extraction is requested for an unsupported file type."""
+
+
+@dataclass(frozen=True)
+class _DecodedImage:
+    """Decode outcome for one PDF image XObject."""
+
+    mime_type: str
+    content: bytes
+    geometry: ImageGeometry
+    unsupported_reason: str | None = None
+
+    @property
+    def extension(self) -> str:
+        return _EXTENSION_BY_MIME.get(self.mime_type, "bin")
 
 
 def extract_visual_artifacts(
@@ -62,7 +95,7 @@ def _extract_pdf_artifacts(*, source_doc_id: str, content: bytes) -> tuple[Visua
             stream = image_streams.get(object_id)
             if stream is None:
                 continue
-            mime_type = _pdf_mime_type(objects[object_id])
+            decoded = _decode_pdf_image(objects, objects[object_id], stream)
             source = ArtifactSource(
                 source_doc_id=source_doc_id,
                 page_number=page_number,
@@ -71,11 +104,14 @@ def _extract_pdf_artifacts(*, source_doc_id: str, content: bytes) -> tuple[Visua
             artifacts.append(
                 _build_artifact(
                     source=source,
-                    mime_type=mime_type,
-                    content=stream,
+                    mime_type=decoded.mime_type,
+                    content=decoded.content,
                     storage_path=(
-                        f"artifacts/{source_doc_id}/pdf/page-{page_number}/object-{object_id}.bin"
+                        f"artifacts/{source_doc_id}/pdf/page-{page_number}/"
+                        f"object-{object_id}.{decoded.extension}"
                     ),
+                    geometry=decoded.geometry,
+                    unsupported_reason=decoded.unsupported_reason,
                 )
             )
 
@@ -90,7 +126,7 @@ def _extract_pdf_artifacts(*, source_doc_id: str, content: bytes) -> tuple[Visua
         if object_id in linked_refs:
             continue
         stream = image_streams[object_id]
-        mime_type = _pdf_mime_type(objects[object_id])
+        decoded = _decode_pdf_image(objects, objects[object_id], stream)
         source = ArtifactSource(
             source_doc_id=source_doc_id,
             page_number=0,
@@ -99,9 +135,13 @@ def _extract_pdf_artifacts(*, source_doc_id: str, content: bytes) -> tuple[Visua
         artifacts.append(
             _build_artifact(
                 source=source,
-                mime_type=mime_type,
-                content=stream,
-                storage_path=f"artifacts/{source_doc_id}/pdf/page-0/object-{object_id}.bin",
+                mime_type=decoded.mime_type,
+                content=decoded.content,
+                storage_path=(
+                    f"artifacts/{source_doc_id}/pdf/page-0/object-{object_id}.{decoded.extension}"
+                ),
+                geometry=decoded.geometry,
+                unsupported_reason=decoded.unsupported_reason,
             )
         )
 
@@ -168,14 +208,139 @@ def _map_pdf_page_refs(objects: dict[int, bytes]) -> dict[int, tuple[int, ...]]:
     return page_to_refs
 
 
-def _pdf_mime_type(object_body: bytes) -> str:
-    if b"/DCTDecode" in object_body:
-        return "image/jpeg"
-    if b"/JPXDecode" in object_body:
-        return "image/jp2"
-    if b"/FlateDecode" in object_body:
-        return "application/octet-stream"
-    return "application/octet-stream"
+def _pdf_int(object_body: bytes, key: bytes) -> int | None:
+    match = re.search(rb"/" + key + rb"\s+(\d+)", object_body)
+    return int(match.group(1)) if match else None
+
+
+def _pdf_filter_name(object_body: bytes) -> str | None:
+    for candidate in ("DCTDecode", "JPXDecode", "FlateDecode"):
+        if b"/" + candidate.encode() in object_body:
+            return candidate
+    return None
+
+
+def _resolve_indirect(objects: dict[int, bytes], value: bytes) -> bytes | None:
+    match = _PDF_INDIRECT_REF_PATTERN.fullmatch(value.strip())
+    if match is None:
+        return None
+    return objects.get(int(match.group(1)))
+
+
+def _icc_components(objects: dict[int, bytes], colorspace: bytes) -> int | None:
+    """Read ``/N`` from an ``/ICCBased`` stream, which holds the channel count."""
+
+    ref = _PDF_INDIRECT_REF_PATTERN.search(colorspace)
+    if ref is None:
+        return _pdf_int(colorspace, b"N")
+    referenced = objects.get(int(ref.group(1)))
+    if referenced is None:
+        return None
+    return _pdf_int(referenced, b"N")
+
+
+def _indexed_palette(objects: dict[int, bytes], colorspace: bytes) -> bytes | None:
+    hex_match = _PDF_HEX_STRING_PATTERN.search(colorspace)
+    if hex_match is not None:
+        digits = re.sub(rb"\s", b"", hex_match.group(1))
+        if len(digits) % 2:
+            digits += b"0"
+        try:
+            return binascii.unhexlify(digits)
+        except binascii.Error:
+            return None
+    # Otherwise the lookup table is the last indirect reference in the array.
+    refs = _PDF_INDIRECT_REF_PATTERN.findall(colorspace)
+    if not refs:
+        return None
+    referenced = objects.get(int(refs[-1]))
+    if referenced is None:
+        return None
+    stream = _extract_pdf_stream(referenced)
+    if stream is None:
+        return None
+    if b"/FlateDecode" in referenced:
+        try:
+            return zlib.decompress(stream)
+        except zlib.error:
+            return None
+    return stream
+
+
+def _pdf_colorspace(
+    objects: dict[int, bytes], object_body: bytes
+) -> tuple[str | None, int | None, bytes | None]:
+    """Return the normalized colour space name, channel count, and palette."""
+
+    match = _PDF_COLORSPACE_PATTERN.search(object_body)
+    if match is None:
+        return None, None, None
+    value = match.group(1)
+    resolved = _resolve_indirect(objects, value)
+    if resolved is not None:
+        value = resolved
+
+    if b"/Indexed" in value:
+        return "Indexed", 1, _indexed_palette(objects, value)
+    if b"/DeviceCMYK" in value:
+        return "DeviceCMYK", 4, None
+    if b"/ICCBased" in value:
+        return "ICCBased", _icc_components(objects, value), None
+    if b"/DeviceRGB" in value:
+        return "DeviceRGB", 3, None
+    if b"/DeviceGray" in value or b"/CalGray" in value:
+        return "DeviceGray", 1, None
+    if b"/CalRGB" in value or b"/Lab" in value:
+        return "CalRGB", 3, None
+    return None, None, None
+
+
+def _pdf_geometry(objects: dict[int, bytes], object_body: bytes) -> ImageGeometry:
+    color_space, components, palette = _pdf_colorspace(objects, object_body)
+    decode_parms = _PDF_DECODEPARMS_PATTERN.search(object_body)
+    parms = decode_parms.group(1) if decode_parms else b""
+    return ImageGeometry(
+        width=_pdf_int(object_body, b"Width"),
+        height=_pdf_int(object_body, b"Height"),
+        bits_per_component=_pdf_int(object_body, b"BitsPerComponent"),
+        color_space=color_space,
+        color_components=components,
+        filter_name=_pdf_filter_name(object_body),
+        predictor=_pdf_int(parms, b"Predictor"),
+        predictor_colors=_pdf_int(parms, b"Colors"),
+        predictor_columns=_pdf_int(parms, b"Columns"),
+        palette=palette,
+        has_smask=b"/SMask" in object_body,
+    )
+
+
+def _decode_pdf_image(
+    objects: dict[int, bytes], object_body: bytes, stream: bytes
+) -> _DecodedImage:
+    """Turn one image XObject into viewable bytes, or an explicit skip reason.
+
+    Anything that cannot be decoded keeps the opaque ``.bin`` mime type so a
+    skip row is recorded instead of garbage bytes under an image extension.
+    """
+
+    geometry = _pdf_geometry(objects, object_body)
+
+    if geometry.color_space == "DeviceCMYK":
+        return _DecodedImage(_OCTET_STREAM, stream, geometry, UNSUPPORTED_COLORSPACE)
+    if geometry.filter_name == "JPXDecode":
+        return _DecodedImage("image/jp2", stream, geometry, UNSUPPORTED_ENCODING)
+    if geometry.filter_name == "DCTDecode":
+        # A /DCTDecode stream is already a JPEG file; copy it byte-for-byte.
+        return _DecodedImage("image/jpeg", stream, geometry)
+    if geometry.filter_name == "FlateDecode":
+        try:
+            return _DecodedImage(
+                "image/png", rebuild_flate_raster_to_png(stream, geometry), geometry
+            )
+        except PngEncodeError:
+            return _DecodedImage(_OCTET_STREAM, stream, geometry, UNSUPPORTED_ENCODING)
+
+    return _DecodedImage(_OCTET_STREAM, stream, geometry, UNSUPPORTED_ENCODING)
 
 
 def _collect_slide_targets(archive: zipfile.ZipFile) -> dict[int, tuple[tuple[str, str], ...]]:
@@ -236,6 +401,8 @@ def _build_artifact(
     mime_type: str,
     content: bytes,
     storage_path: str,
+    geometry: ImageGeometry | None = None,
+    unsupported_reason: str | None = None,
 ) -> VisualArtifact:
     digest = hashlib.sha256(content).hexdigest()
     source_key = (
@@ -252,4 +419,6 @@ def _build_artifact(
         byte_size=len(content),
         storage_path=storage_path,
         content=content,
+        geometry=geometry,
+        unsupported_reason=unsupported_reason,
     )

--- a/src/inv_man_intake/images/extractor.py
+++ b/src/inv_man_intake/images/extractor.py
@@ -281,6 +281,9 @@ def _pdf_colorspace(
         value = resolved
 
     if b"/Indexed" in value:
+        # PNG PLTE requires 3 bytes/entry; only DeviceRGB bases map cleanly.
+        if b"/DeviceRGB" not in value:
+            return None, None, None
         return "Indexed", 1, _indexed_palette(objects, value)
     if b"/DeviceCMYK" in value:
         return "DeviceCMYK", 4, None
@@ -290,8 +293,11 @@ def _pdf_colorspace(
         return "DeviceRGB", 3, None
     if b"/DeviceGray" in value or b"/CalGray" in value:
         return "DeviceGray", 1, None
-    if b"/CalRGB" in value or b"/Lab" in value:
+    if b"/CalRGB" in value:
         return "CalRGB", 3, None
+    if b"/Lab" in value:
+        # Lab samples are not RGB; do not silently mis-map into PNG RGB channels.
+        return None, None, None
     return None, None, None
 
 

--- a/src/inv_man_intake/images/models.py
+++ b/src/inv_man_intake/images/models.py
@@ -16,6 +16,41 @@ class ArtifactSource:
 
 
 @dataclass(frozen=True)
+class ImageGeometry:
+    """Decoding geometry carried from a PDF image XObject dictionary.
+
+    Without these keys a ``/FlateDecode`` sample stream cannot be turned back
+    into a viewable raster, which is why they are retained rather than dropped
+    at extraction time.
+    """
+
+    width: int | None = None
+    height: int | None = None
+    bits_per_component: int | None = None
+    color_space: str | None = None
+    color_components: int | None = None
+    filter_name: str | None = None
+    predictor: int | None = None
+    predictor_colors: int | None = None
+    predictor_columns: int | None = None
+    palette: bytes | None = None
+    has_smask: bool = False
+
+    @property
+    def is_complete(self) -> bool:
+        """Whether every field required to rebuild a raster is present."""
+
+        return (
+            self.width is not None
+            and self.width > 0
+            and self.height is not None
+            and self.height > 0
+            and self.bits_per_component is not None
+            and self.color_components is not None
+        )
+
+
+@dataclass(frozen=True)
 class VisualArtifact:
     """Extracted visual artifact payload with stable identity metadata."""
 
@@ -26,3 +61,5 @@ class VisualArtifact:
     byte_size: int
     storage_path: str
     content: bytes
+    geometry: ImageGeometry | None = None
+    unsupported_reason: str | None = None

--- a/src/inv_man_intake/images/png.py
+++ b/src/inv_man_intake/images/png.py
@@ -112,6 +112,10 @@ def rebuild_flate_raster_to_png(stream: bytes, geometry: ImageGeometry) -> bytes
         if len(samples) != expected:
             raise PngEncodeError(f"predicted stream is {len(samples)} bytes, expected {expected}")
         scanlines = samples
+    elif predictor not in (1,):
+        # Predictor 2 (TIFF horizontal differencing) is not reversed here;
+        # treating it as raw samples would silently corrupt pixel data.
+        raise PngEncodeError(f"unsupported predictor: {predictor}")
     else:
         expected = stride * height
         if len(samples) != expected:

--- a/src/inv_man_intake/images/png.py
+++ b/src/inv_man_intake/images/png.py
@@ -1,0 +1,133 @@
+"""Stdlib-only PNG encoding for PDF ``/FlateDecode`` image XObjects.
+
+Pillow and every other native imaging dependency are deliberately excluded so
+the core import graph stays Pyodide-clean; ``zlib`` and ``struct`` are enough
+because PDF's ``/Predictor >= 10`` filtering is byte-for-byte PNG filtering.
+"""
+
+from __future__ import annotations
+
+import struct
+import zlib
+
+from inv_man_intake.images.models import ImageGeometry
+
+_PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
+
+_COLOR_TYPE_GRAY = 0
+_COLOR_TYPE_RGB = 2
+_COLOR_TYPE_INDEXED = 3
+
+_VALID_BIT_DEPTHS = {
+    _COLOR_TYPE_GRAY: frozenset({1, 2, 4, 8, 16}),
+    _COLOR_TYPE_RGB: frozenset({8, 16}),
+    _COLOR_TYPE_INDEXED: frozenset({1, 2, 4, 8}),
+}
+
+
+class PngEncodeError(ValueError):
+    """Raised when the XObject geometry cannot describe a valid PNG."""
+
+
+def _chunk(tag: bytes, payload: bytes) -> bytes:
+    return (
+        struct.pack(">I", len(payload))
+        + tag
+        + payload
+        + struct.pack(">I", zlib.crc32(tag + payload) & 0xFFFFFFFF)
+    )
+
+
+def _color_type_for(geometry: ImageGeometry) -> int:
+    color_space = (geometry.color_space or "").casefold()
+    if color_space == "indexed":
+        return _COLOR_TYPE_INDEXED
+    if geometry.color_components == 1:
+        return _COLOR_TYPE_GRAY
+    if geometry.color_components == 3:
+        return _COLOR_TYPE_RGB
+    raise PngEncodeError(f"unsupported colour geometry: {geometry.color_space!r}")
+
+
+def _row_stride(*, width: int, components: int, bit_depth: int) -> int:
+    return (width * components * bit_depth + 7) // 8
+
+
+def encode_png(
+    *,
+    width: int,
+    height: int,
+    bit_depth: int,
+    color_type: int,
+    scanlines: bytes,
+    palette: bytes | None = None,
+) -> bytes:
+    """Assemble a PNG from already-filtered scanlines (one filter byte per row)."""
+
+    if width <= 0 or height <= 0:
+        raise PngEncodeError("image dimensions must be positive")
+    if bit_depth not in _VALID_BIT_DEPTHS.get(color_type, frozenset()):
+        raise PngEncodeError(f"bit depth {bit_depth} is invalid for colour type {color_type}")
+    if color_type == _COLOR_TYPE_INDEXED and not palette:
+        raise PngEncodeError("indexed images require a palette")
+
+    header = struct.pack(">IIBBBBB", width, height, bit_depth, color_type, 0, 0, 0)
+    chunks = [_PNG_MAGIC, _chunk(b"IHDR", header)]
+    if palette:
+        chunks.append(_chunk(b"PLTE", palette))
+    chunks.append(_chunk(b"IDAT", zlib.compress(scanlines, 9)))
+    chunks.append(_chunk(b"IEND", b""))
+    return b"".join(chunks)
+
+
+def rebuild_flate_raster_to_png(stream: bytes, geometry: ImageGeometry) -> bytes:
+    """Rebuild a PDF ``/FlateDecode`` sample stream into a viewable PNG.
+
+    A ``/Predictor >= 10`` stream already carries PNG per-scanline filter bytes,
+    so its inflated bytes map straight onto the IDAT payload. Unpredicted
+    streams are raw samples and need a zero filter byte prepended per row.
+    """
+
+    if not geometry.is_complete:
+        raise PngEncodeError("incomplete XObject geometry")
+
+    width = geometry.width
+    height = geometry.height
+    bit_depth = geometry.bits_per_component
+    components = geometry.color_components
+    if width is None or height is None or bit_depth is None or components is None:
+        raise PngEncodeError("incomplete XObject geometry")
+
+    color_type = _color_type_for(geometry)
+    try:
+        samples = zlib.decompress(stream)
+    except zlib.error as exc:
+        raise PngEncodeError(f"stream is not valid zlib data: {exc}") from exc
+
+    stride = _row_stride(width=width, components=components, bit_depth=bit_depth)
+    predictor = geometry.predictor or 1
+
+    if predictor >= 10:
+        expected = (stride + 1) * height
+        if len(samples) != expected:
+            raise PngEncodeError(f"predicted stream is {len(samples)} bytes, expected {expected}")
+        scanlines = samples
+    else:
+        expected = stride * height
+        if len(samples) != expected:
+            raise PngEncodeError(f"sample stream is {len(samples)} bytes, expected {expected}")
+        scanlines = b"".join(
+            b"\x00" + samples[row * stride : (row + 1) * stride] for row in range(height)
+        )
+
+    return encode_png(
+        width=width,
+        height=height,
+        bit_depth=bit_depth,
+        color_type=color_type,
+        scanlines=scanlines,
+        palette=geometry.palette,
+    )
+
+
+__all__ = ["PngEncodeError", "encode_png", "rebuild_flate_raster_to_png"]

--- a/src/inv_man_intake/packet.py
+++ b/src/inv_man_intake/packet.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from types import MappingProxyType
 
 from inv_man_intake.export.image_export import export_document_images, merge_manifests
-from inv_man_intake.export.manifest import ExportArtifact, ExportManifest
+from inv_man_intake.export.manifest import ExportArtifact, ExportManifest, ManifestSkip
 from inv_man_intake.extraction.cross_check import (
     CrossCheckReport,
     cross_check_extraction_results,
@@ -238,18 +238,34 @@ def _collect_fields(
 
 
 def _graphics_manifest(files: Sequence[PacketFile]) -> ExportManifest:
-    """Export real image bytes for the packet instead of placeholder ref strings."""
+    """Export real image bytes for the packet instead of placeholder ref strings.
 
-    return merge_manifests(
-        [
-            export_document_images(
-                source_doc_id=packet_file.document_id,
-                file_name=packet_file.filename,
-                content=packet_file.content,
+    Isolate each document so one decode/export failure cannot abort the whole packet.
+    """
+
+    manifests: list[ExportManifest] = []
+    for packet_file in files:
+        try:
+            manifests.append(
+                export_document_images(
+                    source_doc_id=packet_file.document_id,
+                    file_name=packet_file.filename,
+                    content=packet_file.content,
+                )
             )
-            for packet_file in files
-        ]
-    )
+        except Exception:
+            manifests.append(
+                ExportManifest(
+                    artifacts=(),
+                    skipped=(
+                        ManifestSkip(
+                            item_ref=f"{packet_file.document_id}:image:0",
+                            reason_code="unsupported_encoding",
+                        ),
+                    ),
+                )
+            )
+    return merge_manifests(manifests)
 
 
 def _flagged_non_standard_items(

--- a/src/inv_man_intake/packet.py
+++ b/src/inv_man_intake/packet.py
@@ -7,6 +7,8 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from types import MappingProxyType
 
+from inv_man_intake.export.image_export import export_document_images, merge_manifests
+from inv_man_intake.export.manifest import ExportArtifact, ExportManifest
 from inv_man_intake.extraction.cross_check import (
     CrossCheckReport,
     cross_check_extraction_results,
@@ -60,6 +62,8 @@ class ManagerProfile:
     scores: Mapping[str, float]
     lineage_refs: tuple[str, ...]
     reconciliation: CrossCheckReport
+    graphics_artifacts: tuple[ExportArtifact, ...] = ()
+    graphics_skipped: tuple[tuple[str, str], ...] = ()
 
     @property
     def escalations(self) -> tuple[str, ...]:
@@ -118,13 +122,14 @@ def ingest_packet(
         extractions,
         tolerance_percent=tolerance_percent,
     )
+    graphics = _graphics_manifest(files)
     return ManagerProfile(
         packet_id=packet_id,
         documents=tuple(document_profiles),
         identity=MappingProxyType(_collect_fields(extractions, prefix="identity.")),
         terms=MappingProxyType(_collect_fields(extractions, prefix="terms.")),
         returns_metrics=MappingProxyType(_collect_fields(extractions, prefix="performance.")),
-        graphics_refs=_graphics_refs(extractions),
+        graphics_refs=tuple(entry.item_ref for entry in graphics.artifacts),
         per_doc_standard_element_coverage=MappingProxyType(
             {
                 document.document_id: document.standard_element_coverage
@@ -137,6 +142,8 @@ def ingest_packet(
             lineage_ref for document in document_profiles for lineage_ref in document.lineage_refs
         ),
         reconciliation=reconciliation,
+        graphics_artifacts=tuple(entry.artifact for entry in graphics.artifacts),
+        graphics_skipped=tuple((entry.item_ref, entry.reason_code) for entry in graphics.skipped),
     )
 
 
@@ -230,12 +237,19 @@ def _collect_fields(
     return collected
 
 
-def _graphics_refs(results: Sequence[ExtractedDocumentResult]) -> tuple[str, ...]:
-    refs: list[str] = []
-    for result in results:
-        images = getattr(result, "images", ())
-        refs.extend(f"{result.source_doc_id}:image:{index}" for index, _ in enumerate(images))
-    return tuple(refs)
+def _graphics_manifest(files: Sequence[PacketFile]) -> ExportManifest:
+    """Export real image bytes for the packet instead of placeholder ref strings."""
+
+    return merge_manifests(
+        [
+            export_document_images(
+                source_doc_id=packet_file.document_id,
+                file_name=packet_file.filename,
+                content=packet_file.content,
+            )
+            for packet_file in files
+        ]
+    )
 
 
 def _flagged_non_standard_items(

--- a/tests/export/test_image_export.py
+++ b/tests/export/test_image_export.py
@@ -1,0 +1,373 @@
+"""Tests for rebuilding PDF image XObjects into real, viewable export files."""
+
+from __future__ import annotations
+
+import struct
+import zlib
+
+from inv_man_intake.export.image_export import (
+    build_image_export_items,
+    export_document_images,
+)
+from inv_man_intake.extraction.providers.base import ExtractedDocumentResult
+from inv_man_intake.images.extractor import extract_visual_artifacts
+from inv_man_intake.intake.standard_elements import (
+    StandardElementLibrary,
+    load_standard_element_library,
+)
+from inv_man_intake.packet import PacketFile, ingest_packet
+
+PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
+
+
+class _StubProvider:
+    """Minimal extraction provider: this suite exercises the image path only."""
+
+    def extract(self, source_doc_id: str, content: bytes) -> ExtractedDocumentResult:
+        _ = content
+        return ExtractedDocumentResult(
+            source_doc_id=source_doc_id,
+            provider_name="stub",
+            fields=(),
+        )
+
+
+def _library() -> StandardElementLibrary:
+    return load_standard_element_library(
+        {
+            "version": "image-export-test",
+            "non_authoritative": True,
+            "doc_types": {
+                "deck": [
+                    {
+                        "key": "operations.aum",
+                        "detector_name": "field_present",
+                        "mandatory": False,
+                    }
+                ]
+            },
+        }
+    )
+
+
+_WIDTH = 4
+_HEIGHT = 3
+
+
+def _rgb_samples() -> bytes:
+    return bytes(
+        ((row * _WIDTH + column) * 7) % 256
+        for row in range(_HEIGHT)
+        for column in range(_WIDTH)
+        for _ in range(3)
+    )
+
+
+def _flate_image_object(object_id: int, *, predictor: bool) -> bytes:
+    """Build one ``/FlateDecode`` RGB image XObject, optionally PNG-predicted."""
+
+    samples = _rgb_samples()
+    stride = _WIDTH * 3
+    if predictor:
+        payload = b"".join(
+            b"\x00" + samples[row * stride : (row + 1) * stride] for row in range(_HEIGHT)
+        )
+        decode_parms = (
+            b" /DecodeParms << /Predictor 15 /Colors 3 /Columns "
+            + str(_WIDTH).encode()
+            + b" /BitsPerComponent 8 >>"
+        )
+    else:
+        payload = samples
+        decode_parms = b""
+
+    stream = zlib.compress(payload)
+    return (
+        str(object_id).encode()
+        + b" 0 obj\n<< /Subtype /Image /Filter /FlateDecode /Width "
+        + str(_WIDTH).encode()
+        + b" /Height "
+        + str(_HEIGHT).encode()
+        + b" /BitsPerComponent 8 /ColorSpace /DeviceRGB"
+        + decode_parms
+        + b" >>\nstream\n"
+        + stream
+        + b"\nendstream\nendobj\n"
+    )
+
+
+def _cmyk_image_object(object_id: int) -> bytes:
+    return (
+        str(object_id).encode()
+        + b" 0 obj\n<< /Subtype /Image /Filter /FlateDecode /Width 2 /Height 2"
+        b" /BitsPerComponent 8 /ColorSpace /DeviceCMYK >>\nstream\n"
+        + zlib.compress(bytes(range(16)))
+        + b"\nendstream\nendobj\n"
+    )
+
+
+def _pdf_with(*objects: bytes, page_refs: str) -> bytes:
+    page = (
+        b"1 0 obj\n<< /Type /Page /Resources << /XObject << "
+        + page_refs.encode()
+        + b" >> >> >>\nendobj\n"
+    )
+    return page + b"".join(objects)
+
+
+def _flate_deck(*, predictor: bool = True) -> bytes:
+    return _pdf_with(_flate_image_object(5, predictor=predictor), page_refs="/Im0 5 0 R")
+
+
+def _png_ihdr(png: bytes) -> tuple[int, int, int, int]:
+    width, height, bit_depth, color_type = struct.unpack(">IIBB", png[16:26])
+    return width, height, bit_depth, color_type
+
+
+def _png_idat(png: bytes) -> bytes:
+    offset = len(PNG_MAGIC)
+    chunks: list[bytes] = []
+    while offset < len(png):
+        (length,) = struct.unpack(">I", png[offset : offset + 4])
+        tag = png[offset + 4 : offset + 8]
+        if tag == b"IDAT":
+            chunks.append(png[offset + 8 : offset + 8 + length])
+        offset += 12 + length
+    return zlib.decompress(b"".join(chunks))
+
+
+def test_flate_raster_rebuilds_to_valid_png() -> None:
+    manifest = export_document_images(
+        source_doc_id="doc_flate",
+        file_name="deck.pdf",
+        content=_flate_deck(),
+    )
+
+    assert len(manifest.artifacts) == 1
+    assert manifest.skipped == ()
+
+    png = manifest.artifacts[0].artifact.content
+    assert png.startswith(PNG_MAGIC)
+    assert manifest.artifacts[0].artifact.media_type == "image/png"
+    assert manifest.artifacts[0].artifact.name.endswith(".png")
+
+    width, height, bit_depth, color_type = _png_ihdr(png)
+    assert (width, height) == (_WIDTH, _HEIGHT)
+    assert (bit_depth, color_type) == (8, 2)
+
+    # One filter byte plus width*3 sample bytes for each scanline.
+    assert len(_png_idat(png)) == (_WIDTH * 3 + 1) * _HEIGHT
+
+
+def test_unpredicted_flate_raster_gains_png_filter_bytes() -> None:
+    manifest = export_document_images(
+        source_doc_id="doc_raw",
+        file_name="deck.pdf",
+        content=_flate_deck(predictor=False),
+    )
+
+    png = manifest.artifacts[0].artifact.content
+    scanlines = _png_idat(png)
+    stride = _WIDTH * 3 + 1
+    assert png.startswith(PNG_MAGIC)
+    assert all(scanlines[row * stride] == 0 for row in range(_HEIGHT))
+    assert scanlines[1:stride] == _rgb_samples()[: _WIDTH * 3]
+
+
+def test_cmyk_is_reported_unsupported_and_not_emitted() -> None:
+    manifest = export_document_images(
+        source_doc_id="doc_cmyk",
+        file_name="deck.pdf",
+        content=_pdf_with(_cmyk_image_object(5), page_refs="/Im0 5 0 R"),
+    )
+
+    assert manifest.artifacts == ()
+    assert len(manifest.skipped) == 1
+    assert manifest.skipped[0].reason_code == "unsupported_colorspace"
+    assert manifest.skipped[0].item_ref == "doc_cmyk:image:0"
+
+
+def test_jpx_encoding_is_reported_unsupported() -> None:
+    jpx = (
+        b"5 0 obj\n<< /Subtype /Image /Filter /JPXDecode /Width 2 /Height 2"
+        b" /BitsPerComponent 8 /ColorSpace /DeviceRGB >>\nstream\njp2-bytes\nendstream\nendobj\n"
+    )
+    manifest = export_document_images(
+        source_doc_id="doc_jpx",
+        file_name="deck.pdf",
+        content=_pdf_with(jpx, page_refs="/Im0 5 0 R"),
+    )
+
+    assert manifest.artifacts == ()
+    assert [entry.reason_code for entry in manifest.skipped] == ["unsupported_encoding"]
+
+
+def test_dct_stream_is_exported_byte_for_byte_as_jpeg() -> None:
+    jpeg_bytes = b"\xff\xd8\xff\xe0jpeg-payload\xff\xd9"
+    dct = (
+        b"5 0 obj\n<< /Subtype /Image /Filter /DCTDecode /Width 2 /Height 2"
+        b" /BitsPerComponent 8 /ColorSpace /DeviceRGB >>\nstream\n"
+        + jpeg_bytes
+        + b"\nendstream\nendobj\n"
+    )
+    manifest = export_document_images(
+        source_doc_id="doc_jpeg",
+        file_name="deck.pdf",
+        content=_pdf_with(dct, page_refs="/Im0 5 0 R"),
+    )
+
+    assert len(manifest.artifacts) == 1
+    artifact = manifest.artifacts[0].artifact
+    assert artifact.content == jpeg_bytes
+    assert artifact.media_type == "image/jpeg"
+    assert artifact.name.endswith(".jpg")
+
+
+def test_indexed_colorspace_emits_palette_png() -> None:
+    palette = b"\xff\x00\x00\x00\xff\x00"
+    indexed = (
+        b"5 0 obj\n<< /Subtype /Image /Filter /FlateDecode /Width 2 /Height 2"
+        b" /BitsPerComponent 8 /ColorSpace [/Indexed /DeviceRGB 1 <FF0000 00FF00>]"
+        b" >>\nstream\n" + zlib.compress(bytes([0, 1, 1, 0])) + b"\nendstream\nendobj\n"
+    )
+    artifacts = extract_visual_artifacts(
+        source_doc_id="doc_indexed",
+        file_name="deck.pdf",
+        content=_pdf_with(indexed, page_refs="/Im0 5 0 R"),
+    )
+
+    assert artifacts[0].mime_type == "image/png"
+    assert artifacts[0].geometry is not None
+    assert artifacts[0].geometry.palette == palette
+    assert b"PLTE" in artifacts[0].content
+    assert _png_ihdr(artifacts[0].content)[3] == 3
+
+
+def test_device_gray_rebuilds_as_grayscale_png() -> None:
+    gray = (
+        b"5 0 obj\n<< /Subtype /Image /Filter /FlateDecode /Width 2 /Height 2"
+        b" /BitsPerComponent 8 /ColorSpace /DeviceGray >>\nstream\n"
+        + zlib.compress(bytes([0, 64, 128, 255]))
+        + b"\nendstream\nendobj\n"
+    )
+    artifacts = extract_visual_artifacts(
+        source_doc_id="doc_gray",
+        file_name="deck.pdf",
+        content=_pdf_with(gray, page_refs="/Im0 5 0 R"),
+    )
+
+    assert artifacts[0].mime_type == "image/png"
+    assert _png_ihdr(artifacts[0].content) == (2, 2, 8, 0)
+
+
+def test_iccbased_channel_count_comes_from_the_profile_stream() -> None:
+    icc = (
+        b"5 0 obj\n<< /Subtype /Image /Filter /FlateDecode /Width 2 /Height 2"
+        b" /BitsPerComponent 8 /ColorSpace [/ICCBased 7 0 R] >>\nstream\n"
+        + zlib.compress(bytes(range(12)))
+        + b"\nendstream\nendobj\n"
+        b"7 0 obj\n<< /N 3 /Alternate /DeviceRGB >>\nstream\nicc\nendstream\nendobj\n"
+    )
+    artifacts = extract_visual_artifacts(
+        source_doc_id="doc_icc",
+        file_name="deck.pdf",
+        content=_pdf_with(icc, page_refs="/Im0 5 0 R"),
+    )
+
+    geometry = artifacts[0].geometry
+    assert geometry is not None
+    assert geometry.color_space == "ICCBased"
+    assert geometry.color_components == 3
+    assert _png_ihdr(artifacts[0].content) == (2, 2, 8, 2)
+
+
+def test_smask_presence_is_retained_on_the_artifact() -> None:
+    artifacts = extract_visual_artifacts(
+        source_doc_id="doc_smask",
+        file_name="deck.pdf",
+        content=_pdf_with(
+            b"5 0 obj\n<< /Subtype /Image /Filter /FlateDecode /Width 2 /Height 2"
+            b" /BitsPerComponent 8 /ColorSpace /DeviceGray /SMask 9 0 R >>\nstream\n"
+            + zlib.compress(bytes([1, 2, 3, 4]))
+            + b"\nendstream\nendobj\n",
+            page_refs="/Im0 5 0 R",
+        ),
+    )
+
+    geometry = artifacts[0].geometry
+    assert geometry is not None
+    assert geometry.has_smask is True
+
+
+def test_extractor_retains_xobject_geometry() -> None:
+    artifacts = extract_visual_artifacts(
+        source_doc_id="doc_geom",
+        file_name="deck.pdf",
+        content=_flate_deck(),
+    )
+
+    geometry = artifacts[0].geometry
+    assert geometry is not None
+    assert (geometry.width, geometry.height) == (_WIDTH, _HEIGHT)
+    assert geometry.bits_per_component == 8
+    assert geometry.color_space == "DeviceRGB"
+    assert geometry.color_components == 3
+    assert geometry.predictor == 15
+    assert geometry.filter_name == "FlateDecode"
+
+
+def test_export_items_carry_stable_provenance_refs() -> None:
+    artifacts = extract_visual_artifacts(
+        source_doc_id="doc_prov",
+        file_name="deck.pdf",
+        content=_flate_deck(),
+    )
+    items = build_image_export_items(artifacts, source_doc_id="doc_prov")
+
+    assert [item.item_ref for item in items] == ["doc_prov:image:0"]
+    assert items[0].artifact is not None
+    assert items[0].artifact.provenance_refs[0] == "doc_prov:image:0"
+
+
+def test_packet_exposes_real_image_bytes_not_ref_strings() -> None:
+    profile = ingest_packet(
+        [PacketFile(document_id="doc_flate", content=_flate_deck(), filename="deck.pdf")],
+        provider=_StubProvider(),
+        standard_library=_library(),
+    )
+
+    assert profile.graphics_refs == ("doc_flate:image:0",)
+    assert len(profile.graphics_artifacts) == 1
+    content = profile.graphics_artifacts[0].content
+    assert isinstance(content, bytes)
+    assert content.startswith(PNG_MAGIC)
+    assert not isinstance(content, str)
+
+
+def test_packet_records_unsupported_images_as_skips() -> None:
+    profile = ingest_packet(
+        [
+            PacketFile(
+                document_id="doc_cmyk",
+                content=_pdf_with(_cmyk_image_object(5), page_refs="/Im0 5 0 R"),
+                filename="deck.pdf",
+            )
+        ],
+        provider=_StubProvider(),
+        standard_library=_library(),
+    )
+
+    assert profile.graphics_refs == ()
+    assert profile.graphics_artifacts == ()
+    assert profile.graphics_skipped == (("doc_cmyk:image:0", "unsupported_colorspace"),)
+
+
+def test_non_visual_document_yields_empty_manifest() -> None:
+    manifest = export_document_images(
+        source_doc_id="doc_txt",
+        file_name="notes.txt",
+        content=b"plain text",
+    )
+
+    assert manifest.artifacts == ()
+    assert manifest.skipped == ()

--- a/tests/export/test_image_export.py
+++ b/tests/export/test_image_export.py
@@ -371,3 +371,81 @@ def test_non_visual_document_yields_empty_manifest() -> None:
 
     assert manifest.artifacts == ()
     assert manifest.skipped == ()
+
+
+def test_indexed_non_rgb_base_is_unsupported() -> None:
+    indexed_gray = (
+        b"5 0 obj\n<< /Subtype /Image /Filter /FlateDecode /Width 2 /Height 2"
+        b" /BitsPerComponent 8 /ColorSpace [/Indexed /DeviceGray 1 <00 FF>]"
+        b" >>\nstream\n" + zlib.compress(bytes([0, 1, 1, 0])) + b"\nendstream\nendobj\n"
+    )
+    artifacts = extract_visual_artifacts(
+        source_doc_id="doc_indexed_gray",
+        file_name="deck.pdf",
+        content=_pdf_with(indexed_gray, page_refs="/Im0 5 0 R"),
+    )
+
+    assert artifacts[0].mime_type == "application/octet-stream"
+    assert artifacts[0].unsupported_reason == "unsupported_encoding"
+
+
+def test_lab_colorspace_is_unsupported_not_mapped_to_rgb() -> None:
+    lab = (
+        b"5 0 obj\n<< /Subtype /Image /Filter /FlateDecode /Width 2 /Height 2"
+        b" /BitsPerComponent 8 /ColorSpace /Lab >>\nstream\n"
+        + zlib.compress(bytes(range(12)))
+        + b"\nendstream\nendobj\n"
+    )
+    artifacts = extract_visual_artifacts(
+        source_doc_id="doc_lab",
+        file_name="deck.pdf",
+        content=_pdf_with(lab, page_refs="/Im0 5 0 R"),
+    )
+
+    assert artifacts[0].mime_type == "application/octet-stream"
+    assert artifacts[0].unsupported_reason == "unsupported_encoding"
+    assert artifacts[0].geometry is not None
+    assert artifacts[0].geometry.color_space is None
+
+
+def test_tiff_predictor_is_rejected_instead_of_silent_misdecode() -> None:
+    predicted = (
+        b"5 0 obj\n<< /Subtype /Image /Filter /FlateDecode /Width 2 /Height 2"
+        b" /BitsPerComponent 8 /ColorSpace /DeviceRGB"
+        b" /DecodeParms << /Predictor 2 /Colors 3 /Columns 2 >> >>\nstream\n"
+        + zlib.compress(bytes(range(12)))
+        + b"\nendstream\nendobj\n"
+    )
+    artifacts = extract_visual_artifacts(
+        source_doc_id="doc_pred2",
+        file_name="deck.pdf",
+        content=_pdf_with(predicted, page_refs="/Im0 5 0 R"),
+    )
+
+    assert artifacts[0].mime_type == "application/octet-stream"
+    assert artifacts[0].unsupported_reason == "unsupported_encoding"
+
+
+def test_packet_isolates_graphics_export_failures_per_document(monkeypatch) -> None:
+    from inv_man_intake import packet as packet_mod
+
+    good = PacketFile(document_id="doc_ok", content=_flate_deck(), filename="ok.pdf")
+    bad = PacketFile(document_id="doc_bad", content=_flate_deck(), filename="bad.pdf")
+    original = packet_mod.export_document_images
+
+    def _flaky_export(*, source_doc_id: str, file_name: str | None, content: bytes):
+        if source_doc_id == "doc_bad":
+            raise RuntimeError("simulated decode failure")
+        return original(source_doc_id=source_doc_id, file_name=file_name, content=content)
+
+    monkeypatch.setattr(packet_mod, "export_document_images", _flaky_export)
+
+    profile = ingest_packet(
+        [good, bad],
+        provider=_StubProvider(),
+        standard_library=_library(),
+    )
+
+    assert profile.graphics_refs == ("doc_ok:image:0",)
+    assert len(profile.graphics_artifacts) == 1
+    assert profile.graphics_skipped == (("doc_bad:image:0", "unsupported_encoding"),)


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:847 -->
> **Source:** Issue #847

Closes #847

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
_Scope section missing from source issue._

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#845](https://github.com/stranske/Inv-Man-Intake/issues/845)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] In `images/extractor.py`, parse and retain from the image XObject dict: `/Width`, `/Height`,
  `/BitsPerComponent`, `/ColorSpace`, `/DecodeParms` (incl. `/Predictor`) and `/SMask`; carry them on `VisualArtifact`
  (extend `images/models.py`).
- [ ] Encode to real files using **stdlib only** (`zlib`, `struct`, `zlib.crc32`) — **do not add Pillow**:
  `/DCTDecode` → `.jpg` (stream is already JPEG, write byte-for-byte); `/FlateDecode` → **`.png`** (IHDR + IDAT with
  per-scanline filter bytes + IEND; PNG `/Predictor >= 10` data maps directly onto PNG filtering).
- [ ] Support `DeviceGray`, `DeviceRGB`, `ICCBased` (N=1/3) and `Indexed` (emit the palette as PLTE). Record
  `DeviceCMYK` and `/JPXDecode` as `unsupported_colorspace` / `unsupported_encoding` skip rows in the X1 manifest —
  **never emit garbage bytes under an image extension**.
- [ ] Replace `packet.py:233-238` `_graphics_refs()` with real `ExportArtifact`s from the extractor so
  `ManagerProfile` carries actual images; keep a stable ref string on each artifact for existing provenance consumers.

#### Acceptance criteria
- [ ] Named test: `tests/export/test_image_export.py::test_flate_raster_rebuilds_to_valid_png` — a fixture PDF containing

<!-- auto-status-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added image export support for packet ingestion, including real image bytes and stable image references.
  * Converts supported PDF images to PNG or preserves JPEG data.
  * Captures image dimensions, color details, palettes, and transparency metadata.
  * Reports unsupported image formats with clear skip reasons instead of exporting them.
  * Supports combining image manifests across multiple documents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->