### PR TITLE
chore: sync workflow templates

### DIFF
--- a/.github/scripts/issue_format.py
+++ b/.github/scripts/issue_format.py
@@ -92,8 +92,10 @@ _TASK_KNOWN_BASENAME = (
     r"LICENSE(?:\.(?:md|txt))?|\.gitignore|\.editorconfig)"
 )
 _TASK_COMMAND = (
-    r"(?:python(?:3)?|pytest|npm|pnpm|yarn|make|just|cargo|go|dotnet|gh|curl|"
-    r"node|vitest|jest|playwright)"
+    r"(?:python(?:3)?\s+-m\s+(?:pytest|unittest)\b|pytest\b|node\s+--test\b|"
+    r"(?:npm|pnpm|yarn)\s+(?:run\s+)?(?:test|vitest|jest|playwright)\b|"
+    r"(?:make|just|cargo|go|dotnet)\s+(?:test|check)\b|"
+    r"gh\s+(?:workflow\s+run|run)\s+\S+|curl\s+\S+)"
 )
 
 
@@ -146,7 +148,9 @@ def _task_has_concrete_target(item: str) -> bool:
     # Unquoted path with a directory separator (src/main.go, .github/workflows/x.yml).
     if re.search(r"(?:^|[\s])((?:\./)?[\w.-]+(?:/[\w./-]+)+)", item):
         return True
-    return re.search(rf"\b{_TASK_COMMAND}\b", item, re.I) is not None
+    # Command names in prose ("make the UI better", "go improve it") are not
+    # concrete targets. Require a command-shaped invocation instead.
+    return re.search(rf"(?:^|[\s`]){_TASK_COMMAND}", item, re.I) is not None
 
 
 def _headings(body: str) -> list[tuple[str, int, int]]:

--- a/.github/workflows/agents-auto-pilot.yml
+++ b/.github/workflows/agents-auto-pilot.yml
@@ -795,6 +795,12 @@ jobs:
               with open('/tmp/guard_blocked', 'w') as f:
                   f.write(reason)
               sys.exit(0)
+          if result.get('needs_refinement'):
+              reason = 'Formatter output does not satisfy the canonical issue-format contract.'
+              print(f'NEEDS_REFINEMENT: {reason}')
+              with open('/tmp/needs_refinement', 'w') as f:
+                  f.write(reason)
+              sys.exit(0)
           formatted = result.get('formatted_body', '')
           if not formatted:
               print('ERROR: No formatted body returned')
@@ -858,7 +864,36 @@ jobs:
               process.exit(1);
             });
           GUARD_NODE
+            echo "stop_autopilot=true" >> "$GITHUB_OUTPUT"
             echo "🛑 Automation stopped due to prompt injection guard."
+            exit 0
+          fi
+
+          # Never publish or mark a body as formatted when the formatter itself
+          # reports that its final output fails the canonical contract.
+          if [ -f /tmp/needs_refinement ]; then
+            echo "⚠️ Formatter requires human refinement; pausing auto-pilot."
+            FORMAT_REFINEMENT_REASON="$(cat /tmp/needs_refinement)" node - <<'REFINEMENT_NODE'
+            (async () => {
+              const { Octokit } = require('@octokit/rest');
+              const { createTokenAwareRetry } = require('./.github/scripts/github-api-with-retry.js');
+              const core = { info: () => {}, warning: console.warn, debug: () => {} };
+              const github = new Octokit({ auth: process.env.GITHUB_TOKEN });
+              const { withRetry } = await createTokenAwareRetry({
+                github, core, env: process.env, task: 'auto-pilot', capabilities: ['issues:write'],
+              });
+              const [owner, repo] = process.env.GITHUB_REPOSITORY.split('/');
+              const issue_number = Number(process.env.ISSUE_NUMBER);
+              await withRetry((client) => client.rest.issues.addLabels({
+                owner, repo, issue_number, labels: ['needs-human', 'agents:auto-pilot-pause'],
+              }));
+              await withRetry((client) => client.rest.issues.createComment({
+                owner, repo, issue_number,
+                body: `⚠️ **Auto-pilot paused during formatting.**\n\n${process.env.FORMAT_REFINEMENT_REASON}`,
+              }));
+            })().catch((error) => { console.error(error); process.exit(1); });
+          REFINEMENT_NODE
+            echo "stop_autopilot=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 

--- a/.github/workflows/agents-issue-format-guard.yml
+++ b/.github/workflows/agents-issue-format-guard.yml
@@ -90,6 +90,11 @@ jobs:
           error_file="$(mktemp)"
           trap 'rm -f "$report_file" "$error_file"' EXIT
           if [[ ! -f .github/scripts/issue_format.py ]]; then
+            # Tolerated: a consumer repo mid-sync may not have the validator yet,
+            # and hard-failing would block every issue there. But the job used to
+            # exit GREEN having validated nothing, so a sync that dropped the
+            # file removed the gate with no signal at all. Make it loud.
+            echo "::warning title=Issue format guard inactive::.github/scripts/issue_format.py is missing, so this issue was NOT validated. Re-sync from stranske/Workflows to restore the gate."
             echo "validator absent — skipping while this repo is mid-sync"
             echo "rc=skip" >> "$GITHUB_OUTPUT"
             exit 0
@@ -143,8 +148,14 @@ jobs:
             cat "$error_file" >&2
             exit 1
           fi
-          if gh issue view "$NUMBER" --repo "$GITHUB_REPOSITORY" --json labels \
-              --jq '.labels[].name' | grep -qx 'agents:formatted'; then
+          # `gh … | grep -q` inverts under `set -o pipefail`: grep exits at its
+          # first match, gh dies on SIGPIPE, and the failed pipeline makes this
+          # `if` take the FALSE branch even though the label IS present. It only
+          # bites once gh is slow enough to still be writing — i.e. as the issue
+          # grows. Materialise first, then grep a file.
+          gh issue view "$NUMBER" --repo "$GITHUB_REPOSITORY" --json labels \
+            --jq '.labels[].name' > labels.txt
+          if grep -qx 'agents:formatted' labels.txt; then
             if gh issue edit "$NUMBER" --repo "$GITHUB_REPOSITORY" --remove-label "agents:formatted"; then
               echo "Invalid issue body — cleared stale agents:formatted."
             else
@@ -351,8 +362,9 @@ jobs:
           NUMBER: ${{ steps.issue.outputs.number }}
         run: |
           set -euo pipefail
-          if gh issue view "$NUMBER" --repo "$GITHUB_REPOSITORY" --json labels \
-              --jq '[.labels[].name] | any(. == "agents:auto-pilot-pause" or . == "needs-human")' | grep -qx true; then
+          gh issue view "$NUMBER" --repo "$GITHUB_REPOSITORY" --json labels \
+            --jq '[.labels[].name] | any(. == "agents:auto-pilot-pause" or . == "needs-human")' > held.txt
+          if grep -qx true held.txt; then
             echo "Issue remains held — leaving agents:formatted cleared."
             exit 0
           fi
@@ -367,8 +379,9 @@ jobs:
           NUMBER: ${{ steps.issue.outputs.number }}
         run: |
           set -euo pipefail
-          if gh issue view "$NUMBER" --repo "$GITHUB_REPOSITORY" --json labels \
-              --jq '.labels[].name' | grep -qx 'agents:format'; then
+          gh issue view "$NUMBER" --repo "$GITHUB_REPOSITORY" --json labels \
+            --jq '.labels[].name' > labels.txt
+          if grep -qx 'agents:format' labels.txt; then
             gh issue edit "$NUMBER" --repo "$GITHUB_REPOSITORY" --remove-label "agents:format"
             echo "Conforms now — cleared agents:format."
           fi

--- a/scripts/langchain/issue_formatter.py
+++ b/scripts/langchain/issue_formatter.py
@@ -168,6 +168,18 @@ SECTION_TITLES = {
 LIST_ITEM_REGEX = re.compile(r"^(\s*)([-*+]|\d+[.)]|[A-Za-z][.)])\s+(.*)$")
 CHECKBOX_REGEX = re.compile(r"^\[([ xX])\]\s*(.*)$")
 VERIFY_HINT_REGEX = re.compile(r"\(verify:\s*([^\n)]+)\)", re.IGNORECASE)
+SAFE_VERIFY_COMMAND_RE = re.compile(
+    r"^(?:"
+    r"(?:python(?:3)?\s+-m\s+)?pytest\b"
+    r"|node\s+--test\b"
+    r"|(?:npm|pnpm|yarn)\s+(?:run\s+)?(?:test|vitest|jest|playwright)\b"
+    r"|(?:make|just|cargo|go|dotnet)\s+(?:test|check)\b"
+    r"|gh\s+(?:workflow\s+run|run)\b"
+    r"|curl\s+\S+"
+    r")",
+    re.IGNORECASE,
+)
+SHELL_METACHARACTERS_RE = re.compile(r"[;&|`$<>\n\r]")
 
 
 def _context_token_budget() -> int:
@@ -378,16 +390,24 @@ def _format_issue_fallback(issue_body: str) -> str:
         # Consumer checkouts can be mid-sync or missing the canonical validator.
         # Keep the pre-validator fallback usable instead of failing the formatter.
         validator = None
-    if validator is not None and not validator.GATE.search(acceptance_text):
+    gate = getattr(validator, "GATE", None) if validator is not None else None
+    if gate is not None and not gate.search(acceptance_text):
         verify_hint = VERIFY_HINT_REGEX.search(tasks_text)
         if verify_hint:
             command = verify_hint.group(1).strip().strip("`")
             if command.startswith("pytest "):
                 command = f"python3 -m {command}"
-            acceptance_text = (
-                f"{acceptance_text}\n"
-                f"- [ ] Run `{command}` and capture the command output in PR validation evidence."
-            )
+            if (
+                SAFE_VERIFY_COMMAND_RE.match(command)
+                and not SHELL_METACHARACTERS_RE.search(command)
+                and gate.search(command)
+            ):
+                if is_placeholder_checklist_text(acceptance_text) or re.fullmatch(
+                    r"- \[ \] _Not provided\._", acceptance_text.strip()
+                ):
+                    acceptance_text = ""
+                criterion = f"- [ ] Run `{command}` and capture the command output in PR validation evidence."
+                acceptance_text = "\n".join(part for part in (acceptance_text, criterion) if part)
 
     parts = [
         "## Why",
@@ -443,7 +463,7 @@ _DETAILS_TAG_RE = re.compile(r"</?details\b[^>]*>", re.IGNORECASE)
 # already-embedded original can be recovered (and re-embedded once) instead of
 # being wrapped again.
 _ORIGINAL_ISSUE_INNER_RE = re.compile(
-    r"<details>\s*<summary>Original Issue</summary>\s*"
+    r"<details\b[^>]*>\s*<summary>Original Issue</summary>\s*"
     r"(?P<fence>`{3,})text\n(?P<inner>.*?)\n(?P=fence)\s*</details>",
     re.DOTALL | re.IGNORECASE,
 )
@@ -644,20 +664,24 @@ def _reuse_already_formatted(issue_body: str, workflow: str) -> dict[str, Any] |
     """
     reused = reuse_formatted_body({"body": issue_body}, workflow)
     if reused is not None:
+        body = _with_reuse_marker(reused)
         return {
-            "formatted_body": _with_reuse_marker(reused),
+            "formatted_body": body,
             "provider_used": None,
             "used_llm": False,
             "skipped": "reused_marker",
             "validation_audit": None,
+            "needs_refinement": not _formatted_output_valid(body),
         }
     if already_conformant(issue_body):
+        body = _with_reuse_marker(issue_body)
         return {
-            "formatted_body": _with_reuse_marker(issue_body),
+            "formatted_body": body,
             "provider_used": None,
             "used_llm": False,
             "skipped": "already_conformant",
             "validation_audit": None,
+            "needs_refinement": not _formatted_output_valid(body),
         }
     return None
 
@@ -749,6 +773,7 @@ def format_issue_body(issue_body: str, *, use_llm: bool = True) -> dict[str, Any
                         "provider_used": provider,
                         "used_llm": True,
                         "validation_audit": audit,
+                        "needs_refinement": not _formatted_output_valid(formatted),
                     }
                     result.update(trace.as_dict())
                     return result
@@ -757,13 +782,13 @@ def format_issue_body(issue_body: str, *, use_llm: bool = True) -> dict[str, Any
                 pass
 
     formatted = _format_issue_fallback(issue_body)
-    needs_refinement = not _formatted_output_valid(formatted)
     # NOTE: Task decomposition is now handled by agents:optimize step
     # which uses LLM for intelligent splitting. Don't do heuristic
     # splitting here - it causes task explosion (issue #805, #1143).
     formatted, audit = _validate_and_refine_tasks(formatted, use_llm=use_llm)
     formatted = _append_raw_issue_section(formatted, issue_body)
     formatted = _with_reuse_marker(formatted)
+    needs_refinement = not _formatted_output_valid(formatted)
     return {
         "formatted_body": formatted,
         "provider_used": None,
@@ -809,6 +834,7 @@ def main() -> None:
             "provider_used": result.get("provider_used"),
             "used_llm": result.get("used_llm", False),
             "labels": build_label_transition(),
+            "needs_refinement": result.get("needs_refinement", False),
         }
         if result.get("guard_blocked"):
             payload["guard_blocked"] = True


### PR DESCRIPTION
## Sync Summary

### Files Updated
- agents-issue-format-guard.yml: Issue format guard - validates issues on open/edit/reopen, hold/exemption-label changes, and manual dispatch against AGENT_ISSUE_FORMAT, while durable/wontfix and bot issues remain exempt. Pause and needs-human labels hold dispatch. Any invalid non-exempt issue change on those triggers clears stale agents:formatted state, and hold removal revalidates on resume. Non-conforming unheld work gets agents:format so the optimizer repairs it. Requires .github/scripts/issue_format.py.
- agents-auto-pilot.yml: Auto-pilot - end-to-end automation orchestrator (format → optimize → agent → verify)
- issue_format.py: Pure-stdlib validator for AGENT_ISSUE_FORMAT compliance. Single fleet definition of agent-processable; used by agents-issue-format-guard.yml and callable directly by local filers to pre-flight before gh issue create (non-zero exit = unfit). Do not fork per repo.
- issue_formatter.py: Issue formatter - converts raw text to AGENT_ISSUE_TEMPLATE format

### Files Skipped
- pr-00-gate.yml: File exists and sync_mode is create_only
- ci.yml: File exists and sync_mode is create_only
- renovate.json: File exists and sync_mode is create_only
- cross-repo-smoke.yml: File exists and sync_mode is create_only
- llm_slots.json: None

---

### Review Checklist
- [ ] CI passes with updated workflows
- [ ] No repo-specific customizations were overwritten

**Source:** stranske/Workflows
**Source SHA:** `102f1fb3f1a95bab7891ab7a1cdc6fc64d411b00`
**Template hash:** `094aacef9848`
**Consumer-sync plan ID:** `sha256:094aacef98480da4c310fbfba2c057352d51b55633530513639d2e18435c7910`
**Sync phase:** `canary`
**Sync branch:** `sync/workflows-094aacef9848`
**Consumer repo:** `stranske/Inv-Man-Intake`
**Manifest:** `.github/sync-manifest.yml`

<!-- workflows-consumer-sync:v1 {"schema":"workflows-consumer-sync-pr/v1","consumer_repo":"stranske/Inv-Man-Intake","source_repository":"stranske/Workflows","source_sha":"102f1fb3f1a95bab7891ab7a1cdc6fc64d411b00","template_hash":"094aacef9848","plan_id":"sha256:094aacef98480da4c310fbfba2c057352d51b55633530513639d2e18435c7910","sync_phase":"canary","sync_branch":"sync/workflows-094aacef9848","manifest":".github/sync-manifest.yml","lifecycle_state":"opened","run_id":"31306004319","run_attempt":"1","changes_count":4} -->
<!-- sync-pr-delivery-record:v1 {"schema":"sync-pr-delivery-record/v1","durable_issue_url":"https://github.com/stranske/Workflows/issues/1836","plan_id":"sha256:094aacef98480da4c310fbfba2c057352d51b55633530513639d2e18435c7910","generation":"094aacef9848","repository":"stranske/Inv-Man-Intake","desired_tree_hash":"e0f61e5110610ab586ebc1d64b953560bdfe7637","source_commit":"102f1fb3f1a95bab7891ab7a1cdc6fc64d411b00","lease_expires_at":"2026-08-12T09:29:46Z","predecessor_prs":[],"successor_prs":[]} -->