### PR TITLE
chore(config): make llm_slots profile-driven so slots track reviewed selections

### DIFF
--- a/config/llm_slots.json
+++ b/config/llm_slots.json
@@ -3,17 +3,17 @@
     {
       "name": "slot1",
       "provider": "openai",
-      "model": "gpt-5.4"
+      "profile": "verifier-balanced"
     },
     {
       "name": "slot2",
       "provider": "anthropic",
-      "model": "claude-sonnet-4-6"
+      "profile": "verifier-balanced"
     },
     {
       "name": "slot3",
       "provider": "github-models",
-      "model": "codex-mini-latest"
+      "profile": "verifier-balanced"
     }
   ]
 }


### PR DESCRIPTION
## Why

The pinned slot form does **not** track the model registry. `tools/llm_registry.py` deliberately *retains* an unprofiled pin while the pinned model is still `lifecycle: current`, so an advancing reviewed selection was silently ignored. Probed against a registry whose selections had advanced:

| slot | pinned | resolved | why |
|---|---|---|---|
| slot1 openai | `gpt-5.4` | **`gpt-5.4`** | pin still `current` → retained |
| slot2 anthropic | `claude-sonnet-4-6` | `claude-opus-4-6` | pin absent from registry → falls through to selection |
| slot3 github-models | `codex-mini-latest` | **`codex-mini-latest`** | pin still `current` → retained |

Only slot2 followed the reviewed selection, and only by accident of its pin being invalid.

## What changed

All three slots switch to `profile: verifier-balanced` — the form `stranske/Workflows` now ships. No code change: the synced `tools/llm_registry.py` is already profile-aware, and this repo has no local client fork.

`config/llm_slots.json` is `sync_mode: create_only` in the Workflows manifest ("repos may customize provider preferences"), so it can only be changed here.

## Verification

```
tools/check_model_registry_freshness.py -> 0 blocking (profile slots accepted)
resolve_slots(), current registry       -> gpt-5.4 / claude-opus-4-6 / codex-mini-latest   (unchanged today)
resolve_slots(), advanced registry      -> gpt-5.6-terra / claude-sonnet-5 / openai/gpt-5  (now tracks)
pytest tests/tools/test_llm_client_single_source.py tests/tools/test_langchain_client_config.py -> 13 passed
```

Order-independent w.r.t. stranske/Workflows#2852: correct against today's registry, and starts tracking the advanced selections as soon as the registry syncs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)