### PR TITLE
chore: sync workflow templates

### DIFF
--- a/scripts/check_deliberate_break.py
+++ b/scripts/check_deliberate_break.py
@@ -165,7 +165,8 @@ def _supported_pyyaml_version(installed_version: str | None) -> bool:
     if installed_version is None:
         return False
     installed_match = re.fullmatch(
-        r"(\d+(?:\.\d+)*)(?:\.post\d+)?(?:\+[\w.-]+)?", installed_version
+        r"(\d+(?:\.\d+)*)(?P<pre>(?:a|b|rc)\d+)?" r"(?:\.post\d+)?(?P<dev>\.dev\d+)?(?:\+[\w.-]+)?",
+        installed_version,
     )
     floor_match = re.fullmatch(r"(\d+(?:\.\d+)*)", PYYAML_VERSION)
     if installed_match is None or floor_match is None:
@@ -173,9 +174,11 @@ def _supported_pyyaml_version(installed_version: str | None) -> bool:
     installed_release = tuple(int(part) for part in installed_match.group(1).split("."))
     floor_release = tuple(int(part) for part in floor_match.group(1).split("."))
     width = max(len(installed_release), len(floor_release))
-    return installed_release + (0,) * (width - len(installed_release)) >= floor_release + (0,) * (
-        width - len(floor_release)
-    )
+    normalized_installed = installed_release + (0,) * (width - len(installed_release))
+    normalized_floor = floor_release + (0,) * (width - len(floor_release))
+    if normalized_installed != normalized_floor:
+        return normalized_installed > normalized_floor
+    return installed_match.group("pre") is None and installed_match.group("dev") is None
 
 
 def _ensure_pytest_runtime_deps() -> None:
@@ -694,8 +697,8 @@ def _runtime_dependency_error_result(error: Exception) -> dict[str, object]:
             reason="dependency-install-failed",
             command=list(error.cmd) if isinstance(error.cmd, (tuple, list)) else str(error.cmd),
             returncode=error.returncode,
-            stdout=error.stdout,
-            stderr=error.stderr,
+            stdout=_subprocess_output_text(error.stdout),
+            stderr=_subprocess_output_text(error.stderr),
         )
     if isinstance(error, ImportError):
         return _json_result(

--- a/scripts/langchain/pr_verifier.py
+++ b/scripts/langchain/pr_verifier.py
@@ -678,17 +678,17 @@ def _fallback_evaluation(
 def _text_from_response_content(content: object) -> str | None:
     """Return provider text, or None when the payload carries no text blocks."""
     if isinstance(content, str):
-        return content
+        return content if content and not content.isspace() else None
     if isinstance(content, Mapping):
+        block_type = content.get("type")
         for key in ("text", "content"):
             text = content.get(key)
-            if isinstance(text, str):
-                if key == "content" and content.get("type") not in (
-                    None,
-                    "text",
-                    "output_text",
-                ):
-                    continue
+            if (
+                isinstance(text, str)
+                and text
+                and not text.isspace()
+                and block_type in (None, "text", "output_text")
+            ):
                 return text
         return None
     if isinstance(content, list):
@@ -697,17 +697,19 @@ def _text_from_response_content(content: object) -> str | None:
             if isinstance(block, str):
                 text = block
             elif isinstance(block, Mapping):
-                text = block.get("text")
-                if not isinstance(text, str):
-                    text = block.get("content")
-                    if block.get("type") not in (None, "text", "output_text"):
-                        text = None
+                if block.get("type") not in (None, "text", "output_text"):
+                    text = None
+                else:
+                    text = block.get("text")
+                    if not isinstance(text, str):
+                        text = block.get("content")
             else:
-                text = getattr(block, "text", None)
-                if not isinstance(text, str):
-                    text = getattr(block, "content", None)
-                    if getattr(block, "type", None) not in (None, "text", "output_text"):
-                        text = None
+                if getattr(block, "type", None) not in (None, "text", "output_text"):
+                    text = None
+                else:
+                    text = getattr(block, "text", None)
+                    if not isinstance(text, str):
+                        text = getattr(block, "content", None)
             if isinstance(text, str):
                 text_blocks.append(text)
         if any(block and not block.isspace() for block in text_blocks):


### PR DESCRIPTION
## Sync Summary

### Files Updated
- check_deliberate_break.py: Opt-in Gate helper that proves named deliberate-break acceptance tests fail against the base implementation
- pr_verifier.py: PR verifier - validates PR changes against acceptance criteria

### Files Skipped
- pr-00-gate.yml: File exists and sync_mode is create_only
- ci.yml: File exists and sync_mode is create_only
- renovate.json: File exists and sync_mode is create_only
- cross-repo-smoke.yml: File exists and sync_mode is create_only
- llm_slots.json: None

---

### Review Checklist
- [ ] CI passes with updated workflows
- [ ] No repo-specific customizations were overwritten

**Source:** stranske/Workflows
**Source SHA:** `ecda8dd48e776e547216a9fa927e8ebd0e4dbafb`
**Template hash:** `4e0cda83c0b0`
**Consumer-sync plan ID:** `sha256:4e0cda83c0b060c6fe61aca924c580736e12a80305df53df6305320ae6732252`
**Sync phase:** `canary`
**Sync branch:** `sync/workflows-4e0cda83c0b0`
**Consumer repo:** `stranske/Inv-Man-Intake`
**Manifest:** `.github/sync-manifest.yml`

<!-- workflows-consumer-sync:v1 {"schema":"workflows-consumer-sync-pr/v1","consumer_repo":"stranske/Inv-Man-Intake","source_repository":"stranske/Workflows","source_sha":"ecda8dd48e776e547216a9fa927e8ebd0e4dbafb","template_hash":"4e0cda83c0b0","plan_id":"sha256:4e0cda83c0b060c6fe61aca924c580736e12a80305df53df6305320ae6732252","sync_phase":"canary","sync_branch":"sync/workflows-4e0cda83c0b0","manifest":".github/sync-manifest.yml","lifecycle_state":"opened","run_id":"30916714483","run_attempt":"1","changes_count":2} -->
<!-- sync-pr-delivery-record:v1 {"schema":"sync-pr-delivery-record/v1","durable_issue_url":"https://github.com/stranske/Workflows/issues/1836","plan_id":"sha256:4e0cda83c0b060c6fe61aca924c580736e12a80305df53df6305320ae6732252","generation":"4e0cda83c0b0","repository":"stranske/Inv-Man-Intake","desired_tree_hash":"5023692b0fff84e9e72dc184ef86052c81673d37","source_commit":"ecda8dd48e776e547216a9fa927e8ebd0e4dbafb","lease_expires_at":"2026-08-07T14:01:49Z","predecessor_prs":[],"successor_prs":[]} -->