### PR TITLE
[Epic #845][P1] One-page strategy summary

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -14,7 +14,7 @@
       @page { size: Letter; margin: .25in; }
       @media print {
         .operator-shell > :not(#one-pager) { display: none !important; }
-        #one-pager { box-sizing: border-box; display: block; height: 10.25in; max-height: 10.25in; margin: 0; overflow: hidden; }
+        #one-pager { box-sizing: border-box; display: block; margin: 0; }
         .one-pager-actions { display: none !important; }
       }
     </style>
@@ -29,7 +29,7 @@
         <p id="runtime-status" role="status">Loading local Pyodide runtime...</p>
       </header>
 
-      <section id="one-pager" class="one-pager" aria-labelledby="one-pager-title">
+      <section id="one-pager" class="one-pager" aria-labelledby="one-pager-title" hidden>
         <div class="one-pager-actions"><button id="save-as-pdf" type="button">Save as PDF</button></div>
         <p class="eyebrow">Ink &amp; Air manager brief</p>
         <h2 id="one-pager-title">Manager strategy summary</h2>

--- a/app/index.html
+++ b/app/index.html
@@ -6,6 +6,18 @@
     <title>Inv-Man-Intake Operator App</title>
     <link rel="stylesheet" href="../design-system/tokens.css" />
     <link rel="stylesheet" href="../design-system/components.css" />
+    <style>
+      .one-pager { max-width: 8in; margin: 1rem auto; padding: 1rem; background: var(--surface, #fff); color: var(--ink, #17202a); }
+      .one-pager-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: .5rem 1rem; }
+      .one-pager h3, .one-pager p { margin: .25rem 0; }
+      .one-pager ul { margin: .15rem 0; padding-left: 1.1rem; }
+      @page { size: Letter; margin: .25in; }
+      @media print {
+        .operator-shell > :not(#one-pager) { display: none !important; }
+        #one-pager { box-sizing: border-box; display: block; height: 10.25in; max-height: 10.25in; margin: 0; overflow: hidden; }
+        .one-pager-actions { display: none !important; }
+      }
+    </style>
     <script src="./vendor/pyodide@0.26.2/pyodide.js"></script>
     <script type="module" src="./static_operator_app.js"></script>
   </head>
@@ -16,6 +28,21 @@
         <h1>Operator intake console</h1>
         <p id="runtime-status" role="status">Loading local Pyodide runtime...</p>
       </header>
+
+      <section id="one-pager" class="one-pager" aria-labelledby="one-pager-title">
+        <div class="one-pager-actions"><button id="save-as-pdf" type="button">Save as PDF</button></div>
+        <p class="eyebrow">Ink &amp; Air manager brief</p>
+        <h2 id="one-pager-title">Manager strategy summary</h2>
+        <p>Final score: <strong id="one-pager-score">0.0000</strong></p>
+        <div class="one-pager-grid">
+          <section><h3>Identity</h3><ul id="one-pager-identity"></ul></section>
+          <section><h3>Coverage</h3><ul id="one-pager-coverage"></ul></section>
+          <section><h3>Explainability</h3><ul id="one-pager-explainability"></ul></section>
+          <section><h3>Return stats</h3><ul id="one-pager-returns"></ul></section>
+          <section><h3>Top provenance citations</h3><ul id="one-pager-provenance"></ul></section>
+          <section><h3>Exported graphics</h3><ul id="one-pager-graphics"></ul></section>
+        </div>
+      </section>
 
       <section class="operator-panel" aria-labelledby="packet-upload-heading">
         <div>

--- a/app/pyodide_packet_bridge.py
+++ b/app/pyodide_packet_bridge.py
@@ -13,6 +13,7 @@ _ingest_packet: Any = None
 _load_standard_element_library: Any = None
 
 try:  # pragma: no cover - browser bundle can run before package sources are vendored.
+    from inv_man_intake.export.one_pager import build_one_pager as _imported_build_one_pager
     from inv_man_intake.extraction.providers.base import (
         ExtractedDocumentResult as _ImportedExtractedDocumentResult,
     )
@@ -20,7 +21,6 @@ try:  # pragma: no cover - browser bundle can run before package sources are ven
     from inv_man_intake.intake.standard_elements import (
         load_standard_element_library as _imported_load_standard_element_library,
     )
-    from inv_man_intake.export.one_pager import build_one_pager as _imported_build_one_pager
     from inv_man_intake.packet import PacketFile as _ImportedPacketFile
     from inv_man_intake.packet import ingest_packet as _imported_ingest_packet
 

--- a/app/pyodide_packet_bridge.py
+++ b/app/pyodide_packet_bridge.py
@@ -8,6 +8,7 @@ from typing import Any
 _ExtractedDocumentResult: Any = None
 _ExtractedField: Any = None
 _PacketFile: Any = None
+_build_one_pager: Any = None
 _ingest_packet: Any = None
 _load_standard_element_library: Any = None
 
@@ -19,12 +20,14 @@ try:  # pragma: no cover - browser bundle can run before package sources are ven
     from inv_man_intake.intake.standard_elements import (
         load_standard_element_library as _imported_load_standard_element_library,
     )
+    from inv_man_intake.export.one_pager import build_one_pager as _imported_build_one_pager
     from inv_man_intake.packet import PacketFile as _ImportedPacketFile
     from inv_man_intake.packet import ingest_packet as _imported_ingest_packet
 
     _ExtractedDocumentResult = _ImportedExtractedDocumentResult
     _ExtractedField = _ImportedExtractedField
     _PacketFile = _ImportedPacketFile
+    _build_one_pager = _imported_build_one_pager
     _ingest_packet = _imported_ingest_packet
     _load_standard_element_library = _imported_load_standard_element_library
 except ModuleNotFoundError:  # pragma: no cover
@@ -86,6 +89,9 @@ def _run_ingest_packet(files: Sequence[Mapping[str, str]]) -> dict[str, Any]:
 
 
 def _packet_view_from_profile(profile: Any) -> dict[str, Any]:
+    if _build_one_pager is None:  # pragma: no cover
+        raise RuntimeError("inv_man_intake one-pager export is not available")
+    one_pager = _build_one_pager(profile).as_dict()
     coverage = [
         {
             "document": document.document_id,
@@ -134,6 +140,7 @@ def _packet_view_from_profile(profile: Any) -> dict[str, Any]:
             "Apply manually: review packet exceptions before promotion; citations "
             f"{', '.join(profile.lineage_refs) or 'packet:operator-browser-packet'}."
         ),
+        "one_pager": one_pager,
         "outbound_calls": 0,
     }
 
@@ -251,6 +258,16 @@ def _fallback_packet_view(files: Sequence[Mapping[str, str]]) -> dict[str, Any]:
             "Apply manually: review performance_conflict before promotion; citations "
             "packet:upload_1 and graphic:drawdown-chart."
         ),
+        "one_pager": {
+            "title": "Summit Arc Capital strategy summary",
+            "identity": [{"label": "Manager", "value": "Summit Arc Capital"}],
+            "coverage": [{"label": "Documents", "value": str(len(files))}],
+            "final_score": 0.7809,
+            "explainability": [{"label": "Extraction Confidence", "value": "0.7809"}],
+            "provenance_citations": ["fallback:pyodide_packet_bridge.py"],
+            "return_stats": [{"label": "1Y", "value": "8.4%"}],
+            "graphics": [{"label": "drawdown-chart", "provenance_ref": "drawdown-chart"}],
+        },
         "outbound_calls": 0,
     }
 

--- a/app/pyodide_packet_bridge.py
+++ b/app/pyodide_packet_bridge.py
@@ -258,16 +258,9 @@ def _fallback_packet_view(files: Sequence[Mapping[str, str]]) -> dict[str, Any]:
             "Apply manually: review performance_conflict before promotion; citations "
             "packet:upload_1 and graphic:drawdown-chart."
         ),
-        "one_pager": {
-            "title": "Summit Arc Capital strategy summary",
-            "identity": [{"label": "Manager", "value": "Summit Arc Capital"}],
-            "coverage": [{"label": "Documents", "value": str(len(files))}],
-            "final_score": 0.7809,
-            "explainability": [{"label": "Extraction Confidence", "value": "0.7809"}],
-            "provenance_citations": ["fallback:pyodide_packet_bridge.py"],
-            "return_stats": [{"label": "1Y", "value": "8.4%"}],
-            "graphics": [{"label": "drawdown-chart", "provenance_ref": "drawdown-chart"}],
-        },
+        # A fallback has no validated ManagerProfile, so it must not print a
+        # fabricated report about an arbitrary upload.
+        "one_pager": None,
         "outbound_calls": 0,
     }
 

--- a/app/pyodide_packet_bridge.py
+++ b/app/pyodide_packet_bridge.py
@@ -117,7 +117,7 @@ def _packet_view_from_profile(profile: Any) -> dict[str, Any]:
         "packet_path": "inv-man-intake.ingest_packet",
         "manager_profile": {
             "Manager": profile.identity.get("identity.manager", "Unknown manager"),
-            "Final score": f"{profile.scores.get('extraction_confidence', 0.0):.4f}",
+            "Final score": f"{one_pager['final_score']:.4f}",
             "Explainability": ", ".join(sorted(profile.scores)) or "No score components",
             "Provenance": ", ".join(profile.lineage_refs) or "packet:no-lineage",
         },

--- a/app/static_operator_app.js
+++ b/app/static_operator_app.js
@@ -10,6 +10,8 @@ const PRODUCTION_PACKET_MODULES = [
   "intake/standard_elements.py",
   "performance/contracts.py",
   "performance/conflict_resolver.py",
+  "export/manifest.py",
+  "export/one_pager.py",
 ];
 
 const state = {
@@ -44,6 +46,38 @@ function appendRow(tableId, cells) {
   document.querySelector(`#${tableId} tbody`).append(row);
 }
 
+function appendSummaryList(containerId, rows, formatter) {
+  const container = document.getElementById(containerId);
+  container.replaceChildren();
+  for (const row of rows) {
+    const item = document.createElement("li");
+    item.textContent = formatter(row);
+    container.append(item);
+  }
+}
+
+function renderOnePager(onePager) {
+  if (!onePager) {
+    return;
+  }
+  document.getElementById("one-pager-title").textContent = onePager.title;
+  document.getElementById("one-pager-score").textContent = onePager.final_score.toFixed(4);
+  appendSummaryList("one-pager-identity", onePager.identity, (row) => `${row.label}: ${row.value}`);
+  appendSummaryList("one-pager-coverage", onePager.coverage, (row) => `${row.label}: ${row.value}`);
+  appendSummaryList(
+    "one-pager-explainability",
+    onePager.explainability,
+    (row) => `${row.label}: ${row.value}`,
+  );
+  appendSummaryList("one-pager-provenance", onePager.provenance_citations, (citation) => citation);
+  appendSummaryList("one-pager-returns", onePager.return_stats, (row) => `${row.label}: ${row.value}`);
+  appendSummaryList(
+    "one-pager-graphics",
+    onePager.graphics,
+    (graphic) => `${graphic.label} — ${graphic.provenance_ref}`,
+  );
+}
+
 function seedConflict(profile) {
   if (profile.queue.some((row) => row.item === "Seeded deterministic conflict")) {
     return;
@@ -59,6 +93,7 @@ function seedConflict(profile) {
 function renderProfile(profile) {
   state.profile = profile;
   document.querySelector("main").dataset.packetPath = profile.packet_path || "unknown";
+  renderOnePager(profile.one_pager);
   clearRows("coverage-table");
   clearRows("graphics-table");
   clearRows("returns-table");
@@ -203,5 +238,7 @@ document.getElementById("refresh-assistant").addEventListener("click", () => {
     document.getElementById("assistant-answer").textContent = state.profile.assistant_answer;
   }
 });
+
+document.getElementById("save-as-pdf").addEventListener("click", () => window.print());
 
 loadProfile([{ name: "pdf_primary_mixed_bundle.json", text: "Summit Arc Capital seeded packet." }]);

--- a/app/static_operator_app.js
+++ b/app/static_operator_app.js
@@ -57,9 +57,12 @@ function appendSummaryList(containerId, rows, formatter) {
 }
 
 function renderOnePager(onePager) {
+  const summary = document.getElementById("one-pager");
   if (!onePager) {
+    summary.hidden = true;
     return;
   }
+  summary.hidden = false;
   document.getElementById("one-pager-title").textContent = onePager.title;
   document.getElementById("one-pager-score").textContent = onePager.final_score.toFixed(4);
   appendSummaryList("one-pager-identity", onePager.identity, (row) => `${row.label}: ${row.value}`);

--- a/app/static_operator_app.js
+++ b/app/static_operator_app.js
@@ -12,6 +12,11 @@ const PRODUCTION_PACKET_MODULES = [
   "performance/conflict_resolver.py",
   "export/manifest.py",
   "export/one_pager.py",
+  "export/service.py",
+  "export/image_export.py",
+  "images/models.py",
+  "images/png.py",
+  "images/extractor.py",
 ];
 
 const state = {

--- a/src/inv_man_intake/export/__init__.py
+++ b/src/inv_man_intake/export/__init__.py
@@ -8,6 +8,13 @@ from inv_man_intake.export.manifest import (
     ManifestArtifact,
     ManifestSkip,
 )
+from inv_man_intake.export.one_pager import (
+    OnePagerExporter,
+    OnePagerField,
+    OnePagerGraphic,
+    OnePagerModel,
+    build_one_pager,
+)
 from inv_man_intake.export.service import (
     DefaultExportService,
     Exporter,
@@ -29,7 +36,12 @@ __all__ = [
     "ManifestArtifact",
     "ManifestExporter",
     "ManifestSkip",
+    "OnePagerExporter",
+    "OnePagerField",
+    "OnePagerGraphic",
+    "OnePagerModel",
     "build_default_export_service",
+    "build_one_pager",
     "ensure_export_service",
     "export_return_series",
 ]

--- a/src/inv_man_intake/export/one_pager.py
+++ b/src/inv_man_intake/export/one_pager.py
@@ -119,9 +119,9 @@ def _graphics(profile: ManagerProfile, *, max_graphics: int) -> tuple[OnePagerGr
     artifacts = tuple(
         OnePagerGraphic(
             label=artifact.name,
-            provenance_ref=artifact.provenance_refs[0]
-            if artifact.provenance_refs
-            else artifact.name,
+            provenance_ref=(
+                artifact.provenance_refs[0] if artifact.provenance_refs else artifact.name
+            ),
             media_type=artifact.media_type,
         )
         for artifact in profile.graphics_artifacts[:max_graphics]

--- a/src/inv_man_intake/export/one_pager.py
+++ b/src/inv_man_intake/export/one_pager.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 from dataclasses import asdict, dataclass
 from math import isfinite
 from typing import TYPE_CHECKING
@@ -168,7 +168,7 @@ def _validate_scores(scores: Mapping[str, float]) -> None:
 
 
 def _bounded_fields(
-    fields: object, max_fields: int, max_value_characters: int
+    fields: Iterable[OnePagerField], max_fields: int, max_value_characters: int
 ) -> tuple[OnePagerField, ...]:
     return tuple(
         OnePagerField(field.label, _bounded_text(field.value, max_value_characters))

--- a/src/inv_man_intake/export/one_pager.py
+++ b/src/inv_man_intake/export/one_pager.py
@@ -77,7 +77,9 @@ class OnePagerExporter:
         identity = _identity_fields(
             profile.identity, self.max_identity_fields, self.max_value_characters
         )
-        manager = next((field.value for field in identity if field.label == "Manager"), "Manager")
+        manager = next(
+            (field.value for field in identity if field.label == "Manager"), "Unknown manager"
+        )
         return OnePagerModel(
             title=f"{manager} strategy summary",
             identity=identity,
@@ -103,7 +105,11 @@ class OnePagerExporter:
                 self.max_return_stats,
                 self.max_value_characters,
             ),
-            graphics=_graphics(profile, max_graphics=self.max_graphics),
+            graphics=_graphics(
+                profile,
+                max_graphics=self.max_graphics,
+                max_value_characters=self.max_value_characters,
+            ),
         )
 
 
@@ -185,12 +191,15 @@ def _bounded_text(value: str, max_characters: int) -> str:
     )
 
 
-def _graphics(profile: ManagerProfile, *, max_graphics: int) -> tuple[OnePagerGraphic, ...]:
+def _graphics(
+    profile: ManagerProfile, *, max_graphics: int, max_value_characters: int
+) -> tuple[OnePagerGraphic, ...]:
     artifacts = tuple(
         OnePagerGraphic(
-            label=artifact.name,
-            provenance_ref=(
-                artifact.provenance_refs[0] if artifact.provenance_refs else artifact.name
+            label=_bounded_text(artifact.name, max_value_characters),
+            provenance_ref=_bounded_text(
+                artifact.provenance_refs[0] if artifact.provenance_refs else artifact.name,
+                max_value_characters,
             ),
             media_type=artifact.media_type,
         )
@@ -199,7 +208,10 @@ def _graphics(profile: ManagerProfile, *, max_graphics: int) -> tuple[OnePagerGr
     if artifacts:
         return artifacts
     return tuple(
-        OnePagerGraphic(label=ref, provenance_ref=ref)
+        OnePagerGraphic(
+            label=_bounded_text(ref, max_value_characters),
+            provenance_ref=_bounded_text(ref, max_value_characters),
+        )
         for ref in profile.graphics_refs[:max_graphics]
     )
 

--- a/src/inv_man_intake/export/one_pager.py
+++ b/src/inv_man_intake/export/one_pager.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from dataclasses import asdict, dataclass
+from math import isfinite
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -52,27 +53,55 @@ class OnePagerExporter:
 
     max_graphics: int = 4
     max_citations: int = 5
+    max_identity_fields: int = 4
+    max_explainability_fields: int = 5
+    max_return_stats: int = 4
+    max_value_characters: int = 80
 
     def build(self, profile: ManagerProfile) -> OnePagerModel:
         """Build the complete one-page content model without I/O or network access."""
 
-        if self.max_graphics < 0 or self.max_citations < 0:
+        if (
+            min(
+                self.max_graphics,
+                self.max_citations,
+                self.max_identity_fields,
+                self.max_explainability_fields,
+                self.max_return_stats,
+                self.max_value_characters,
+            )
+            < 0
+        ):
             raise ValueError("one-pager limits must be non-negative")
-        identity = _identity_fields(profile.identity)
+        _validate_scores(profile.scores)
+        identity = _identity_fields(
+            profile.identity, self.max_identity_fields, self.max_value_characters
+        )
         manager = next((field.value for field in identity if field.label == "Manager"), "Manager")
         return OnePagerModel(
             title=f"{manager} strategy summary",
             identity=identity,
-            coverage=_coverage_fields(profile),
+            coverage=_coverage_fields(profile, self.max_value_characters),
             final_score=_final_score(profile.scores),
-            explainability=tuple(
-                OnePagerField(label=_display_label(key), value=f"{value:.4f}")
-                for key, value in sorted(profile.scores.items())
+            explainability=_bounded_fields(
+                (
+                    OnePagerField(label=_display_label(key), value=f"{value:.4f}")
+                    for key, value in sorted(profile.scores.items())
+                ),
+                self.max_explainability_fields,
+                self.max_value_characters,
             ),
-            provenance_citations=tuple(profile.lineage_refs[: self.max_citations]),
-            return_stats=tuple(
-                OnePagerField(label=_display_label(key), value=value)
-                for key, value in sorted(profile.returns_metrics.items())
+            provenance_citations=tuple(
+                _bounded_text(ref, self.max_value_characters)
+                for ref in profile.lineage_refs[: self.max_citations]
+            ),
+            return_stats=_bounded_fields(
+                (
+                    OnePagerField(label=_display_label(key), value=value)
+                    for key, value in sorted(profile.returns_metrics.items())
+                ),
+                self.max_return_stats,
+                self.max_value_characters,
             ),
             graphics=_graphics(profile, max_graphics=self.max_graphics),
         )
@@ -84,17 +113,27 @@ def build_one_pager(profile: ManagerProfile, *, max_graphics: int = 4) -> OnePag
     return OnePagerExporter(max_graphics=max_graphics).build(profile)
 
 
-def _identity_fields(identity: Mapping[str, str]) -> tuple[OnePagerField, ...]:
-    fields = tuple(
-        OnePagerField(label=_display_label(key), value=value)
-        for key, value in sorted(identity.items())
+def _identity_fields(
+    identity: Mapping[str, str], max_fields: int, max_value_characters: int
+) -> tuple[OnePagerField, ...]:
+    fields = _bounded_fields(
+        (
+            OnePagerField(label=_display_label(key), value=value)
+            for key, value in sorted(
+                identity.items(), key=lambda item: (item[0] != "identity.manager", item[0])
+            )
+        ),
+        max_fields,
+        max_value_characters,
     )
     if fields:
         return fields
     return (OnePagerField(label="Manager", value="Unknown manager"),)
 
 
-def _coverage_fields(profile: ManagerProfile) -> tuple[OnePagerField, ...]:
+def _coverage_fields(
+    profile: ManagerProfile, max_value_characters: int
+) -> tuple[OnePagerField, ...]:
     document_types = ", ".join(sorted({document.document_type for document in profile.documents}))
     coverage_items = sum(len(document.standard_element_coverage) for document in profile.documents)
     detected_items = sum(
@@ -104,7 +143,10 @@ def _coverage_fields(profile: ManagerProfile) -> tuple[OnePagerField, ...]:
     )
     return (
         OnePagerField(label="Documents", value=str(len(profile.documents))),
-        OnePagerField(label="Document types", value=document_types or "Not classified"),
+        OnePagerField(
+            label="Document types",
+            value=_bounded_text(document_types or "Not classified", max_value_characters),
+        ),
         OnePagerField(label="Standard elements", value=f"{detected_items}/{coverage_items}"),
     )
 
@@ -113,6 +155,34 @@ def _final_score(scores: Mapping[str, float]) -> float:
     if "final_score" in scores:
         return scores["final_score"]
     return scores.get("extraction_confidence", 0.0)
+
+
+def _validate_scores(scores: Mapping[str, float]) -> None:
+    invalid = [
+        key
+        for key, value in scores.items()
+        if isinstance(value, bool) or not isinstance(value, (int, float)) or not isfinite(value)
+    ]
+    if invalid:
+        raise ValueError(f"one-pager scores must be finite numbers: {invalid}")
+
+
+def _bounded_fields(
+    fields: object, max_fields: int, max_value_characters: int
+) -> tuple[OnePagerField, ...]:
+    return tuple(
+        OnePagerField(field.label, _bounded_text(field.value, max_value_characters))
+        for field in tuple(fields)[:max_fields]
+    )
+
+
+def _bounded_text(value: str, max_characters: int) -> str:
+    value = str(value)
+    return (
+        value
+        if len(value) <= max_characters
+        else f"{value[: max(0, max_characters - 1)].rstrip()}…"
+    )
 
 
 def _graphics(profile: ManagerProfile, *, max_graphics: int) -> tuple[OnePagerGraphic, ...]:

--- a/src/inv_man_intake/export/one_pager.py
+++ b/src/inv_man_intake/export/one_pager.py
@@ -1,0 +1,140 @@
+"""No-egress content model for the browser-printable manager strategy summary."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import asdict, dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from inv_man_intake.packet import ManagerProfile
+
+
+@dataclass(frozen=True)
+class OnePagerField:
+    """A labeled, human-readable value in the one-page summary."""
+
+    label: str
+    value: str
+
+
+@dataclass(frozen=True)
+class OnePagerGraphic:
+    """A bounded graphic reference with enough provenance for the SPA."""
+
+    label: str
+    provenance_ref: str
+    media_type: str | None = None
+
+
+@dataclass(frozen=True)
+class OnePagerModel:
+    """Structured content consumed by HTML, print, or later document renderers."""
+
+    title: str
+    identity: tuple[OnePagerField, ...]
+    coverage: tuple[OnePagerField, ...]
+    final_score: float
+    explainability: tuple[OnePagerField, ...]
+    provenance_citations: tuple[str, ...]
+    return_stats: tuple[OnePagerField, ...]
+    graphics: tuple[OnePagerGraphic, ...]
+
+    def as_dict(self) -> dict[str, object]:
+        """Return JSON-ready primitives for the static SPA without rendering HTML."""
+
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class OnePagerExporter:
+    """Build a browser-agnostic summary model from the packet's canonical profile."""
+
+    max_graphics: int = 4
+    max_citations: int = 5
+
+    def build(self, profile: ManagerProfile) -> OnePagerModel:
+        """Build the complete one-page content model without I/O or network access."""
+
+        if self.max_graphics < 0 or self.max_citations < 0:
+            raise ValueError("one-pager limits must be non-negative")
+        identity = _identity_fields(profile.identity)
+        manager = next((field.value for field in identity if field.label == "Manager"), "Manager")
+        return OnePagerModel(
+            title=f"{manager} strategy summary",
+            identity=identity,
+            coverage=_coverage_fields(profile),
+            final_score=_final_score(profile.scores),
+            explainability=tuple(
+                OnePagerField(label=_display_label(key), value=f"{value:.4f}")
+                for key, value in sorted(profile.scores.items())
+            ),
+            provenance_citations=tuple(profile.lineage_refs[: self.max_citations]),
+            return_stats=tuple(
+                OnePagerField(label=_display_label(key), value=value)
+                for key, value in sorted(profile.returns_metrics.items())
+            ),
+            graphics=_graphics(profile, max_graphics=self.max_graphics),
+        )
+
+
+def build_one_pager(profile: ManagerProfile, *, max_graphics: int = 4) -> OnePagerModel:
+    """Build the default one-page strategy summary model for a manager profile."""
+
+    return OnePagerExporter(max_graphics=max_graphics).build(profile)
+
+
+def _identity_fields(identity: Mapping[str, str]) -> tuple[OnePagerField, ...]:
+    fields = tuple(
+        OnePagerField(label=_display_label(key), value=value)
+        for key, value in sorted(identity.items())
+    )
+    if fields:
+        return fields
+    return (OnePagerField(label="Manager", value="Unknown manager"),)
+
+
+def _coverage_fields(profile: ManagerProfile) -> tuple[OnePagerField, ...]:
+    document_types = ", ".join(sorted({document.document_type for document in profile.documents}))
+    coverage_items = sum(len(document.standard_element_coverage) for document in profile.documents)
+    detected_items = sum(
+        coverage.detected
+        for document in profile.documents
+        for coverage in document.standard_element_coverage
+    )
+    return (
+        OnePagerField(label="Documents", value=str(len(profile.documents))),
+        OnePagerField(label="Document types", value=document_types or "Not classified"),
+        OnePagerField(label="Standard elements", value=f"{detected_items}/{coverage_items}"),
+    )
+
+
+def _final_score(scores: Mapping[str, float]) -> float:
+    if "final_score" in scores:
+        return scores["final_score"]
+    return scores.get("extraction_confidence", 0.0)
+
+
+def _graphics(profile: ManagerProfile, *, max_graphics: int) -> tuple[OnePagerGraphic, ...]:
+    artifacts = tuple(
+        OnePagerGraphic(
+            label=artifact.name,
+            provenance_ref=artifact.provenance_refs[0]
+            if artifact.provenance_refs
+            else artifact.name,
+            media_type=artifact.media_type,
+        )
+        for artifact in profile.graphics_artifacts[:max_graphics]
+    )
+    if artifacts:
+        return artifacts
+    return tuple(
+        OnePagerGraphic(label=ref, provenance_ref=ref)
+        for ref in profile.graphics_refs[:max_graphics]
+    )
+
+
+def _display_label(key: str) -> str:
+    if key == "identity.manager":
+        return "Manager"
+    return key.replace("_", " ").replace(".", " / ").title()

--- a/tests/app/test_static_spa_browser_e2e.py
+++ b/tests/app/test_static_spa_browser_e2e.py
@@ -131,32 +131,43 @@ def _with_page(
     """Open the static SPA with optional test-only handler controls."""
 
     server_context = local_static_spa()
-    url = server_context.__enter__()
-    playwright_context = sync_playwright()
-    playwright = playwright_context.__enter__()
-    # CI installs bundled Chromium; local prefer Chrome channel when present.
-    launch_kwargs: dict[str, object] = {"headless": True}
-    if os.environ.get("CI") != "true":
-        launch_kwargs["channel"] = "chrome"
+    playwright_context = None
+    browser = None
     try:
-        browser = playwright.chromium.launch(**launch_kwargs)
-    except Exception:
-        if "channel" in launch_kwargs:
+        url = server_context.__enter__()
+        playwright_context = sync_playwright()
+        playwright = playwright_context.__enter__()
+        # CI installs bundled Chromium; local prefer Chrome channel when present.
+        launch_kwargs: dict[str, object] = {"headless": True}
+        if os.environ.get("CI") != "true":
+            launch_kwargs["channel"] = "chrome"
+        try:
+            browser = playwright.chromium.launch(**launch_kwargs)
+        except Exception:
+            if "channel" not in launch_kwargs:
+                raise
             launch_kwargs.pop("channel")
             browser = playwright.chromium.launch(**launch_kwargs)
-        else:
-            raise
-    page = browser.new_page()
-    external_requests: list[str] = []
-    if enforce_local_requests:
-        # This is deliberately registered before navigation so initial Pyodide
-        # bootstrap requests cannot bypass the no-egress assertion.
-        page.route("**/*", lambda route: handle_offline_route(route, external_requests))
-    if test_controls:
-        page.add_init_script(f"window.__STATIC_SPA_TEST_CONTROLS__ = {json.dumps(test_controls)};")
-    page.goto(url, wait_until="domcontentloaded", timeout=45_000)
-    page.get_by_role("heading", name="Packet upload").wait_for(timeout=45_000)
-    return server_context, playwright_context, browser, page, external_requests
+        page = browser.new_page()
+        external_requests: list[str] = []
+        if enforce_local_requests:
+            # This is deliberately registered before navigation so initial Pyodide
+            # bootstrap requests cannot bypass the no-egress assertion.
+            page.route("**/*", lambda route: handle_offline_route(route, external_requests))
+        if test_controls:
+            page.add_init_script(
+                f"window.__STATIC_SPA_TEST_CONTROLS__ = {json.dumps(test_controls)};"
+            )
+        page.goto(url, wait_until="domcontentloaded", timeout=45_000)
+        page.get_by_role("heading", name="Packet upload").wait_for(timeout=45_000)
+        return server_context, playwright_context, browser, page, external_requests
+    except Exception:
+        if browser is not None:
+            browser.close()
+        if playwright_context is not None:
+            playwright_context.__exit__(None, None, None)
+        server_context.__exit__(None, None, None)
+        raise
 
 
 def _close_page(server_context: object, playwright_context: object, browser: object) -> None:

--- a/tests/app/test_static_spa_browser_e2e.py
+++ b/tests/app/test_static_spa_browser_e2e.py
@@ -223,6 +223,8 @@ def test_one_pager_renders_single_page_in_print_layout() -> None:
         page.emulate_media(media="print")
         box = page.locator("#one-pager").bounding_box()
         assert box is not None and box["height"] <= 1056
-        assert not page.locator(".operator-grid").is_visible()
+        operator_grid = page.locator(".operator-grid")
+        assert operator_grid.count() == 1
+        assert not operator_grid.is_visible()
     finally:
         _close_page(server_context, playwright_context, browser)

--- a/tests/app/test_static_spa_browser_e2e.py
+++ b/tests/app/test_static_spa_browser_e2e.py
@@ -88,6 +88,10 @@ def _verify_static_spa_interactions(page: object) -> None:
     )
     assert page.locator("main").get_attribute("data-packet-path") == "inv-man-intake.ingest_packet"
 
+    one_pager = page.locator("#one-pager")
+    assert "strategy summary" in one_pager.inner_text().lower()
+    assert "Explainability" in one_pager.inner_text()
+
     profile_details = page.locator("#profile-list")
     assert "Manager" in profile_details.inner_text()
     assert "Summit Arc Capital" in profile_details.inner_text()
@@ -206,3 +210,19 @@ def test_e2e_suite_is_not_skipped() -> None:
             assert "ok" in page.content()
         finally:
             browser.close()
+
+
+def test_one_pager_renders_single_page_in_print_layout() -> None:
+    """The print-only summary is bounded to one US-Letter page and hides app chrome."""
+
+    _require_browser_e2e()
+    server_context, playwright_context, browser, page, _ = _with_page()
+    try:
+        page.locator("#packet-upload").set_input_files(str(PACKET_FIXTURE))
+        page.locator("#one-pager-identity li").wait_for(timeout=45_000)
+        page.emulate_media(media="print")
+        box = page.locator("#one-pager").bounding_box()
+        assert box is not None and box["height"] <= 1056
+        assert not page.locator(".operator-grid").is_visible()
+    finally:
+        _close_page(server_context, playwright_context, browser)

--- a/tests/app/test_static_spa_bundle.py
+++ b/tests/app/test_static_spa_bundle.py
@@ -1,9 +1,71 @@
 from __future__ import annotations
 
+import ast
 import importlib.util
+import re
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
+PACKAGE_ROOT = ROOT / "src" / "inv_man_intake"
+
+
+def _bundled_modules() -> tuple[str, ...]:
+    script = (ROOT / "app" / "static_operator_app.js").read_text(encoding="utf-8")
+    block = re.search(r"const PRODUCTION_PACKET_MODULES = \[(.*?)\];", script, re.DOTALL)
+    assert block is not None, "PRODUCTION_PACKET_MODULES array not found"
+    return tuple(re.findall(r'"([^"]+)"', block.group(1)))
+
+
+def _eager_package_imports(source: str) -> set[str]:
+    """Return inv_man_intake modules imported when ``source`` is executed.
+
+    Function-scoped and ``TYPE_CHECKING`` imports are excluded: they do not run
+    when the browser bundle imports the module.
+    """
+
+    tree = ast.parse(source)
+    skipped: set[ast.AST] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) or (
+            isinstance(node, ast.If) and "TYPE_CHECKING" in ast.dump(node.test)
+        ):
+            skipped.update(ast.walk(node))
+    modules: set[str] = set()
+    for node in ast.walk(tree):
+        if node in skipped:
+            continue
+        if isinstance(node, ast.ImportFrom) and (node.module or "").startswith("inv_man_intake"):
+            modules.add(node.module or "")
+        elif isinstance(node, ast.Import):
+            modules.update(
+                alias.name for alias in node.names if alias.name.startswith("inv_man_intake")
+            )
+    return modules
+
+
+def _relative_path(module: str) -> str:
+    parts = module.split(".")[1:]
+    candidate = PACKAGE_ROOT.joinpath(*parts).with_suffix(".py")
+    assert candidate.is_file(), f"{module} does not resolve to a bundleable module file"
+    return "/".join(parts) + ".py"
+
+
+def _required_bundle_closure() -> set[str]:
+    pending = [
+        _relative_path(module)
+        for module in _eager_package_imports(
+            (ROOT / "app" / "pyodide_packet_bridge.py").read_text(encoding="utf-8")
+        )
+    ]
+    required: set[str] = set()
+    while pending:
+        current = pending.pop()
+        if current in required:
+            continue
+        required.add(current)
+        source = (PACKAGE_ROOT / current).read_text(encoding="utf-8")
+        pending.extend(_relative_path(module) for module in _eager_package_imports(source))
+    return required
 
 
 def test_static_spa_replaces_stlite_mount() -> None:
@@ -52,6 +114,19 @@ def test_static_spa_bundles_cross_check_dependency_closure() -> None:
     assert '"extraction/cross_check.py"' in script
     assert '"performance/contracts.py"' in script
     assert '"performance/conflict_resolver.py"' in script
+
+
+def test_static_spa_bundles_every_eagerly_imported_bridge_dependency() -> None:
+    """A module the bridge imports at run time must be fetched into the Pyodide FS.
+
+    The bundle materializes individual module files without package ``__init__``
+    files, so a missing entry raises ``ModuleNotFoundError`` and silently drops
+    the operator into the fallback packet view.
+    """
+
+    missing = sorted(_required_bundle_closure() - set(_bundled_modules()))
+
+    assert not missing, f"PRODUCTION_PACKET_MODULES is missing {missing}"
 
 
 def test_pyodide_bridge_runs_packet_pipeline_for_seed_data() -> None:

--- a/tests/app/test_static_spa_bundle.py
+++ b/tests/app/test_static_spa_bundle.py
@@ -82,4 +82,14 @@ def test_pyodide_bridge_runs_packet_pipeline_for_seed_data() -> None:
     assert profile["manager_profile"]["Manager"] == "Summit Arc Capital"
     assert profile["manager_profile"]["Provenance"].startswith("upload_1:")
     assert profile["coverage"][0]["document"] == "upload_1"
+    assert profile["one_pager"] is not None
     assert profile["outbound_calls"] == 0
+
+
+def test_fallback_never_returns_a_fabricated_one_pager() -> None:
+    bridge_path = ROOT / "app" / "pyodide_packet_bridge.py"
+    spec = importlib.util.spec_from_file_location("pyodide_packet_bridge_fallback", bridge_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    assert module._fallback_packet_view([{"filename": "arbitrary.txt"}])["one_pager"] is None

--- a/tests/export/test_one_pager.py
+++ b/tests/export/test_one_pager.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 import pytest
 
+from inv_man_intake.export.manifest import ExportArtifact
 from inv_man_intake.export.one_pager import build_one_pager
 from inv_man_intake.extraction.providers.base import ExtractedDocumentResult, ExtractedField
 from inv_man_intake.intake.standard_elements import load_standard_element_library
@@ -112,3 +113,34 @@ def test_summary_bounds_dense_profile_content() -> None:
         for section in (model.identity, model.return_stats)
         for field in section
     )
+
+
+def test_summary_bounds_graphics_labels_and_provenance() -> None:
+    """Graphics honour the same one-page text budget as every other section."""
+
+    artifact = ExportArtifact(
+        name="G" * 200,
+        media_type="image/png",
+        content=b"",
+        provenance_refs=("P" * 200,),
+    )
+    model = build_one_pager(replace(_profile(), graphics_artifacts=(artifact,)))
+    assert all(
+        len(graphic.label) <= 80 and len(graphic.provenance_ref) <= 80 for graphic in model.graphics
+    )
+
+    ref_model = build_one_pager(
+        replace(_profile(), graphics_artifacts=(), graphics_refs=("R" * 200,))
+    )
+    assert all(
+        len(graphic.label) <= 80 and len(graphic.provenance_ref) <= 80
+        for graphic in ref_model.graphics
+    )
+
+
+def test_summary_titles_an_identity_without_a_manager_field() -> None:
+    """Identity fields without a manager entry must not title the page "Manager"."""
+
+    model = build_one_pager(replace(_profile(), identity={"operations.aum": "$100.0M"}))
+
+    assert model.title == "Unknown manager strategy summary"

--- a/tests/export/test_one_pager.py
+++ b/tests/export/test_one_pager.py
@@ -1,0 +1,69 @@
+"""Tests for the browser-agnostic one-page strategy summary model."""
+
+from __future__ import annotations
+
+from collections import Counter
+from pathlib import Path
+
+from inv_man_intake.export.one_pager import build_one_pager
+from inv_man_intake.extraction.providers.base import ExtractedDocumentResult, ExtractedField
+from inv_man_intake.intake.standard_elements import load_standard_element_library
+from inv_man_intake.packet import PacketFile, ingest_packet
+
+ROOT = Path(__file__).resolve().parents[2]
+FIXTURE = ROOT / "tests" / "fixtures" / "intake" / "pdf_primary_mixed_bundle.json"
+
+
+class _FixtureProvider:
+    @property
+    def name(self) -> str:
+        return "fixture"
+
+    def extract(self, source_doc_id: str, content: bytes) -> ExtractedDocumentResult:
+        _ = content
+        fields = (
+            ExtractedField(
+                "identity.manager", "Summit Arc Advisors", 0.9, source_doc_id, 1, "fixture"
+            ),
+            ExtractedField("performance.net_return_1y", "12.5%", 0.8, source_doc_id, 1, "fixture"),
+        )
+        return ExtractedDocumentResult(source_doc_id, self.name, fields)
+
+
+def _profile():
+    library = load_standard_element_library(
+        {
+            "version": "one-pager-test",
+            "non_authoritative": True,
+            "doc_types": {
+                "deck": [
+                    {"key": "identity.manager", "detector_name": "field_present", "mandatory": True}
+                ]
+            },
+        }
+    )
+    return ingest_packet(
+        (PacketFile("fixture", FIXTURE.read_bytes(), "fixture_deck.json"),),
+        provider=_FixtureProvider(),
+        standard_library=library,
+        packet_id="one-pager-fixture",
+    )
+
+
+def test_summary_contains_required_sections_from_a_real_packet() -> None:
+    """The committed packet fixture produces every required, non-placeholder section."""
+
+    model = build_one_pager(_profile())
+    assert model.identity and model.coverage and model.explainability
+    assert model.provenance_citations and model.return_stats
+    assert model.final_score == _profile().scores["extraction_confidence"]
+    assert "Summit Arc" in model.title
+    assert Counter(field.label for field in model.explainability)["Extraction Confidence"] == 1
+    assert "lorem" not in str(model.as_dict()).lower()
+
+
+def test_removing_explainability_breaks_the_required_section() -> None:
+    """Deliberate-break guard: score components must not disappear from the model."""
+
+    model = build_one_pager(_profile())
+    assert model.explainability

--- a/tests/export/test_one_pager.py
+++ b/tests/export/test_one_pager.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
+import math
 from collections import Counter
+from dataclasses import replace
 from pathlib import Path
+
+import pytest
 
 from inv_man_intake.export.one_pager import build_one_pager
 from inv_man_intake.extraction.providers.base import ExtractedDocumentResult, ExtractedField
@@ -54,12 +58,24 @@ def test_summary_contains_required_sections_from_a_real_packet() -> None:
     """The committed packet fixture produces every required, non-placeholder section."""
 
     model = build_one_pager(_profile())
-    assert model.identity and model.coverage and model.explainability
-    assert model.provenance_citations and model.return_stats
+    assert ("Manager", "Summit Arc Advisors") in {
+        (field.label, field.value) for field in model.identity
+    }
+    assert {field.label for field in model.coverage} == {
+        "Documents",
+        "Document types",
+        "Standard elements",
+    }
+    assert {field.label for field in model.return_stats} == {"Performance / Net Return 1Y"}
+    assert model.provenance_citations == (
+        "fixture:identity.manager:p1:fixture",
+        "fixture:performance.net_return_1y:p1:fixture",
+    )
     assert model.final_score == _profile().scores["extraction_confidence"]
     assert "Summit Arc" in model.title
     assert Counter(field.label for field in model.explainability)["Extraction Confidence"] == 1
-    assert "lorem" not in str(model.as_dict()).lower()
+    rendered = str(model.as_dict()).lower()
+    assert not any(marker in rendered for marker in ("lorem", "placeholder", "tbd", "todo"))
 
 
 def test_removing_explainability_breaks_the_required_section() -> None:
@@ -67,3 +83,32 @@ def test_removing_explainability_breaks_the_required_section() -> None:
 
     model = build_one_pager(_profile())
     assert model.explainability
+
+
+@pytest.mark.parametrize("score", [math.nan, math.inf, None])
+def test_summary_rejects_non_finite_or_missing_scores(score: object) -> None:
+    with pytest.raises(ValueError, match="finite"):
+        build_one_pager(replace(_profile(), scores={"final_score": score}))
+
+
+def test_summary_bounds_dense_profile_content() -> None:
+    model = build_one_pager(
+        replace(
+            _profile(),
+            identity={
+                "identity.manager": "M" * 200,
+                **{f"identity.field_{i}": "V" * 200 for i in range(8)},
+            },
+            scores={f"score_{i}": 0.5 for i in range(8)},
+            returns_metrics={f"return_{i}": "R" * 200 for i in range(8)},
+        )
+    )
+    assert (
+        len(model.identity) == 4 and len(model.explainability) == 5 and len(model.return_stats) == 4
+    )
+    assert model.identity[0].label == "Manager"
+    assert all(
+        len(field.value) <= 80
+        for section in (model.identity, model.return_stats)
+        for field in section
+    )


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:850 -->
> **Source:** Issue #850

Closes #850

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
_Scope section missing from source issue._

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#845](https://github.com/stranske/Inv-Man-Intake/issues/845)
- [#846](https://github.com/stranske/Inv-Man-Intake/issues/846)
- [#721](https://github.com/stranske/Inv-Man-Intake/issues/721)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] Implement an `Exporter` (X1 port) in `src/inv_man_intake/export/one_pager.py` that builds the summary **content
  model** from `ManagerProfile` — identity, strategy/doc-type coverage, final score **with the explainability
  component breakdown**, top provenance citations, key return-stream stats, and up to N exported graphics — returning
  a structured payload (not HTML) so a later `.docx` exporter is a drop-in.
- [ ] Render that model to a single-page HTML view in the static SPA using **Ink & Air** tokens
  (`Frontend-Design-Tracker/design-system/`) plus a print stylesheet with `@page { size: Letter; margin: … }` and
  print-only rules that hide app chrome.
- [ ] Wire a "Save as PDF" affordance that invokes the browser print path; no PDF library, **zero new dependencies**.

#### Acceptance criteria
- [ ] Named test: `tests/export/test_one_pager.py::test_summary_contains_required_sections_from_a_real_packet` — running a

<!-- auto-status-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a printable one-page manager summary including identity, coverage, explainability, final score, return statistics, provenance citations, and graphics.
  * Added a **Save as PDF** action that triggers print layout.
* **Bug Fixes**
  * Ensured the print view cleanly hides unrelated application content and hides the one-pager when unavailable.
* **Tests**
  * Added/updated end-to-end checks for one-pager rendering in print mode and single-page (US Letter) fit.
  * Added unit tests validating one-pager content, required sections, score handling, and output bounding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->