### PR TITLE
fix: multi-color vector E2E fixture after #861 CI failure

### DIFF
--- a/tests/app/test_static_spa_browser_e2e.py
+++ b/tests/app/test_static_spa_browser_e2e.py
@@ -43,9 +43,21 @@ def _free_port() -> int:
 
 
 def _vector_chart_pdf() -> bytes:
-    """Build a compact PDF with one filled vector rectangle for browser rendering."""
+    """Build a compact PDF with two overlapping filled bars for browser rendering.
 
-    stream = b"q 0.1 0.4 0.8 rg 120 180 260 190 re f Q\n"
+    The bars use distinct RGB fills and intersect so ``pathBounds`` merges them into
+    one region. A solid single-color crop would make ``colors > 1`` fail even when
+    rendering succeeded (post-merge CI failure on #861); multi-color content is the
+    intentional gate against blank/uniform canvases.
+    """
+
+    # Blue bar + overlapping red bar (distinct fills; merged region is multi-color).
+    stream = (
+        b"q "
+        b"0.1 0.4 0.8 rg 120 180 200 190 re f "
+        b"0.9 0.2 0.1 rg 220 220 180 150 re f "
+        b"Q\n"
+    )
     objects = (
         b"<< /Type /Catalog /Pages 2 0 R >>",
         b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
@@ -217,6 +229,16 @@ def test_static_spa_offline_upload_runs_local_pyodide_packet_path_without_egress
         assert external_requests == []
     finally:
         _close_page(server_context, playwright_context, browser)
+
+
+def test_vector_chart_pdf_fixture_encodes_two_distinct_fills() -> None:
+    """Fixture must stay multi-color so the browser colors>1 gate remains meaningful."""
+
+    pdf = _vector_chart_pdf()
+    assert b"0.1 0.4 0.8 rg" in pdf
+    assert b"0.9 0.2 0.1 rg" in pdf
+    # Deliberate break: reverting to a single solid fill makes this fail.
+    assert pdf.count(b" re f ") >= 2
 
 
 def test_vector_figure_export_renders_a_local_pdf_region_without_egress() -> None:

--- a/tests/app/test_static_spa_browser_e2e.py
+++ b/tests/app/test_static_spa_browser_e2e.py
@@ -16,6 +16,7 @@ from urllib.request import urlopen
 
 import pytest
 from scripts.verify_static_spa_pyodide import handle_offline_route
+from tests.app.vector_chart_pdf import build_vector_chart_pdf as _vector_chart_pdf
 
 try:
     from playwright.sync_api import sync_playwright
@@ -40,47 +41,6 @@ def _free_port() -> int:
     with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
         sock.bind(("127.0.0.1", 0))
         return int(sock.getsockname()[1])
-
-
-def _vector_chart_pdf() -> bytes:
-    """Build a compact PDF with two overlapping filled bars for browser rendering.
-
-    The bars use distinct RGB fills and intersect so ``pathBounds`` merges them into
-    one region. A solid single-color crop would make ``colors > 1`` fail even when
-    rendering succeeded (post-merge CI failure on #861); multi-color content is the
-    intentional gate against blank/uniform canvases.
-    """
-
-    # Blue bar + overlapping red bar (distinct fills; merged region is multi-color).
-    stream = (
-        b"q "
-        b"0.1 0.4 0.8 rg 120 180 200 190 re f "
-        b"0.9 0.2 0.1 rg 220 220 180 150 re f "
-        b"Q\n"
-    )
-    objects = (
-        b"<< /Type /Catalog /Pages 2 0 R >>",
-        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
-        b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R >>",
-        b"<< /Length " + str(len(stream)).encode() + b" >>\nstream\n" + stream + b"endstream",
-    )
-    document = bytearray(b"%PDF-1.4\n%\xe2\xe3\xcf\xd3\n")
-    offsets = [0]
-    for number, value in enumerate(objects, start=1):
-        offsets.append(len(document))
-        document.extend(f"{number} 0 obj\n".encode())
-        document.extend(value)
-        document.extend(b"\nendobj\n")
-    xref_offset = len(document)
-    document.extend(f"xref\n0 {len(objects) + 1}\n".encode())
-    document.extend(b"0000000000 65535 f \n")
-    document.extend(b"".join(f"{offset:010d} 00000 n \n".encode() for offset in offsets[1:]))
-    document.extend(
-        b"trailer\n<< /Size 5 /Root 1 0 R >>\nstartxref\n"
-        + str(xref_offset).encode()
-        + b"\n%%EOF\n"
-    )
-    return bytes(document)
 
 
 @contextmanager
@@ -229,16 +189,6 @@ def test_static_spa_offline_upload_runs_local_pyodide_packet_path_without_egress
         assert external_requests == []
     finally:
         _close_page(server_context, playwright_context, browser)
-
-
-def test_vector_chart_pdf_fixture_encodes_two_distinct_fills() -> None:
-    """Fixture must stay multi-color so the browser colors>1 gate remains meaningful."""
-
-    pdf = _vector_chart_pdf()
-    assert b"0.1 0.4 0.8 rg" in pdf
-    assert b"0.9 0.2 0.1 rg" in pdf
-    # Deliberate break: reverting to a single solid fill makes this fail.
-    assert pdf.count(b" re f ") >= 2
 
 
 def test_vector_figure_export_renders_a_local_pdf_region_without_egress() -> None:

--- a/tests/app/test_vector_chart_pdf_fixture.py
+++ b/tests/app/test_vector_chart_pdf_fixture.py
@@ -1,0 +1,15 @@
+"""Non-browser gate for the multi-color vector chart PDF fixture."""
+
+from __future__ import annotations
+
+from tests.app.vector_chart_pdf import build_vector_chart_pdf
+
+
+def test_vector_chart_pdf_fixture_encodes_two_distinct_fills() -> None:
+    """Fixture must stay multi-color so the browser colors>1 gate remains meaningful."""
+
+    pdf = build_vector_chart_pdf()
+    assert b"0.1 0.4 0.8 rg" in pdf
+    assert b"0.9 0.2 0.1 rg" in pdf
+    # Deliberate break: reverting to a single solid fill makes this fail.
+    assert pdf.count(b" re f ") >= 2

--- a/tests/app/vector_chart_pdf.py
+++ b/tests/app/vector_chart_pdf.py
@@ -1,0 +1,44 @@
+"""Shared PDF fixture for offline vector-figure browser coverage."""
+
+from __future__ import annotations
+
+
+def build_vector_chart_pdf() -> bytes:
+    """Build a compact PDF with two overlapping filled bars for browser rendering.
+
+    The bars use distinct RGB fills and intersect so ``pathBounds`` merges them into
+    one region. A solid single-color crop would make ``colors > 1`` fail even when
+    rendering succeeded (post-merge CI failure on #861); multi-color content is the
+    intentional gate against blank/uniform canvases.
+    """
+
+    # Blue bar + overlapping red bar (distinct fills; merged region is multi-color).
+    stream = (
+        b"q "
+        b"0.1 0.4 0.8 rg 120 180 200 190 re f "
+        b"0.9 0.2 0.1 rg 220 220 180 150 re f "
+        b"Q\n"
+    )
+    objects = (
+        b"<< /Type /Catalog /Pages 2 0 R >>",
+        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+        b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R >>",
+        b"<< /Length " + str(len(stream)).encode() + b" >>\nstream\n" + stream + b"endstream",
+    )
+    document = bytearray(b"%PDF-1.4\n%\xe2\xe3\xcf\xd3\n")
+    offsets = [0]
+    for number, value in enumerate(objects, start=1):
+        offsets.append(len(document))
+        document.extend(f"{number} 0 obj\n".encode())
+        document.extend(value)
+        document.extend(b"\nendobj\n")
+    xref_offset = len(document)
+    document.extend(f"xref\n0 {len(objects) + 1}\n".encode())
+    document.extend(b"0000000000 65535 f \n")
+    document.extend(b"".join(f"{offset:010d} 00000 n \n".encode() for offset in offsets[1:]))
+    document.extend(
+        b"trailer\n<< /Size 5 /Root 1 0 R >>\nstartxref\n"
+        + str(xref_offset).encode()
+        + b"\n%%EOF\n"
+    )
+    return bytes(document)

--- a/tests/app/vector_chart_pdf.py
+++ b/tests/app/vector_chart_pdf.py
@@ -14,10 +14,7 @@ def build_vector_chart_pdf() -> bytes:
 
     # Blue bar + overlapping red bar (distinct fills; merged region is multi-color).
     stream = (
-        b"q "
-        b"0.1 0.4 0.8 rg 120 180 200 190 re f "
-        b"0.9 0.2 0.1 rg 220 220 180 150 re f "
-        b"Q\n"
+        b"q " b"0.1 0.4 0.8 rg 120 180 200 190 re f " b"0.9 0.2 0.1 rg 220 220 180 150 re f " b"Q\n"
     )
     objects = (
         b"<< /Type /Catalog /Pages 2 0 R >>",


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:848 -->
> **Source:** Issue #848

Closes #848

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
_Scope section missing from source issue._

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#845](https://github.com/stranske/Inv-Man-Intake/issues/845)
- [#847](https://github.com/stranske/Inv-Man-Intake/issues/847)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] **Vendor pdf.js offline** into `app/vendor/pdfjs@<version>/` (the single build actually used, incl. its worker).
  No CDN references; extend the existing offline-bundle assertion to cover it.
- [ ] **Detect** figure regions on the **JS side** in `app/static_operator_app.js` using pdf.js
  `page.getOperatorList()`: cluster fill/stroke/path construction ops into bounding boxes, discarding page furniture
  (full-width rules, header/footer bands) and boxes below a minimum area.
  *Detection must NOT be done in Python with pdfplumber* — that would pull pdfplumber+Pillow into the core import
  graph and breach the Pyodide-viability constraint.
- [ ] **Render** each detected region: `page.render()` to an offscreen canvas at a fixed device scale, crop to the
  bbox, `toBlob('image/png')` → bytes.
- [ ] Return bytes to Python over `app/pyodide_packet_bridge.py` as X1 `ExportArtifact`s carrying page number + bbox
  provenance. Record failures as `vector_render_failed` manifest skip rows.

#### Acceptance criteria
- [ ] Named test: `tests/app/test_static_spa_browser_e2e.py::test_vector_figure_exports_png` — upload a committed fixture

<!-- auto-status-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage to verify that generated vector chart PDFs preserve multiple distinct fill colors.
  * Standardized browser tests to use a shared vector chart PDF fixture.
  * Added validation that the fixture contains multiple filled chart elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->