### PR TITLE
chore: sync workflow templates

### DIFF
--- a/.github/scripts/github-api-with-retry.js
+++ b/.github/scripts/github-api-with-retry.js
@@ -428,7 +428,7 @@ async function withRetry(fn, options = {}) {
           ? 'rate limit'
           : 'transient error';
 
-      console.log(
+      console.error(
         `${retryReason} (attempt ${attempt + 1}/${maxRetries + 1}). ` +
         `Retrying in ${Math.round(actualDelay / 1000)}s...`
       );

--- a/.github/scripts/issue_format.py
+++ b/.github/scripts/issue_format.py
@@ -10,8 +10,6 @@ filed with no label and no Tasks/Acceptance block is invisible to the entire
 pipeline — nothing validates it, nothing optimises it, nothing claims it. Local
 automation that files *findings* rather than *work orders* therefore produces
 issues no agent can ever pick up: good evidence, permanently unactionable.
-(Observed in Fine-Art-Archive #406-409: four well-evidenced audit findings, zero
-labels, no Tasks section between them.)
 
 Used at both ends:
   * `agents-issue-format-guard.yml` validates every issue on open/edit and, on
@@ -63,14 +61,92 @@ RECOMMENDED: dict[str, tuple[str, ...]] = {
 GATE = re.compile(
     r"(tests?/[\w./-]+\.py(::[\w:\[\]-]+)?"
     r"|\btest_[\w]+"
-    r"|\bpytest\b|\bnpm test\b|\bmake test\b"
+    r"|\bpytest\b|\b(?:python(?:3)?\s+-m\s+(?:unittest|pytest)\b)"
+    r"|\bnode\s+--test\b|\b(?:npm|pnpm|yarn)\s+(?:run\s+)?(?:test|vitest|jest|playwright)\b"
+    r"|\b(?:make|just|cargo|go|dotnet)\s+(?:test|check)\b"
     r"|\bgh workflow run\b|\bgh run\b"
     r"|\bcurl\b|\bHTTP [1-5]\d\d\b"
     r"|\b(?:API|endpoint|request|response)\s+(?:returns?|responds with)\s+[1-5]\d\d(?:\s+status)?\b"
     r"|\bsmoke\b|\bverif\w*)",
     re.I,
 )
-BANNED_ADJECTIVES = ("clean", "nice", "good", "fast", "better", "intuitive", "polished")
+BANNED_ADJECTIVES = (
+    "clean",
+    "nice",
+    "good",
+    "fast",
+    "better",
+    "intuitive",
+    "polished",
+    "performant",
+)
+_TASK_CATEGORY = r"(?:file|function|class|method|path|config(?:uration)?|key|job|workflow|command)"
+_TASK_EXTENSION = (
+    r"py|js|jsx|ts|tsx|yml|yaml|json|toml|md|sh|go|rs|java|kt|rb|php|css|html|sql|"
+    r"xml|txt|ini|cfg|conf|lock|gradle|swift|c|cc|cpp|h|hpp|cs|fs|r|jl"
+)
+_TASK_KNOWN_BASENAME = (
+    r"(?:Dockerfile|Makefile|Justfile|Procfile|Gemfile|Rakefile|"
+    r"Cargo\.toml|pyproject\.toml|package\.json|go\.mod|go\.sum|pom\.xml|"
+    r"build\.gradle|CMakeLists\.txt|README(?:\.(?:md|rst|txt))?|"
+    r"LICENSE(?:\.(?:md|txt))?|\.gitignore|\.editorconfig)"
+)
+_TASK_COMMAND = (
+    r"(?:python(?:3)?|pytest|npm|pnpm|yarn|make|just|cargo|go|dotnet|gh|curl|"
+    r"node|vitest|jest|playwright)"
+)
+
+
+def _concrete_span(span: str) -> bool:
+    """Return True when a backticked/unquoted token names a real work target."""
+    span = span.strip()
+    if not span:
+        return False
+    if re.fullmatch(_TASK_CATEGORY, span, re.I):
+        return False
+    # Bare lowercase English words (`bugs`, `later`) are not actionable targets.
+    if re.fullmatch(r"[a-z]{2,24}", span):
+        return False
+    if "/" in span or span.startswith("."):
+        return True
+    if re.fullmatch(_TASK_KNOWN_BASENAME, span, re.I):
+        return True
+    if re.fullmatch(rf"[\w.-]+\.(?:{_TASK_EXTENSION})", span, re.I):
+        return True
+    if "_" in span or "." in span:
+        return True
+    # Multi-segment PascalCase or lowerCamelCase symbols (e.g. IssueFormatter,
+    # calculateDiscount). A capitalized interior segment distinguishes them from
+    # generic lowercase prose.
+    return re.fullmatch(r"[A-Za-z][a-zA-Z0-9]*[A-Z][a-zA-Z0-9]+", span) is not None
+
+
+def _task_has_concrete_target(item: str) -> bool:
+    """True when a task checkbox names a file, path, symbol, config, job, or command."""
+    # Category word must be followed by a concrete identifier (not "file handling").
+    for match in re.finditer(rf"\b{_TASK_CATEGORY}\s+(`[^`]+`|[^\s]+)", item, re.I):
+        token = match.group(1)
+        span = token[1:-1] if token.startswith("`") and token.endswith("`") else token.strip("'\"")
+        if _concrete_span(span):
+            return True
+    for match in re.finditer(r"`([^`]+)`", item):
+        if _concrete_span(match.group(1)):
+            return True
+    for token in re.findall(r"\b[A-Za-z][A-Za-z0-9_]*\b", item):
+        # Unquoted: only unambiguous lowerCamelCase (calculateDiscount).
+        # Brand/prose capitals (GitHub, JavaScript, OpenAI) must not satisfy.
+        if not re.fullmatch(r"[a-z][a-zA-Z0-9]*[A-Z][a-zA-Z0-9]+", token):
+            continue
+        if _concrete_span(token):
+            return True
+    if re.search(rf"(?:^|[\s])({_TASK_KNOWN_BASENAME})\b", item, re.I):
+        return True
+    if re.search(rf"(?:^|[\s])([\w.-]+\.(?:{_TASK_EXTENSION}))\b", item, re.I):
+        return True
+    # Unquoted path with a directory separator (src/main.go, .github/workflows/x.yml).
+    if re.search(r"(?:^|[\s])((?:\./)?[\w.-]+(?:/[\w./-]+)+)", item):
+        return True
+    return re.search(rf"\b{_TASK_COMMAND}\b", item, re.I) is not None
 
 
 def _headings(body: str) -> list[tuple[str, int, int]]:
@@ -165,12 +241,18 @@ def validate(body: str) -> Report:
             report.missing_recommended.append(name)
 
     tasks_at = _find(body, REQUIRED["Tasks"])
-    if tasks_at is not None and not re.search(
-        r"^\s*[-*]\s*\[[ xX]\]", _section_text(body, tasks_at), re.M
-    ):
-        report.problems.append(
-            "`Tasks` has no checkbox items (`- [ ] …`); agents track progress by them."
+    if tasks_at is not None:
+        task_items = re.findall(
+            r"^\s*[-*]\s*\[[ xX]\]\s*(.+)$", _section_text(body, tasks_at), re.M
         )
+        if not task_items:
+            report.problems.append(
+                "`Tasks` has no checkbox items (`- [ ] …`); agents track progress by them."
+            )
+        elif any(not _task_has_concrete_target(item) for item in task_items):
+            report.problems.append(
+                "`Tasks` must name a concrete file, symbol, path, config key, job, or command."
+            )
 
     acceptance_at = _find(body, REQUIRED["Acceptance Criteria"])
     if acceptance_at is not None:

--- a/.github/workflows/agents-issue-format-guard.yml
+++ b/.github/workflows/agents-issue-format-guard.yml
@@ -16,8 +16,15 @@ permissions:
   issues: write
 
 concurrency:
-  group: issue-format-guard-${{ github.event.issue.number || inputs.issue_number }}
-  cancel-in-progress: true
+  # Event inputs are null for issue events, so retain the manual fallback
+  # without making normal issue-triggered runs depend on the dispatch-only
+  # `inputs` context.
+  group: >-
+    issue-format-guard-${{
+    github.event.issue.number || github.event.inputs.issue_number ||
+    github.run_id }}
+  # A skipped label event must never cancel an in-flight opened/edited check.
+  cancel-in-progress: false
 
 jobs:
   check:
@@ -39,7 +46,7 @@ jobs:
         id: issue
         env:
           GH_TOKEN: ${{ github.token }}
-          NUMBER: ${{ github.event.issue.number || inputs.issue_number }}
+          NUMBER: ${{ github.event.issue.number || github.event.inputs.issue_number }}
         run: |
           set -euo pipefail
           gh issue view "$NUMBER" --repo "$GITHUB_REPOSITORY" \
@@ -47,6 +54,14 @@ jobs:
           jq -r '.body // ""' issue.json > body.md
           exempt=false
           held=false
+          # A closed issue has nothing left to format. Routing one to the optimizer
+          # produces a body edit, that edit re-fires this guard, and the pair loops
+          # against work that is already delivered — see Fine-Art-Archive#464, which
+          # kept formatting for 17.5 hours after it was closed.
+          if [[ "$(jq -r '.state // "" | ascii_downcase' issue.json)" == "closed" ]]; then
+            echo "Issue is closed — nothing to format."
+            exempt=true
+          fi
           if jq -e '[.labels[].name] | any(. == "tracker:durable" or . == "wontfix")' issue.json >/dev/null; then exempt=true; fi
           if jq -e '[.labels[].name] | any(. == "agents:auto-pilot-pause" or . == "needs-human")' issue.json >/dev/null; then held=true; fi
           if jq -er '.author.login // ""' issue.json | grep -qiE '(\[bot\]|^renovate$|^dependabot$)'; then exempt=true; fi
@@ -55,7 +70,16 @@ jobs:
             echo "number=$NUMBER"
             echo "exempt=$exempt"
             echo "held=$held"
+            echo "state=$(jq -r '.state' issue.json)"
           } >> "$GITHUB_OUTPUT"
+
+      - name: Setup API client
+        if: steps.issue.outputs.exempt != 'true' && steps.issue.outputs.held != 'true'
+        uses: ./.github/actions/setup-api-client
+        with:
+          # This guard only reads issue comments with the workflow token. Do not
+          # expose the repository-wide secret bundle to the composite action.
+          github_token: ${{ github.token }}
 
       - name: Validate against AGENT_ISSUE_FORMAT
         id: validate
@@ -89,12 +113,36 @@ jobs:
 
       - name: Invalidate stale format completion after an invalid issue change
         if: >-
-          steps.issue.outputs.exempt != 'true' && steps.validate.outputs.rc == '1'
+          steps.issue.outputs.exempt != 'true' && steps.issue.outputs.state == 'OPEN' &&
+          steps.validate.outputs.rc == '1'
         env:
           GH_TOKEN: ${{ github.token }}
           NUMBER: ${{ steps.issue.outputs.number }}
         run: |
           set -euo pipefail
+          live_issue="$(mktemp)"
+          live_body="$(mktemp)"
+          error_file="$(mktemp)"
+          trap 'rm -f "$live_issue" "$live_body" "$error_file"' EXIT
+          gh issue view "$NUMBER" --repo "$GITHUB_REPOSITORY" --json body,state > "$live_issue"
+          if [[ "$(jq -r '.state' "$live_issue")" != "OPEN" ]]; then
+            echo "Issue is now closed — preserving agents:formatted."
+            exit 0
+          fi
+          jq -r '.body // ""' "$live_issue" > "$live_body"
+          set +e
+          python3 .github/scripts/issue_format.py "$live_body" > /dev/null 2> "$error_file"
+          live_rc=$?
+          set -e
+          if [[ "$live_rc" -eq 0 ]]; then
+            echo "Live body now conforms — preserving agents:formatted."
+            exit 0
+          fi
+          if [[ "$live_rc" -ne 1 || -s "$error_file" ]]; then
+            echo "::error::issue-format validator failed unexpectedly during label revalidation"
+            cat "$error_file" >&2
+            exit 1
+          fi
           if gh issue view "$NUMBER" --repo "$GITHUB_REPOSITORY" --json labels \
               --jq '.labels[].name' | grep -qx 'agents:formatted'; then
             if gh issue edit "$NUMBER" --repo "$GITHUB_REPOSITORY" --remove-label "agents:formatted"; then
@@ -105,38 +153,193 @@ jobs:
           fi
 
       - name: Route non-conforming issue to the optimizer
-        if: steps.issue.outputs.exempt != 'true' && steps.issue.outputs.held != 'true' && steps.validate.outputs.rc == '1'
+        if: steps.issue.outputs.exempt != 'true' && steps.issue.outputs.held != 'true' && steps.issue.outputs.state == 'OPEN' && steps.validate.outputs.rc == '1'
         env:
           GH_TOKEN: ${{ github.token }}
           NUMBER: ${{ steps.issue.outputs.number }}
         run: |
           set -euo pipefail
-          if gh issue view "$NUMBER" --repo "$GITHUB_REPOSITORY" --json labels \
-              --jq '[.labels[].name] | any(. == "agents:auto-pilot-pause" or . == "needs-human")' | grep -qx true; then
+          # Re-fetch before side effects: cancel-in-progress is false so a queued
+          # older run must not dispatch against a body a newer edit already fixed.
+          gh issue view "$NUMBER" --repo "$GITHUB_REPOSITORY" \
+            --json number,body,labels,state,author > live.json
+          jq -r '.body // ""' live.json > body.md
+          if [[ "$(jq -r '.state' live.json)" != "OPEN" ]]; then
+            echo "Issue is now closed — skipping optimizer dispatch."
+            exit 0
+          fi
+          if jq -e '[.labels[].name] | any(. == "agents:auto-pilot-pause" or . == "needs-human")' live.json >/dev/null; then
             echo "Issue is now held — skipping optimizer dispatch."
             exit 0
           fi
-          fingerprint="$(sha256sum body.md | cut -c1-12)"
-          if ! gh issue view "$NUMBER" --repo "$GITHUB_REPOSITORY" --json comments \
-              --jq '.comments[].body' | grep -qF "format-guard:$fingerprint"; then
-            {
-              cat report.md
-              echo
-              echo "Dispatching the Agents Issue Optimizer format phase."
-              echo
-              echo "<!-- format-guard:$fingerprint -->"
-            } | gh issue comment "$NUMBER" --repo "$GITHUB_REPOSITORY" --body-file -
+          if [[ -f .github/scripts/issue_format.py ]]; then
+            error_file="$(mktemp)"
+            set +e
+            python3 .github/scripts/issue_format.py body.md > report.md 2> "$error_file"
+            revalidate_rc=$?
+            set -e
+            if [[ "$revalidate_rc" -eq 0 ]]; then
+              echo "Live body now conforms — skipping optimizer dispatch."
+              rm -f "$error_file"
+              exit 0
+            fi
+            # Exit 1 is used for both non-conformance and Python crashes; stderr
+            # distinguishes a validator runtime error (fail closed) from a normal
+            # non-conforming body (continue to fingerprint/optimizer).
+            if [[ "$revalidate_rc" -eq 1 && -s "$error_file" ]]; then
+              echo "::error::issue-format validator failed unexpectedly during revalidation"
+              cat "$error_file" >&2
+              rm -f "$error_file"
+              exit 1
+            fi
+            if [[ "$revalidate_rc" -ne 1 ]]; then
+              echo "::error::issue-format validator failed unexpectedly during revalidation (exit $revalidate_rc)"
+              cat "$error_file" >&2
+              rm -f "$error_file"
+              exit "$revalidate_rc"
+            fi
+            rm -f "$error_file"
           fi
-          if gh issue view "$NUMBER" --repo "$GITHUB_REPOSITORY" --json labels \
-              --jq '.labels[].name' | grep -qx 'agents:formatted'; then
+          fingerprint="$(sha256sum body.md | cut -c1-12)"
+          marker="<!-- format-guard:$fingerprint -->"
+          retry_marker_prefix="<!-- format-guard:$fingerprint:attempt:"
+          # Only trust exact HTML markers authored by github-actions[bot]
+          # (immutable account id 41898282 when the REST payload includes user.id).
+          marker_state="$(
+          FORMAT_GUARD_MARKER="$marker" \
+          FORMAT_GUARD_RETRY_PREFIX="$retry_marker_prefix" \
+          node - <<'NODE'
+          (async () => {
+            const { Octokit } = require('@octokit/rest');
+            const { createTokenAwareRetry } = require('./.github/scripts/github-api-with-retry.js');
+            const github = new Octokit({ auth: process.env.GH_TOKEN });
+            const core = { info: () => {}, warning: console.warn, debug: () => {} };
+            const { paginateWithRetry } = await createTokenAwareRetry({
+              github,
+              core,
+              env: process.env,
+              task: 'issue-format-guard',
+              capabilities: ['issues:read'],
+            });
+            const [owner, repo] = process.env.GITHUB_REPOSITORY.split('/');
+            const comments = await paginateWithRetry(
+              github.rest.issues.listComments,
+              { owner, repo, issue_number: Number(process.env.NUMBER), per_page: 100 }
+            );
+            const isCurrentAttemptMarker = (body) =>
+              body.includes(process.env.FORMAT_GUARD_MARKER)
+              || body.includes(process.env.FORMAT_GUARD_RETRY_PREFIX);
+            const trusted = comments.some((comment) =>
+              comment.user?.login === 'github-actions[bot]'
+              && (comment.user?.id == null || comment.user.id === 41898282)
+              && isCurrentAttemptMarker(comment.body || '')
+            );
+            const attempts = comments.filter((comment) =>
+              comment.user?.login === 'github-actions[bot]'
+              && (comment.user?.id == null || comment.user.id === 41898282)
+              && isCurrentAttemptMarker(comment.body || '')
+            ).length;
+            process.stdout.write(JSON.stringify({ attempts, trusted }));
+          })().catch((error) => {
+            console.error(error);
+            process.exit(1);
+          });
+          NODE
+          )"
+          trusted_marker="$(jq -r '.trusted' <<<"$marker_state")"
+          format_guard_attempts="$(jq -r '.attempts' <<<"$marker_state")"
+          max_format_guard_attempts=3
+          format_guard_next_attempt=$((format_guard_attempts + 1))
+          attempt_marker="${retry_marker_prefix}${format_guard_next_attempt} -->"
+          if [[ "$format_guard_attempts" -ge "$max_format_guard_attempts" ]]; then
+            echo "Format guard exhausted $format_guard_attempts optimizer attempts; pausing issue."
+            gh issue edit "$NUMBER" --repo "$GITHUB_REPOSITORY" \
+              --add-label "agents:auto-pilot-pause" \
+              || echo "::warning::could not apply agents:auto-pilot-pause"
+            gh issue edit "$NUMBER" --repo "$GITHUB_REPOSITORY" --remove-label "agents:format" \
+              || echo "::warning::could not release agents:format after attempt cap"
+            gh issue comment "$NUMBER" --repo "$GITHUB_REPOSITORY" --body-file - <<EOF
+          <!-- format-guard:attempt-cap -->
+          Automated formatting stopped after $format_guard_attempts optimizer attempts. Fix the issue body manually, then remove agents:auto-pilot-pause before retrying.
+          EOF
+            exit 0
+          fi
+          has_format_label=false
+          if jq -e '[.labels[].name] | any(. == "agents:format")' live.json >/dev/null; then
+            has_format_label=true
+          fi
+          # The marker is written only after dispatch succeeds.  Keep the label as
+          # the in-flight lease: a repeated guard run must not enqueue another
+          # optimizer while that lease is still present.  If the label was removed,
+          # retry the dispatch because the earlier handoff no longer owns the work.
+          dispatch=true
+          if [[ "$trusted_marker" == true && "$has_format_label" == true ]]; then
+            echo "Identical invalid body is already routed and in flight; skipping duplicate dispatch."
+            dispatch=false
+          elif [[ "$trusted_marker" == true ]]; then
+            echo "Prior format-guard marker present but agents:format is absent — retrying optimizer dispatch."
+          fi
+          if jq -e '[.labels[].name] | any(. == "agents:formatted")' live.json >/dev/null; then
             gh issue edit "$NUMBER" --repo "$GITHUB_REPOSITORY" --remove-label "agents:formatted" \
               || echo "::warning::could not remove agents:formatted"
           fi
-          gh issue edit "$NUMBER" --repo "$GITHUB_REPOSITORY" --add-label "agents:format" \
-            || echo "::warning::could not apply agents:format (label missing in this repo?)"
+          if [[ "$dispatch" != true ]]; then
+            exit 0
+          fi
+          # Acquiring the label is the handoff lease. Do not dispatch without it:
+          # otherwise a trusted marker alone could repeat the optimizer dispatch.
+          if ! gh issue edit "$NUMBER" --repo "$GITHUB_REPOSITORY" --add-label "agents:format"; then
+            echo "::error::could not acquire agents:format lease; refusing optimizer dispatch"
+            exit 1
+          fi
           # GITHUB_TOKEN label edits do not start issues:labeled workflows; dispatch is explicit.
-          gh workflow run agents-issue-optimizer.yml --repo "$GITHUB_REPOSITORY" \
-            -f issue_number="$NUMBER" -f phase=format
+          # Persist the completion marker only after a successful workflow_dispatch so a
+          # failed run remains retryable on the next guard pass.
+          # Capture the attempt clock before dispatch: gh workflow run can exit non-zero
+          # after GitHub has already accepted the request.
+          dispatch_attempted_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          if ! gh workflow run agents-issue-optimizer.yml --repo "$GITHUB_REPOSITORY" \
+              -f issue_number="$NUMBER" -f phase=format; then
+            accepted=false
+            for _try in 1 2 3 4 5; do
+              sleep 2
+              # shellcheck disable=SC2016
+              match_count=$(gh run list --repo "$GITHUB_REPOSITORY" \
+                --workflow=agents-issue-optimizer.yml \
+                --event workflow_dispatch \
+                --limit 20 \
+                --json createdAt,displayTitle \
+                | jq --arg since "$dispatch_attempted_at" --arg issue "#$NUMBER" \
+                  '[.[] | select(.createdAt >= $since and (.displayTitle | endswith($issue)))] | length')
+              if [[ "${match_count:-0}" -gt 0 ]]; then
+                accepted=true
+                break
+              fi
+            done
+            if [[ "$accepted" == true ]]; then
+              {
+                cat report.md
+                echo
+                echo "Optimizer dispatch was accepted despite a CLI error; preserving the format lease."
+                echo
+                echo "$attempt_marker"
+              } | gh issue comment "$NUMBER" --repo "$GITHUB_REPOSITORY" --body-file -
+              echo "::warning::optimizer dispatch CLI failed but a matching run was accepted; preserving agents:format lease"
+              echo "::error::optimizer dispatch status ambiguous; recorded the accepted attempt for the retry cap"
+              exit 1
+            fi
+            gh issue edit "$NUMBER" --repo "$GITHUB_REPOSITORY" --remove-label "agents:format" \
+              || echo "::warning::could not release failed agents:format lease"
+            echo "::error::optimizer dispatch failed; no completion marker written so later runs can retry"
+            exit 1
+          fi
+          {
+            cat report.md
+            echo
+            echo "Dispatched the Agents Issue Optimizer format phase (attempt $format_guard_next_attempt of $max_format_guard_attempts)."
+            echo
+            echo "$attempt_marker"
+          } | gh issue comment "$NUMBER" --repo "$GITHUB_REPOSITORY" --body-file -
 
       - name: Restore format completion after an unheld revalidation
         if: >-

--- a/.github/workflows/agents-issue-intake.yml
+++ b/.github/workflows/agents-issue-intake.yml
@@ -111,8 +111,9 @@ jobs:
     if: |
       needs.route.outputs.should_run_bridge == 'true' &&
       (github.event_name != 'issues' ||
-       contains(toJson(github.event.issue.labels.*.name), 'agent:') ||
-       contains(toJson(github.event.issue.labels.*.name), 'agents:')) &&
+       (github.event.issue.state != 'closed' &&
+        (contains(toJson(github.event.issue.labels.*.name), 'agent:') ||
+         contains(toJson(github.event.issue.labels.*.name), 'agents:')))) &&
       !contains(github.event.issue.labels.*.name, 'agents:auto-pilot')
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/agents-issue-optimizer.yml
+++ b/.github/workflows/agents-issue-optimizer.yml
@@ -1,5 +1,12 @@
 name: Agents Issue Optimizer
 
+# The recursion guard below correlates prior runs by issue number via `displayTitle`.
+# workflow_dispatch runs otherwise display the bare workflow name, so the guard matched
+# nothing and reported 0 for an issue it was re-running every minute. Pin the issue
+# number into the run name so both trigger types are correlatable.
+run-name: >-
+  Agents Issue Optimizer #${{ github.event.issue.number || github.event.inputs.issue_number }}
+
 on:
   issues:
     types: [labeled]
@@ -17,6 +24,13 @@ on:
           - analyze
           - apply
           - format
+
+concurrency:
+  group: >-
+    agents-issue-optimizer-${{
+    github.repository }}-${{
+    github.event.issue.number || github.event.inputs.issue_number || github.run_id }}
+  cancel-in-progress: false
 
 jobs:
   optimize_issue:
@@ -126,6 +140,7 @@ jobs:
           repository: stranske/Workflows
           path: workflows-scripts
           sparse-checkout: |
+            .github/scripts/issue_format.py
             config
             scripts/langchain
             tools
@@ -163,14 +178,17 @@ jobs:
             '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null \
             || date -u -v-1H '+%Y-%m-%dT%H:%M:%SZ')
 
+          # `gh run list` defaults to 20 runs, which a tight loop exhausts inside the
+          # window; ask for enough history to actually see the recursion.
           # shellcheck disable=SC2016
           count=$(gh run list \
             --workflow=agents-issue-optimizer.yml \
+            --limit 100 \
             --json conclusion,createdAt,displayTitle \
             | jq --arg cutoff "$one_hour_ago" \
               --arg issue "#$ISSUE_NUMBER" \
               '[.[] | select(.createdAt > $cutoff
-              and (.displayTitle | contains($issue)))
+              and (.displayTitle | endswith($issue)))
               ] | length')
 
           echo "Optimizer runs for issue #$ISSUE_NUMBER in last hour: $count"
@@ -340,7 +358,8 @@ jobs:
           });
           NODE
 
-          python - <<'PY' || true
+          set +e
+          python - <<'PY'
           import json
           import sys
           sys.path.insert(0, 'workflows-scripts/scripts/langchain')
@@ -350,33 +369,38 @@ jobs:
               issue = json.load(f)
           with open('/tmp/open_issues.json', encoding='utf-8') as f:
               open_issues = json.load(f)
-            with open('/tmp/dedup_comments.json', encoding='utf-8') as f:
-                comments = json.load(f)
+          with open('/tmp/dedup_comments.json', encoding='utf-8') as f:
+              comments = json.load(f)
 
-            marker = issue_dedup.SIMILAR_ISSUES_MARKER
-            for comment in comments or []:
-                body = (comment or {}).get('body') or ''
-                if marker in body:
-                    raise SystemExit(0)
+          marker = issue_dedup.SIMILAR_ISSUES_MARKER
+          for comment in comments or []:
+              body = (comment or {}).get('body') or ''
+              if marker in body:
+                  raise SystemExit(0)
 
           # Conservative defaults; can be tuned later.
           threshold = 0.82
-            store = issue_dedup.build_issue_vector_store(open_issues)
-            if store is None:
-                raise SystemExit(0)
+          store = issue_dedup.build_issue_vector_store(open_issues)
+          if store is None:
+              raise SystemExit(0)
 
-            title = (issue.get('title') or '').strip()
-            body = (issue.get('body') or '').strip()
-            query = f"{title}\n{body}".strip() if body else title
-            if not query:
-                raise SystemExit(0)
+          title = (issue.get('title') or '').strip()
+          body = (issue.get('body') or '').strip()
+          query = f"{title}\n{body}".strip() if body else title
+          if not query:
+              raise SystemExit(0)
 
-            matches = issue_dedup.find_similar_issues(store, query, threshold=threshold, k=5)
-            comment = issue_dedup.format_similar_issues_comment(matches, max_items=5)
-            if comment:
-                with open('/tmp/dedup_comment.md', 'w', encoding='utf-8') as out:
-                    out.write(comment)
+          matches = issue_dedup.find_similar_issues(store, query, threshold=threshold, k=5)
+          comment = issue_dedup.format_similar_issues_comment(matches, max_items=5)
+          if comment:
+              with open('/tmp/dedup_comment.md', 'w', encoding='utf-8') as out:
+                  out.write(comment)
           PY
+          dedup_rc=$?
+          set -e
+          if [[ $dedup_rc -ne 0 ]]; then
+            echo "::warning::issue dedup python exited with $dedup_rc; continuing without similar-issues comment"
+          fi
 
           if [[ -f /tmp/dedup_comment.md ]]; then
             gh issue comment "${ISSUE_NUMBER}" --body-file /tmp/dedup_comment.md || true
@@ -466,6 +490,9 @@ jobs:
           print('Suggestions applied successfully')
           " || exit 1
 
+          # Keep agents:formatted truthful for apply-phase output too.
+          python workflows-scripts/.github/scripts/issue_format.py /tmp/updated_body.md
+
           # Update issue body
           gh issue edit "${ISSUE_NUMBER}" --body-file /tmp/updated_body.md
 
@@ -503,6 +530,11 @@ jobs:
               f.write(formatted)
           print('Issue formatted successfully')
           " || exit 1
+
+          # Keep the format-result label truthful: the generated issue must
+          # pass the canonical Workflows validator before it can be marked
+          # agents:formatted below.
+          python workflows-scripts/.github/scripts/issue_format.py /tmp/formatted_body.md
 
           # Update issue body with formatted version
           gh issue edit "${ISSUE_NUMBER}" --body-file /tmp/formatted_body.md
@@ -550,3 +582,18 @@ jobs:
             body="${body//RUN_URL_PLACEHOLDER/${RUN_URL}}"
             gh issue comment "${ISSUE_NUMBER}" --body "$body" || true
           fi
+
+      - name: Release failed format lease
+        if: >-
+          (failure() || cancelled()) &&
+          (steps.check.outputs.phase == 'format' ||
+          (github.event_name == 'workflow_dispatch' && github.event.inputs.phase == 'format') ||
+          (github.event_name == 'issues' && github.event.label.name == 'agents:format'))
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token || github.token }}
+          ISSUE_NUMBER: ${{ steps.check.outputs.issue_number || github.event.inputs.issue_number || github.event.issue.number }}
+        run: |
+          set -euo pipefail
+          # A guard retry may proceed only after the failed format run releases its lease.
+          gh issue edit "$ISSUE_NUMBER" --remove-label "agents:format" \
+            || echo "::warning::could not release failed agents:format lease"

--- a/scripts/langchain/issue_formatter.py
+++ b/scripts/langchain/issue_formatter.py
@@ -10,10 +10,12 @@ Run with:
 from __future__ import annotations
 
 import argparse
+import importlib.util
 import json
 import os
 import re
 import sys
+from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
@@ -45,6 +47,20 @@ except ImportError:  # pragma: no cover - fallback for direct invocation
 # Maximum issue body size to prevent OpenAI rate limit errors (30k TPM limit)
 # ~4 chars per token, so 50k chars ≈ 12.5k tokens, leaving headroom for prompt + output
 MAX_ISSUE_BODY_SIZE = 50000
+
+
+@lru_cache(maxsize=1)
+def _issue_format_validator() -> Any:
+    """Load the fleet's single issue-format definition without forking it."""
+    validator_path = Path(__file__).resolve().parents[2] / ".github/scripts/issue_format.py"
+    spec = importlib.util.spec_from_file_location("_fleet_issue_format", validator_path)
+    if spec is None or spec.loader is None:  # pragma: no cover - repository invariant
+        raise RuntimeError(f"Cannot load canonical issue-format validator: {validator_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
 
 # Workflow tags written into the reuse marker. Tagging every stage of the
 # auto-pilot format -> optimize -> apply chain lets any stage detect a body it (or
@@ -151,6 +167,7 @@ SECTION_TITLES = {
 
 LIST_ITEM_REGEX = re.compile(r"^(\s*)([-*+]|\d+[.)]|[A-Za-z][.)])\s+(.*)$")
 CHECKBOX_REGEX = re.compile(r"^\[([ xX])\]\s*(.*)$")
+VERIFY_HINT_REGEX = re.compile(r"\(verify:\s*([^\n)]+)\)", re.IGNORECASE)
 
 
 def _context_token_budget() -> int:
@@ -355,6 +372,22 @@ def _format_issue_fallback(issue_body: str) -> str:
     impl_text = join_or_placeholder(impl_lines, "_Not provided._")
     tasks_text = join_or_placeholder(tasks_lines, "- [ ] _Not provided._")
     acceptance_text = join_or_placeholder(acceptance_lines, "- [ ] _Not provided._")
+    try:
+        validator = _issue_format_validator()
+    except (ImportError, OSError, RuntimeError, SyntaxError):
+        # Consumer checkouts can be mid-sync or missing the canonical validator.
+        # Keep the pre-validator fallback usable instead of failing the formatter.
+        validator = None
+    if validator is not None and not validator.GATE.search(acceptance_text):
+        verify_hint = VERIFY_HINT_REGEX.search(tasks_text)
+        if verify_hint:
+            command = verify_hint.group(1).strip().strip("`")
+            if command.startswith("pytest "):
+                command = f"python3 -m {command}"
+            acceptance_text = (
+                f"{acceptance_text}\n"
+                f"- [ ] Run `{command}` and capture the command output in PR validation evidence."
+            )
 
     parts = [
         "## Why",
@@ -387,8 +420,12 @@ def _format_issue_fallback(issue_body: str) -> str:
 def _formatted_output_valid(text: str) -> bool:
     if not text:
         return False
-    required = ["## Tasks", "## Acceptance Criteria"]
-    return all(section in text for section in required)
+    try:
+        return bool(_issue_format_validator().validate(text).ok)
+    except (ImportError, OSError, RuntimeError, SyntaxError):
+        # Preserve the former heading-only behavior until the copy-synced
+        # validator becomes available again.
+        return all(section in text for section in ("## Tasks", "## Acceptance Criteria"))
 
 
 def _select_code_fence(text: str) -> str:
@@ -398,12 +435,10 @@ def _select_code_fence(text: str) -> str:
 
 
 ORIGINAL_ISSUE_SUMMARY = "<summary>Original Issue</summary>"
-# Matches an Original-Issue <details> block (and trailing whitespace) so it can
-# be replaced rather than nested. Non-greedy body, anchored to the closing tag.
-_ORIGINAL_ISSUE_BLOCK_RE = re.compile(
-    r"<details>\s*<summary>Original Issue</summary>.*?</details>[ \t]*\n?",
-    re.DOTALL | re.IGNORECASE,
+_ORIGINAL_ISSUE_OPEN_RE = re.compile(
+    r"<details\b[^>]*>\s*<summary>Original Issue</summary>", re.IGNORECASE
 )
+_DETAILS_TAG_RE = re.compile(r"</?details\b[^>]*>", re.IGNORECASE)
 # Captures the verbatim text fenced inside an Original-Issue block, so an
 # already-embedded original can be recovered (and re-embedded once) instead of
 # being wrapped again.
@@ -415,8 +450,25 @@ _ORIGINAL_ISSUE_INNER_RE = re.compile(
 
 
 def _strip_original_issue_blocks(text: str) -> str:
-    """Remove any embedded Original-Issue <details> block(s) from ``text``."""
-    return _ORIGINAL_ISSUE_BLOCK_RE.sub("", text).rstrip()
+    """Remove complete embedded Original-Issue blocks, including nested details."""
+    kept: list[str] = []
+    cursor = 0
+    while match := _ORIGINAL_ISSUE_OPEN_RE.search(text, cursor):
+        kept.append(text[cursor : match.start()])
+        depth = 1
+        end = match.end()
+        for tag in _DETAILS_TAG_RE.finditer(text, match.end()):
+            depth += -1 if tag.group(0).startswith("</") else 1
+            if depth == 0:
+                end = tag.end()
+                break
+        else:
+            # Leave malformed markup intact rather than silently discarding it.
+            kept.append(text[match.start() :])
+            return "".join(kept).rstrip()
+        cursor = end
+    kept.append(text[cursor:])
+    return "".join(kept).rstrip()
 
 
 def _innermost_original_issue(text: str) -> str | None:
@@ -705,6 +757,7 @@ def format_issue_body(issue_body: str, *, use_llm: bool = True) -> dict[str, Any
                 pass
 
     formatted = _format_issue_fallback(issue_body)
+    needs_refinement = not _formatted_output_valid(formatted)
     # NOTE: Task decomposition is now handled by agents:optimize step
     # which uses LLM for intelligent splitting. Don't do heuristic
     # splitting here - it causes task explosion (issue #805, #1143).
@@ -716,6 +769,7 @@ def format_issue_body(issue_body: str, *, use_llm: bool = True) -> dict[str, Any
         "provider_used": None,
         "used_llm": False,
         "validation_audit": audit,
+        "needs_refinement": needs_refinement,
     }
 
 


### PR DESCRIPTION
## Sync Summary

### Files Updated
- agents-issue-intake.yml: Issue intake - processes new issues for agent assignment
- agents-issue-optimizer.yml: Issue optimizer - LangChain-based issue formatting and optimization (Phase 1)
- agents-issue-format-guard.yml: Issue format guard - validates issues on open/edit/reopen, hold/exemption-label changes, and manual dispatch against AGENT_ISSUE_FORMAT, while durable/wontfix and bot issues remain exempt. Pause and needs-human labels hold dispatch. Any invalid non-exempt issue change on those triggers clears stale agents:formatted state, and hold removal revalidates on resume. Non-conforming unheld work gets agents:format so the optimizer repairs it. Requires .github/scripts/issue_format.py.
- issue_format.py: Pure-stdlib validator for AGENT_ISSUE_FORMAT compliance. Single fleet definition of agent-processable; used by agents-issue-format-guard.yml and callable directly by local filers to pre-flight before gh issue create (non-zero exit = unfit). Do not fork per repo.
- github-api-with-retry.js: GitHub API retry wrapper with exponential backoff and pagination support - required by agents-auto-pilot.yml
- issue_formatter.py: Issue formatter - converts raw text to AGENT_ISSUE_TEMPLATE format

### Files Skipped
- pr-00-gate.yml: File exists and sync_mode is create_only
- ci.yml: File exists and sync_mode is create_only
- renovate.json: File exists and sync_mode is create_only
- cross-repo-smoke.yml: File exists and sync_mode is create_only
- llm_slots.json: None

---

### Review Checklist
- [ ] CI passes with updated workflows
- [ ] No repo-specific customizations were overwritten

**Source:** stranske/Workflows
**Source SHA:** `97df65434a98b12d473e054e501fc1f1a2d78562`
**Template hash:** `a63626ce7ac3`
**Consumer-sync plan ID:** `sha256:a63626ce7ac3198e2c5fbc0bf664687a4f0d7ec73fd7741a19511b49cc2e6688`
**Sync phase:** `canary`
**Sync branch:** `sync/workflows-a63626ce7ac3`
**Consumer repo:** `stranske/Inv-Man-Intake`
**Manifest:** `.github/sync-manifest.yml`

<!-- workflows-consumer-sync:v1 {"schema":"workflows-consumer-sync-pr/v1","consumer_repo":"stranske/Inv-Man-Intake","source_repository":"stranske/Workflows","source_sha":"97df65434a98b12d473e054e501fc1f1a2d78562","template_hash":"a63626ce7ac3","plan_id":"sha256:a63626ce7ac3198e2c5fbc0bf664687a4f0d7ec73fd7741a19511b49cc2e6688","sync_phase":"canary","sync_branch":"sync/workflows-a63626ce7ac3","manifest":".github/sync-manifest.yml","lifecycle_state":"opened","run_id":"31292501222","run_attempt":"1","changes_count":6} -->
<!-- sync-pr-delivery-record:v1 {"schema":"sync-pr-delivery-record/v1","durable_issue_url":"https://github.com/stranske/Workflows/issues/1836","plan_id":"sha256:a63626ce7ac3198e2c5fbc0bf664687a4f0d7ec73fd7741a19511b49cc2e6688","generation":"a63626ce7ac3","repository":"stranske/Inv-Man-Intake","desired_tree_hash":"34b25fc136973afa73e959450b3a9c451c68e393","source_commit":"97df65434a98b12d473e054e501fc1f1a2d78562","lease_expires_at":"2026-08-12T03:29:31Z","predecessor_prs":[],"successor_prs":[]} -->